### PR TITLE
Fix: tap matches widgets behind modal route barriers

### DIFF
--- a/packages/marionette_flutter/lib/src/services/element_resolver.dart
+++ b/packages/marionette_flutter/lib/src/services/element_resolver.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/services/widget_finder.dart';
+import 'package:marionette_flutter/src/services/widget_matcher.dart';
+
+/// Matched element paired with its nearest scrollable ancestor.
+class WidgetMatchCandidate {
+  const WidgetMatchCandidate({
+    required this.element,
+    required this.scrollableAncestor,
+  });
+
+  final Element element;
+  final Element? scrollableAncestor;
+}
+
+/// Resolves match candidates into interaction-ready elements.
+///
+/// This centralizes the operations used by tap/enter_text/scroll_to:
+/// collecting candidates, checking hittability, and associating matches
+/// with scroll context.
+class ElementResolver {
+  const ElementResolver(this._widgetFinder);
+
+  final WidgetFinder _widgetFinder;
+
+  /// Finds every matcher hit and pairs each hit with the nearest Scrollable
+  /// ancestor.
+  ///
+  /// The returned list keeps DFS match order from [WidgetFinder], but each
+  /// entry now includes:
+  /// - the matched element itself
+  /// - the closest scrollable container that can move that element (if any)
+  ///
+  /// This gives callers enough context to make tool-specific decisions without
+  /// re-traversing the tree.
+  List<WidgetMatchCandidate> findCandidates(
+    WidgetMatcher matcher,
+    MarionetteConfiguration configuration,
+  ) {
+    // Build this "match + nearest scrollable" list in one place so tap,
+    // enter_text, and scroll_to all start from the same data.
+    // Each tool then applies its own acceptance rule on top of that list.
+    final elements = _widgetFinder.findElements(matcher, configuration);
+    return elements
+        .map(
+          (element) => WidgetMatchCandidate(
+            element: element,
+            scrollableAncestor: findScrollableAncestor(element),
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  /// Finds the first matching element that can receive pointer events.
+  Element? findHittableElement(
+    WidgetMatcher matcher,
+    MarionetteConfiguration configuration,
+  ) {
+    final candidates = findCandidates(matcher, configuration);
+    for (final candidate in candidates) {
+      // This rejects matches hidden behind modal barriers, absorb/ignore
+      // pointer layers, and other non-hit-testable widgets.
+      if (isHittable(candidate.element)) {
+        return candidate.element;
+      }
+    }
+    return null;
+  }
+
+  /// Finds the first match inside a scrollable that can currently receive
+  /// pointer input.
+  WidgetMatchCandidate? findCandidateInHittableScrollable(
+    WidgetMatcher matcher,
+    MarionetteConfiguration configuration,
+  ) {
+    final candidates = findCandidates(matcher, configuration);
+    for (final candidate in candidates) {
+      final scrollable = candidate.scrollableAncestor;
+      // scroll_to must be able to target offscreen widgets, so we do NOT
+      // require the target element itself to be hittable yet. Instead we
+      // require the containing scrollable layer to be currently interactable.
+      if (scrollable != null && isHittable(scrollable)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  /// Finds the nearest [Scrollable] ancestor of [element], if any.
+  Element? findScrollableAncestor(Element element) {
+    Element? scrollableAncestor;
+    element.visitAncestorElements((Element ancestor) {
+      if (ancestor.widget is Scrollable) {
+        // Nearest ancestor wins: this is the scroll container that can
+        // actually move the matched widget into view.
+        scrollableAncestor = ancestor;
+        return false;
+      }
+      return true;
+    });
+    return scrollableAncestor;
+  }
+
+  /// Checks if the element can receive pointer events.
+  static bool isHittable(Element element) {
+    final renderObject = element.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      // Without a sized RenderBox, there is no stable point to hit-test.
+      return false;
+    }
+
+    if (!renderObject.attached) {
+      // Detached objects are stale and cannot receive pointer events.
+      return false;
+    }
+
+    final view = element.findAncestorWidgetOfExactType<View>();
+    final viewId = view?.view.viewId ??
+        WidgetsBinding.instance.platformDispatcher.implicitView?.viewId;
+    if (viewId == null) {
+      // No view means no hit-test target surface.
+      return false;
+    }
+
+    try {
+      // Use the visual center as a pragmatic probe point. This mirrors how
+      // interactive elements are filtered elsewhere in Marionette.
+      final center = renderObject.size.center(Offset.zero);
+      final absoluteOffset = renderObject.localToGlobal(center);
+
+      final result = HitTestResult();
+      WidgetsBinding.instance.hitTestInView(result, absoluteOffset, viewId);
+
+      // The render object must appear in the hit-test path at that point.
+      for (final entry in result.path) {
+        if (entry.target == renderObject) {
+          return true;
+        }
+      }
+
+      return false;
+    } catch (_) {
+      // Geometry queries can throw during transient layout/paint phases.
+      // Treat this as not hittable and let caller retry later.
+      return false;
+    }
+  }
+}

--- a/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
+++ b/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
@@ -28,7 +28,7 @@ class GestureDispatcher {
       return;
     }
 
-    final element = widgetFinder.findElement(matcher, configuration);
+    final element = widgetFinder.findHittableElement(matcher, configuration);
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');

--- a/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
+++ b/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/services/element_resolver.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
 
@@ -28,7 +29,8 @@ class GestureDispatcher {
       return;
     }
 
-    final element = widgetFinder.findHittableElement(matcher, configuration);
+    final resolver = ElementResolver(widgetFinder);
+    final element = resolver.findHittableElement(matcher, configuration);
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
 import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
@@ -133,7 +132,7 @@ class ScrollSimulator {
       // Find the target element
       final target = _widgetFinder.findElement(targetMatcher, configuration);
       // Check if target is visible
-      if (target != null && _isHittable(target)) {
+      if (target != null && WidgetFinder.isHittable(target)) {
         return;
       }
 
@@ -249,45 +248,4 @@ class ScrollSimulator {
     return adaptiveAttempts.clamp(1, _defaultMaxScrollAttemptsCap).toInt();
   }
 
-  /// Checks if the element is hittable (i.e., can receive pointer events).
-  ///
-  /// Performs a hit test at the center of the element to determine if it's
-  /// actually interactive, not just within viewport bounds.
-  bool _isHittable(Element element) {
-    final renderObject = element.renderObject;
-    if (renderObject is! RenderBox) {
-      return false;
-    }
-
-    if (!renderObject.hasSize) {
-      return false;
-    }
-
-    // Get the view ID from the ancestor View widget when available.
-    // In test environments there may be no explicit View widget in the tree,
-    // so we fallback to the implicit view from the platform dispatcher.
-    final view = element.findAncestorWidgetOfExactType<View>();
-    final viewId = view?.view.viewId ??
-        WidgetsBinding.instance.platformDispatcher.implicitView?.viewId;
-    if (viewId == null) {
-      return false;
-    }
-
-    // Calculate the center position of the element
-    final center = renderObject.size.center(Offset.zero);
-    final absoluteOffset = renderObject.localToGlobal(center);
-
-    // Perform hit test at the center of the element
-    final hitResult = HitTestResult();
-    WidgetsBinding.instance.hitTestInView(hitResult, absoluteOffset, viewId);
-
-    // Check if the element's render object is in the hit test path
-    for (final entry in hitResult.path) {
-      if (entry.target == renderObject) {
-        return true;
-      }
-    }
-
-    return false;
-  }
 }

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/services/element_resolver.dart';
 import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
@@ -10,6 +11,7 @@ class ScrollSimulator {
 
   final GestureDispatcher _gestureDispatcher;
   final WidgetFinder _widgetFinder;
+  ElementResolver get _elementResolver => ElementResolver(_widgetFinder);
 
   static const _delta = 64.0;
   static const _fallbackMaxScrollAttempts = 50;
@@ -65,12 +67,15 @@ class ScrollSimulator {
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
   ) {
-    final initialTarget = _widgetFinder.findElement(matcher, configuration);
-    if (initialTarget != null) {
-      final ancestorScrollable = _findScrollableAncestor(initialTarget);
-      if (ancestorScrollable != null) {
-        return ancestorScrollable;
-      }
+    // First preference: a candidate whose owning scrollable layer is
+    // currently hittable. Avoids selecting widgets hidden
+    // underneath modal barriers while still allowing offscreen targets.
+    final candidate = _elementResolver.findCandidateInHittableScrollable(
+      matcher,
+      configuration,
+    );
+    if (candidate != null) {
+      return candidate.scrollableAncestor;
     }
 
     final root = WidgetsBinding.instance.rootElement;
@@ -80,18 +85,31 @@ class ScrollSimulator {
 
     Element? fallbackScrollable;
     Element? scrollableWithRange;
+    Element? hittableFallbackScrollable;
+    Element? hittableScrollableWithRange;
 
     void visit(Element element) {
-      if (scrollableWithRange != null) {
+      // Once we found both "best possible" options, stop looking.
+      if (scrollableWithRange != null && hittableScrollableWithRange != null) {
         return;
       }
 
       if (element.widget is Scrollable) {
+        // Plain fallbacks keep legacy behavior if hittability cannot be
+        // determined (for example unusual test setups).
         fallbackScrollable ??= element;
         final position = _tryResolveScrollPosition(element);
         if (position != null && _hasScrollableRange(position)) {
           scrollableWithRange = element;
-          return;
+        }
+
+        // Preferred fallbacks are scrollables that can currently receive
+        // pointer events. This filters out blocked/background layers.
+        if (ElementResolver.isHittable(element)) {
+          hittableFallbackScrollable ??= element;
+          if (position != null && _hasScrollableRange(position)) {
+            hittableScrollableWithRange = element;
+          }
         }
       }
 
@@ -99,19 +117,15 @@ class ScrollSimulator {
     }
 
     visit(root);
-    return scrollableWithRange ?? fallbackScrollable;
-  }
-
-  Element? _findScrollableAncestor(Element element) {
-    Element? scrollableAncestor;
-    element.visitAncestorElements((Element ancestor) {
-      if (ancestor.widget is Scrollable) {
-        scrollableAncestor = ancestor;
-        return false;
-      }
-      return true;
-    });
-    return scrollableAncestor;
+    // Return order encodes preference:
+    // 1) hittable + has range
+    // 2) hittable
+    // 3) any + has range
+    // 4) any
+    return hittableScrollableWithRange ??
+        hittableFallbackScrollable ??
+        scrollableWithRange ??
+        fallbackScrollable;
   }
 
   /// Repeatedly drags the scrollable until the target is visible.
@@ -129,10 +143,13 @@ class ScrollSimulator {
     var stalledAttempts = 0;
 
     for (var i = 0; i < maxScrollAttempts; i++) {
-      // Find the target element
-      final target = _widgetFinder.findElement(targetMatcher, configuration);
-      // Check if target is visible
-      if (target != null && WidgetFinder.isHittable(target)) {
+      // Stop condition: matcher resolves to a currently hittable element.
+      // This ensures the final match is on the interactive layer.
+      final target = _elementResolver.findHittableElement(
+        targetMatcher,
+        configuration,
+      );
+      if (target != null) {
         return;
       }
 
@@ -155,6 +172,8 @@ class ScrollSimulator {
         throw Exception('Scrollable does not have a RenderBox');
       }
 
+      // Drag from the scrollable's center. This remains stable even when the
+      // scroll view is inset within other layouts.
       final center = renderObject.size.center(Offset.zero);
       final globalPosition = renderObject.localToGlobal(center);
 
@@ -247,5 +266,4 @@ class ScrollSimulator {
     final adaptiveAttempts = oneWayAttempts * 2 + _attemptPadding;
     return adaptiveAttempts.clamp(1, _defaultMaxScrollAttemptsCap).toInt();
   }
-
 }

--- a/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/services/element_resolver.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
 
@@ -8,6 +9,7 @@ class TextInputSimulator {
   const TextInputSimulator(this._widgetFinder);
 
   final WidgetFinder _widgetFinder;
+  ElementResolver get _elementResolver => ElementResolver(_widgetFinder);
 
   /// Enters text into a text field identified by the given matcher.
   Future<void> enterText(
@@ -57,7 +59,13 @@ class TextInputSimulator {
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
   ) {
-    final element = _widgetFinder.findHittableElement(matcher, configuration);
+    // Same resolution rule as tap(): only accept a matcher hit if that element
+    // can currently receive pointer input. This avoids typing into hidden
+    // duplicates behind dialogs/routes.
+    final element = _elementResolver.findHittableElement(
+      matcher,
+      configuration,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');

--- a/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
@@ -57,7 +57,7 @@ class TextInputSimulator {
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
   ) {
-    final element = _widgetFinder.findElement(matcher, configuration);
+    final element = _widgetFinder.findHittableElement(matcher, configuration);
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
@@ -48,5 +49,91 @@ class WidgetFinder {
 
     visitor(startElement);
     return found;
+  }
+
+  /// Finds the first element that matches the given [matcher] and is hittable
+  /// (i.e. can receive pointer events and is not behind a modal barrier).
+  ///
+  /// This should be used by tools that dispatch gestures (tap, enter_text)
+  /// where matching a non-hittable widget would result in a silent failure.
+  /// Tools that need to find offscreen elements (e.g. scroll_to) should use
+  /// [findElement] instead.
+  Element? findHittableElement(
+    WidgetMatcher matcher,
+    MarionetteConfiguration configuration,
+  ) {
+    return _findHittableElementFrom(
+      matcher,
+      WidgetsBinding.instance.rootElement,
+      configuration,
+    );
+  }
+
+  Element? _findHittableElementFrom(
+    WidgetMatcher matcher,
+    Element? startElement,
+    MarionetteConfiguration configuration,
+  ) {
+    if (startElement == null) {
+      return null;
+    }
+
+    Element? found;
+
+    void visitor(Element element) {
+      if (found != null) {
+        return;
+      } else if (matcher.matches(element.widget, configuration) &&
+          isHittable(element)) {
+        found = element;
+      } else {
+        element.visitChildren(visitor);
+      }
+    }
+
+    visitor(startElement);
+    return found;
+  }
+
+  /// Checks if the element can receive pointer events.
+  ///
+  /// Performs a hit test at the center of the element and checks whether its
+  /// render object appears in the hit test path. Elements behind modal
+  /// barriers, [AbsorbPointer], [IgnorePointer], or offscreen will return
+  /// false.
+  static bool isHittable(Element element) {
+    final renderObject = element.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return false;
+    }
+
+    if (!renderObject.attached) {
+      return false;
+    }
+
+    final view = element.findAncestorWidgetOfExactType<View>();
+    final viewId = view?.view.viewId ??
+        WidgetsBinding.instance.platformDispatcher.implicitView?.viewId;
+    if (viewId == null) {
+      return false;
+    }
+
+    try {
+      final center = renderObject.size.center(Offset.zero);
+      final absoluteOffset = renderObject.localToGlobal(center);
+
+      final result = HitTestResult();
+      WidgetsBinding.instance.hitTestInView(result, absoluteOffset, viewId);
+
+      for (final entry in result.path) {
+        if (entry.target == renderObject) {
+          return true;
+        }
+      }
+
+      return false;
+    } catch (_) {
+      return false;
+    }
   }
 }

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
@@ -31,109 +30,48 @@ class WidgetFinder {
     Element? startElement,
     MarionetteConfiguration configuration,
   ) {
-    if (startElement == null) {
-      return null;
-    }
-
-    Element? found;
-
-    void visitor(Element element) {
-      if (found != null) {
-        return;
-      } else if (matcher.matches(element.widget, configuration)) {
-        found = element;
-      } else {
-        element.visitChildren(visitor);
-      }
-    }
-
-    visitor(startElement);
-    return found;
+    // Keep this convenience API for existing callers, but delegate to the
+    // "find all" traversal so there is a single matching implementation.
+    final elements = findElementsFrom(matcher, startElement, configuration);
+    return elements.isEmpty ? null : elements.first;
   }
 
-  /// Finds the first element that matches the given [matcher] and is hittable
-  /// (i.e. can receive pointer events and is not behind a modal barrier).
-  ///
-  /// This should be used by tools that dispatch gestures (tap, enter_text)
-  /// where matching a non-hittable widget would result in a silent failure.
-  /// Tools that need to find offscreen elements (e.g. scroll_to) should use
-  /// [findElement] instead.
-  Element? findHittableElement(
-    WidgetMatcher matcher,
-    MarionetteConfiguration configuration,
-  ) {
-    return _findHittableElementFrom(
-      matcher,
-      WidgetsBinding.instance.rootElement,
-      configuration,
-    );
-  }
-
-  Element? _findHittableElementFrom(
+  /// Finds all elements that match [matcher] within [startElement]'s subtree.
+  List<Element> findElementsFrom(
     WidgetMatcher matcher,
     Element? startElement,
     MarionetteConfiguration configuration,
   ) {
     if (startElement == null) {
-      return null;
+      return const [];
     }
 
-    Element? found;
+    final found = <Element>[];
 
     void visitor(Element element) {
-      if (found != null) {
-        return;
-      } else if (matcher.matches(element.widget, configuration) &&
-          isHittable(element)) {
-        found = element;
-      } else {
-        element.visitChildren(visitor);
+      // DFS order is important: it preserves historical "first match wins"
+      // semantics for callers that still consume only the first match.
+      if (matcher.matches(element.widget, configuration)) {
+        found.add(element);
       }
+      // Even if this element matches, continue traversing. Some workflows need
+      // all candidates to apply additional runtime filters.
+      element.visitChildren(visitor);
     }
 
     visitor(startElement);
     return found;
   }
 
-  /// Checks if the element can receive pointer events.
-  ///
-  /// Performs a hit test at the center of the element and checks whether its
-  /// render object appears in the hit test path. Elements behind modal
-  /// barriers, [AbsorbPointer], [IgnorePointer], or offscreen will return
-  /// false.
-  static bool isHittable(Element element) {
-    final renderObject = element.renderObject;
-    if (renderObject is! RenderBox || !renderObject.hasSize) {
-      return false;
-    }
-
-    if (!renderObject.attached) {
-      return false;
-    }
-
-    final view = element.findAncestorWidgetOfExactType<View>();
-    final viewId = view?.view.viewId ??
-        WidgetsBinding.instance.platformDispatcher.implicitView?.viewId;
-    if (viewId == null) {
-      return false;
-    }
-
-    try {
-      final center = renderObject.size.center(Offset.zero);
-      final absoluteOffset = renderObject.localToGlobal(center);
-
-      final result = HitTestResult();
-      WidgetsBinding.instance.hitTestInView(result, absoluteOffset, viewId);
-
-      for (final entry in result.path) {
-        if (entry.target == renderObject) {
-          return true;
-        }
-      }
-
-      return false;
-    } catch (_) {
-      return false;
-    }
+  /// Finds all matching elements in DFS order from the root tree.
+  List<Element> findElements(
+    WidgetMatcher matcher,
+    MarionetteConfiguration configuration,
+  ) {
+    return findElementsFrom(
+      matcher,
+      WidgetsBinding.instance.rootElement,
+      configuration,
+    );
   }
 }

--- a/packages/marionette_flutter/test/gesture_dispatcher_test.dart
+++ b/packages/marionette_flutter/test/gesture_dispatcher_test.dart
@@ -195,4 +195,63 @@ void main() {
       },
     );
   });
+
+  group('GestureDispatcher matcher resolution', () {
+    testWidgets(
+      'tap(text) targets the visible route when duplicate text exists behind a pushed route',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final navKey = GlobalKey<NavigatorState>();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            navigatorKey: navKey,
+            home: Scaffold(body: Center(child: Text('Hello'))),
+          ),
+        );
+
+        navKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const _RouteTapTargetScreen(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(
+          () => dispatcher.tap(
+            const TextMatcher('Hello'),
+            WidgetFinder(),
+            const MarionetteConfiguration(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Tapped'), findsOneWidget);
+      },
+    );
+  });
+}
+
+class _RouteTapTargetScreen extends StatefulWidget {
+  const _RouteTapTargetScreen();
+
+  @override
+  State<_RouteTapTargetScreen> createState() => _RouteTapTargetScreenState();
+}
+
+class _RouteTapTargetScreenState extends State<_RouteTapTargetScreen> {
+  var _tapped = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          onPressed: () => setState(() => _tapped = true),
+          child: Text(_tapped ? 'Tapped' : 'Hello'),
+        ),
+      ),
+    );
+  }
 }

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -26,7 +26,7 @@ void main() {
         );
 
         final simulator = ScrollSimulator(
-          _WidgetTesterGestureDispatcher(tester, find.byType(Scrollable).first),
+          _WidgetTesterGestureDispatcher(tester),
           WidgetFinder(),
         );
 
@@ -67,7 +67,7 @@ void main() {
         );
 
         final simulator = ScrollSimulator(
-          _WidgetTesterGestureDispatcher(tester, find.byType(Scrollable).first),
+          _WidgetTesterGestureDispatcher(tester),
           WidgetFinder(),
         );
 
@@ -97,10 +97,7 @@ void main() {
           ),
         );
 
-        final dispatcher = _WidgetTesterGestureDispatcher(
-          tester,
-          find.byType(Scrollable).first,
-        );
+        final dispatcher = _WidgetTesterGestureDispatcher(tester);
         final simulator = ScrollSimulator(dispatcher, WidgetFinder());
 
         await expectLater(
@@ -113,6 +110,86 @@ void main() {
         await tester.pump();
 
         expect(dispatcher.dragCount, 200);
+      },
+    );
+
+    testWidgets(
+      'chooses the hittable modal scroll layer when duplicate key exists behind a barrier',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final backgroundController = ScrollController();
+        final modalController = ScrollController();
+
+        addTearDown(() {
+          backgroundController.dispose();
+          modalController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                return Scaffold(
+                  body: Column(
+                    children: [
+                      Expanded(
+                        child: ListView.builder(
+                          controller: backgroundController,
+                          itemCount: 100,
+                          itemBuilder: (context, index) {
+                            return ListTile(
+                              key: ValueKey('shared_target_$index'),
+                              title: Text('Background $index'),
+                            );
+                          },
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          showModalBottomSheet<void>(
+                            context: context,
+                            builder: (_) {
+                              return SizedBox(
+                                height: 320,
+                                child: ListView.builder(
+                                  controller: modalController,
+                                  itemCount: 100,
+                                  itemBuilder: (context, index) {
+                                    return ListTile(
+                                      key: ValueKey('shared_target_$index'),
+                                      title: Text('Modal $index'),
+                                    );
+                                  },
+                                ),
+                              );
+                            },
+                          );
+                        },
+                        child: const Text('open modal'),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open modal'));
+        await tester.pumpAndSettle();
+
+        final simulator = ScrollSimulator(
+          _WidgetTesterGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+        await simulator.scrollUntilVisible(
+          const KeyMatcher('shared_target_90'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(modalController.offset, greaterThan(0));
+        expect(backgroundController.offset, 0);
       },
     );
   });
@@ -144,16 +221,15 @@ Widget _buildItemsApp({
 }
 
 class _WidgetTesterGestureDispatcher extends GestureDispatcher {
-  _WidgetTesterGestureDispatcher(this._tester, this._scrollableFinder);
+  _WidgetTesterGestureDispatcher(this._tester);
 
   final WidgetTester _tester;
-  final Finder _scrollableFinder;
   int dragCount = 0;
 
   @override
   Future<void> drag(Offset from, Offset to) async {
     dragCount++;
-    await _tester.drag(_scrollableFinder, to - from);
+    await _tester.dragFrom(from, to - from);
     await _tester.pump();
   }
 }

--- a/packages/marionette_flutter/test/text_input_simulator_test.dart
+++ b/packages/marionette_flutter/test/text_input_simulator_test.dart
@@ -191,6 +191,66 @@ void main() {
       expect(controller.text, 'Matched by text');
     });
 
+    testWidgets(
+      'prefers the hittable modal field when duplicate key exists behind a dialog',
+      (WidgetTester tester) async {
+        final backgroundController = TextEditingController(text: 'bg');
+        final dialogController = TextEditingController(text: 'dialog');
+
+        addTearDown(() {
+          backgroundController.dispose();
+          dialogController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return Column(
+                    children: [
+                      TextField(
+                        key: const ValueKey('shared_field'),
+                        controller: backgroundController,
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          showDialog<void>(
+                            context: context,
+                            builder: (_) => AlertDialog(
+                              content: TextField(
+                                key: const ValueKey('shared_field'),
+                                controller: dialogController,
+                              ),
+                            ),
+                          );
+                        },
+                        child: const Text('open'),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        final simulator = TextInputSimulator(WidgetFinder());
+        await simulator.enterText(
+          const KeyMatcher('shared_field'),
+          'typed in dialog',
+          configuration,
+        );
+        await tester.pump();
+
+        expect(dialogController.text, 'typed in dialog');
+        expect(backgroundController.text, 'bg');
+      },
+    );
+
     group('FocusedElementMatcher', () {
       testWidgets('enters text into focused TextField',
           (WidgetTester tester) async {


### PR DESCRIPTION
See issue ticket #44 for discussion of the problem.

Added findHittableElement() to WidgetFinder; a version of findElement() that performs a hit test on each candidate and skips elements that can't receive pointer events (eg behind modal barriers, AbsorbPointer, IgnorePointer).

**Callers:**
- GestureDispatcher.tap() and TextInputSimulator.enterText() now uses findHittableElement() so text/key/type taps only match elements that can actually receive the gesture
- ScrollSimulator continues using findElement() (needs offscreen elements), but its private _isHittable() is replaced with the shared WidgetFinder.isHittable() static method, eliminating a duplicated hit test implementation

**Note:** scroll_to is still broken, because it needs to be able to find offscreen elements, and so given the test case will find the previous screen rather than current. There is no easy way to fix this (that i can see), but this patch solves 80% of the problem.

Fixes: #44