### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.2
+
+- Add compatibility for Copilot `initialize` call
+- Make configuration parameter optional in `MarionetteBinding.ensureInitialized()`
+
 # 0.2.1
 
 - Update README

--- a/packages/marionette_flutter/pubspec.yaml
+++ b/packages/marionette_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: marionette_flutter
 description: Flutter extensions enabling AI agents to inspect and interact with running Flutter apps via Marionette MCP.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/leancodepl/marionette-mcp
 issue_tracker: https://github.com/leancodepl/marionette-mcp/issues
 

--- a/packages/marionette_mcp/pubspec.yaml
+++ b/packages/marionette_mcp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: marionette_mcp
 description: MCP server for Flutter app interaction - enables AI agents to inspect and interact with running Flutter apps via VM service.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/leancodepl/marionette-mcp
 issue_tracker: https://github.com/leancodepl/marionette-mcp/issues
 


### PR DESCRIPTION
## Summary

Version bump to 0.2.2 with the following changes:

- Add compatibility for Copilot `initialize` call
- Make configuration parameter optional in `MarionetteBinding.ensureInitialized()`

## Changes

- Updated `marionette_mcp` package version to 0.2.2
- Updated `marionette_flutter` package version to 0.2.2
- Updated CHANGELOG.md files with new version details