### PR TITLE
Release v0.2.3 - Improve pub.dev package scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.3
+
+- Add example symlinks for improved pub.dev package scoring
+- Fix documentation lints for angle brackets in code references
+
 # 0.2.2
 
 - Add compatibility for Copilot `initialize` call

--- a/packages/marionette_flutter/example
+++ b/packages/marionette_flutter/example
@@ -1,0 +1,1 @@
+../../examples/counter

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -63,7 +63,7 @@ class CoordinatesMatcher extends WidgetMatcher {
   }
 }
 
-/// Matches widgets by their ValueKey<String> key.
+/// Matches widgets by their `ValueKey<String>` key.
 class KeyMatcher extends WidgetMatcher {
   const KeyMatcher(this.keyValue);
 

--- a/packages/marionette_flutter/pubspec.yaml
+++ b/packages/marionette_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: marionette_flutter
 description: Flutter extensions enabling AI agents to inspect and interact with running Flutter apps via Marionette MCP.
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/leancodepl/marionette-mcp
 issue_tracker: https://github.com/leancodepl/marionette-mcp/issues
 

--- a/packages/marionette_mcp/example
+++ b/packages/marionette_mcp/example
@@ -1,0 +1,1 @@
+../../examples/counter

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -200,7 +200,7 @@ class VmServiceConnector {
   /// Taps an element matching the given criteria.
   ///
   /// [matcher] should contain one of:
-  /// - 'key': matches by ValueKey<String>
+  /// - 'key': matches by `ValueKey<String>`
   /// - 'text': matches by visible text content
   /// - 'type': matches by widget type name
   /// - 'x' and 'y': screen coordinates for tapping at a specific position

--- a/packages/marionette_mcp/pubspec.yaml
+++ b/packages/marionette_mcp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: marionette_mcp
 description: MCP server for Flutter app interaction - enables AI agents to inspect and interact with running Flutter apps via VM service.
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/leancodepl/marionette-mcp
 issue_tracker: https://github.com/leancodepl/marionette-mcp/issues
 


### PR DESCRIPTION
## Summary

This release improves the pub.dev package scoring for both `marionette_flutter` and `marionette_mcp` packages.

### Changes

- Added `example` symlinks in both packages pointing to the shared counter example
  - `packages/marionette_flutter/example` → `../../examples/counter`
  - `packages/marionette_mcp/example` → `../../examples/counter`
- Fixed documentation lints for angle brackets in code references:
  - `widget_matcher.dart`: Wrapped `ValueKey<String>` in backticks
  - `vm_service_connector.dart`: Wrapped `ValueKey<String>` in backticks
- Bumped versions to 0.2.3 for both packages
- Updated CHANGELOG.md

### Benefits

- Improved pub.dev package scoring with valid example directories
- Resolved all static analysis warnings (40/50 points → clean)
- Better documentation formatting