### PR TITLE
Fix sigterm handling on windows

### DIFF
--- a/packages/marionette_mcp/bin/marionette_mcp.dart
+++ b/packages/marionette_mcp/bin/marionette_mcp.dart
@@ -196,8 +196,8 @@ class _ExitSignal {
     // SIGTERM is not supported on Windows, only listen on non-Windows platforms
     if (!Platform.isWindows) {
       _sigtermSubscription = ProcessSignal.sigterm.watch().listen(
-        _handleSignal,
-      );
+            _handleSignal,
+          );
     }
     _sigintSubscription = ProcessSignal.sigint.watch().listen(_handleSignal);
   }


### PR DESCRIPTION
 The MCP server crashed on Windows with SignalException: Failed to listen for SIGTERM because SIGTERM is not supported on Windows.
Added a platform check to only register the SIGTERM handler on non-Windows systems. SIGINT (Ctrl+C) remains available for graceful shutdown on all platforms.
https://api.dart.dev/dart-io/ProcessSignal/watch.html


https://github.com/leancodepl/marionette_mcp/issues/16