### PR TITLE
feat: add set_device_config for accessibility testing

### DIFF
--- a/packages/marionette_cli/lib/src/cli/commands/set_device_config_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/set_device_config_command.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:marionette_cli/src/cli/instance_command.dart';
+import 'package:marionette_cli/src/instance_registry.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+
+class SetDeviceConfigCommand extends InstanceCommand {
+  SetDeviceConfigCommand(this._registry) {
+    argParser
+      ..addOption(
+        'text-scale-factor',
+        help: 'Text scale factor (e.g., 1.0, 1.5, 2.0). Must be > 0.',
+      )
+      ..addOption(
+        'bold-text',
+        help: 'Enable bold text accessibility (true/false).',
+        allowed: ['true', 'false'],
+      )
+      ..addFlag(
+        'reset',
+        help: 'Reset all overrides to platform defaults.',
+        negatable: false,
+      );
+  }
+
+  final InstanceRegistry _registry;
+
+  @override
+  InstanceRegistry get registry => _registry;
+
+  @override
+  String get name => 'set-device-config';
+
+  @override
+  String get description =>
+      'Override device config (text scale, bold text) for accessibility testing.';
+
+  @override
+  Future<int> execute(VmServiceConnector connector) async {
+    final reset = argResults?['reset'] as bool? ?? false;
+    final rawTextScale = argResults?['text-scale-factor'] as String?;
+    final rawBoldText = argResults?['bold-text'] as String?;
+
+    if (!reset && rawTextScale == null && rawBoldText == null) {
+      usageException(
+        'At least one option required: '
+        '--text-scale-factor, --bold-text, or --reset.',
+      );
+    }
+
+    double? textScaleFactor;
+    if (rawTextScale != null) {
+      textScaleFactor = double.tryParse(rawTextScale);
+      if (textScaleFactor == null || textScaleFactor <= 0) {
+        usageException(
+          '--text-scale-factor must be a positive number, got "$rawTextScale".',
+        );
+      }
+    }
+
+    bool? boldText;
+    if (rawBoldText != null) {
+      boldText = rawBoldText == 'true';
+    }
+
+    final response = await connector.setDeviceConfig(
+      textScaleFactor: textScaleFactor,
+      boldText: boldText,
+      reset: reset,
+    );
+
+    final message = response['message'] as String? ?? 'Device config updated';
+    stdout.writeln(message);
+    return 0;
+  }
+}

--- a/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
+++ b/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
@@ -13,6 +13,7 @@ import 'package:marionette_cli/src/cli/commands/list_command.dart';
 import 'package:marionette_cli/src/cli/commands/mcp_command.dart';
 import 'package:marionette_cli/src/cli/commands/register_command.dart';
 import 'package:marionette_cli/src/cli/commands/scroll_to_command.dart';
+import 'package:marionette_cli/src/cli/commands/set_device_config_command.dart';
 import 'package:marionette_cli/src/cli/commands/take_screenshots_command.dart';
 import 'package:marionette_cli/src/cli/commands/tap_command.dart';
 import 'package:marionette_cli/src/cli/commands/unregister_command.dart';
@@ -49,6 +50,7 @@ class MarionetteCommandRunner extends CommandRunner<int> {
     addCommand(TapCommand(_registry));
     addCommand(LongPressCommand(_registry));
     addCommand(EnterTextCommand(_registry));
+    addCommand(SetDeviceConfigCommand(_registry));
     addCommand(ScrollToCommand(_registry));
     addCommand(ScreenshotCommand(_registry));
     addCommand(LogsCommand(_registry));

--- a/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
+++ b/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
@@ -30,6 +30,7 @@ void main() {
         'tap',
         'long-press',
         'enter-text',
+        'set-device-config',
         'scroll-to',
         'take-screenshots',
         'get-logs',

--- a/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
@@ -4,6 +4,7 @@ import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
 import 'package:marionette_flutter/src/binding/marionette_extension_result.dart';
 import 'package:marionette_flutter/src/binding/register_extension.dart';
 import 'package:marionette_flutter/src/binding/register_extension_internal.dart';
+import 'package:marionette_flutter/src/services/device_config_service.dart';
 import 'package:marionette_flutter/src/services/element_tree_finder.dart';
 import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
 import 'package:marionette_flutter/src/services/log_store.dart';
@@ -39,6 +40,7 @@ class MarionetteBinding extends WidgetsFlutterBinding {
   final MarionetteConfiguration configuration;
 
   // Service instances
+  late final DeviceConfigService _deviceConfigService;
   late final ElementTreeFinder _elementTreeFinder;
   late final GestureDispatcher _gestureDispatcher;
   LogStore? _logStore;
@@ -53,6 +55,7 @@ class MarionetteBinding extends WidgetsFlutterBinding {
     _instance = this;
 
     // Initialize services
+    _deviceConfigService = DeviceConfigService();
     _widgetFinder = WidgetFinder();
     _elementTreeFinder = ElementTreeFinder(configuration);
     _gestureDispatcher = GestureDispatcher();
@@ -314,6 +317,89 @@ See https://pub.dev/packages/marionette_flutter for more details.''',
       },
     );
 
+    // Extension: Set device configuration overrides
+    registerInternalMarionetteExtension(
+      name: 'marionette.setDeviceConfig',
+      callback: (params) async {
+        final rawTextScale = params['textScaleFactor'];
+        final rawBoldText = params['boldText'];
+        final rawReset = params['reset'];
+
+        if (rawTextScale == null && rawBoldText == null && rawReset == null) {
+          return MarionetteExtensionResult.invalidParams(
+            'At least one parameter is required: '
+            'textScaleFactor, boldText, or reset',
+          );
+        }
+
+        // Validate reset parameter
+        if (rawReset != null && rawReset != 'true' && rawReset != 'false') {
+          return MarionetteExtensionResult.invalidParams(
+            'Parameter "reset" must be "true" or "false", got "$rawReset"',
+          );
+        }
+
+        // Reset all overrides
+        if (rawReset == 'true') {
+          _deviceConfigService.setOverrides(
+            resetTextScaleFactor: true,
+            resetBoldText: true,
+          );
+          return MarionetteExtensionResult.success({
+            'message': 'Device config reset to platform defaults',
+            'overrides': _deviceConfigService.current.toJson(),
+          });
+        }
+
+        // Validate textScaleFactor
+        double? textScaleFactor;
+        bool resetTextScale = false;
+        if (rawTextScale != null) {
+          if (rawTextScale == 'reset') {
+            resetTextScale = true;
+          } else {
+            final parsed = double.tryParse(rawTextScale.toString());
+            if (parsed == null || parsed <= 0) {
+              return MarionetteExtensionResult.invalidParams(
+                'Parameter "textScaleFactor" must be a positive number, '
+                'got "$rawTextScale"',
+              );
+            }
+            textScaleFactor = parsed;
+          }
+        }
+
+        // Validate boldText
+        bool? boldText;
+        bool resetBold = false;
+        if (rawBoldText != null) {
+          if (rawBoldText == 'reset') {
+            resetBold = true;
+          } else if (rawBoldText == 'true') {
+            boldText = true;
+          } else if (rawBoldText == 'false') {
+            boldText = false;
+          } else {
+            return MarionetteExtensionResult.invalidParams(
+              'Parameter "boldText" must be a boolean, got "$rawBoldText"',
+            );
+          }
+        }
+
+        final result = _deviceConfigService.setOverrides(
+          textScaleFactor: textScaleFactor,
+          boldText: boldText,
+          resetTextScaleFactor: resetTextScale,
+          resetBoldText: resetBold,
+        );
+
+        return MarionetteExtensionResult.success({
+          'message': 'Device config updated',
+          'overrides': result.toJson(),
+        });
+      },
+    );
+
     // Extension: List custom extensions
     registerInternalMarionetteExtension(
       name: 'marionette.listExtensions',
@@ -328,6 +414,16 @@ See https://pub.dev/packages/marionette_flutter for more details.''',
           ],
         });
       },
+    );
+  }
+
+  @override
+  Widget wrapWithDefaultView(Widget rootWidget) {
+    return super.wrapWithDefaultView(
+      DeviceConfigWrapper(
+        overrides: _deviceConfigService.overrides,
+        child: rootWidget,
+      ),
     );
   }
 

--- a/packages/marionette_flutter/lib/src/services/device_config_service.dart
+++ b/packages/marionette_flutter/lib/src/services/device_config_service.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/widgets.dart';
+
+/// Manages runtime overrides for device configuration (text scale, bold text).
+///
+/// Overrides are applied via a [DeviceConfigWrapper] widget injected at the
+/// root of the widget tree through [MarionetteBinding.wrapWithDefaultView].
+/// Calling [setOverrides] updates the values and triggers a rebuild.
+class DeviceConfigService {
+  /// Notifier that fires whenever any override changes.
+  final ValueNotifier<DeviceConfigOverrides> overrides =
+      ValueNotifier(const DeviceConfigOverrides());
+
+  /// Applies new overrides, merging with existing ones.
+  ///
+  /// Pass a value to set it. Pass [resetTextScaleFactor] or [resetBoldText]
+  /// as `true` to clear that override and revert to the platform default.
+  DeviceConfigOverrides setOverrides({
+    double? textScaleFactor,
+    bool? boldText,
+    bool resetTextScaleFactor = false,
+    bool resetBoldText = false,
+  }) {
+    overrides.value = DeviceConfigOverrides(
+      textScaleFactor: resetTextScaleFactor
+          ? null
+          : (textScaleFactor ?? overrides.value.textScaleFactor),
+      boldText: resetBoldText ? null : (boldText ?? overrides.value.boldText),
+    );
+    return overrides.value;
+  }
+
+  /// Returns the current active overrides.
+  DeviceConfigOverrides get current => overrides.value;
+}
+
+/// Holds the current device config override values.
+///
+/// Fields that are `null` fall through to the platform default.
+class DeviceConfigOverrides {
+  const DeviceConfigOverrides({this.textScaleFactor, this.boldText});
+
+  /// If non-null, overrides the platform text scale factor.
+  final double? textScaleFactor;
+
+  /// If non-null, overrides the platform bold-text accessibility setting.
+  final bool? boldText;
+
+  bool get hasOverrides => textScaleFactor != null || boldText != null;
+
+  Map<String, dynamic> toJson() => {
+        if (textScaleFactor != null) 'textScaleFactor': textScaleFactor,
+        if (boldText != null) 'boldText': boldText,
+      };
+}
+
+/// Widget injected at the root of the tree via
+/// [MarionetteBinding.wrapWithDefaultView].
+///
+/// Listens to [DeviceConfigService.overrides] and applies [MediaQuery]
+/// overrides when active. The [MediaQuery] inserted here becomes the
+/// `platformData` source for [MaterialApp]'s internal
+/// `_MediaQueryFromView`, so the override propagates through the entire
+/// widget tree.
+class DeviceConfigWrapper extends StatelessWidget {
+  const DeviceConfigWrapper({
+    required this.overrides,
+    required this.child,
+    super.key,
+  });
+
+  final ValueNotifier<DeviceConfigOverrides> overrides;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DeviceConfigOverrides>(
+      valueListenable: overrides,
+      builder: (context, config, child) {
+        if (!config.hasOverrides) return child!;
+
+        final baseData = MediaQuery.maybeOf(context) ??
+            MediaQueryData.fromView(View.of(context));
+
+        final data = baseData.copyWith(
+          textScaler: config.textScaleFactor != null
+              ? TextScaler.linear(config.textScaleFactor!)
+              : baseData.textScaler,
+          boldText: config.boldText ?? baseData.boldText,
+        );
+
+        return MediaQuery(data: data, child: child!);
+      },
+      child: child,
+    );
+  }
+}

--- a/packages/marionette_flutter/test/device_config_service_test.dart
+++ b/packages/marionette_flutter/test/device_config_service_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/src/services/device_config_service.dart';
+
+void main() {
+  group('DeviceConfigService', () {
+    late DeviceConfigService service;
+
+    setUp(() {
+      service = DeviceConfigService();
+    });
+
+    test('initial overrides are empty', () {
+      expect(service.current.hasOverrides, isFalse);
+      expect(service.current.textScaleFactor, isNull);
+      expect(service.current.boldText, isNull);
+    });
+
+    test('setOverrides applies textScaleFactor', () {
+      final result = service.setOverrides(textScaleFactor: 2.0);
+      expect(result.textScaleFactor, equals(2.0));
+      expect(result.boldText, isNull);
+    });
+
+    test('setOverrides applies boldText', () {
+      final result = service.setOverrides(boldText: true);
+      expect(result.textScaleFactor, isNull);
+      expect(result.boldText, isTrue);
+    });
+
+    test('setOverrides merges with existing values', () {
+      service.setOverrides(textScaleFactor: 1.5);
+      final result = service.setOverrides(boldText: true);
+      expect(result.textScaleFactor, equals(1.5));
+      expect(result.boldText, isTrue);
+    });
+
+    test('resetTextScaleFactor clears only textScaleFactor', () {
+      service.setOverrides(textScaleFactor: 2.0, boldText: true);
+      final result = service.setOverrides(resetTextScaleFactor: true);
+      expect(result.textScaleFactor, isNull);
+      expect(result.boldText, isTrue);
+    });
+
+    test('resetBoldText clears only boldText', () {
+      service.setOverrides(textScaleFactor: 2.0, boldText: true);
+      final result = service.setOverrides(resetBoldText: true);
+      expect(result.textScaleFactor, equals(2.0));
+      expect(result.boldText, isNull);
+    });
+
+    test('toJson only includes non-null fields', () {
+      expect(const DeviceConfigOverrides().toJson(), isEmpty);
+      expect(
+        const DeviceConfigOverrides(textScaleFactor: 1.5).toJson(),
+        equals({'textScaleFactor': 1.5}),
+      );
+      expect(
+        const DeviceConfigOverrides(boldText: true).toJson(),
+        equals({'boldText': true}),
+      );
+    });
+  });
+
+  group('DeviceConfigWrapper', () {
+    testWidgets(
+      'passes through child when no overrides are set',
+      (WidgetTester tester) async {
+        final overrides = ValueNotifier(const DeviceConfigOverrides());
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: DeviceConfigWrapper(
+              overrides: overrides,
+              child: Builder(
+                builder: (context) {
+                  return Text(
+                    'scale: ${MediaQuery.textScalerOf(context).scale(1.0)}',
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Default text scale factor is 1.0
+        expect(find.text('scale: 1.0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'applies textScaleFactor override',
+      (WidgetTester tester) async {
+        final overrides =
+            ValueNotifier(const DeviceConfigOverrides(textScaleFactor: 2.0));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: DeviceConfigWrapper(
+              overrides: overrides,
+              child: Builder(
+                builder: (context) {
+                  return Text(
+                    'scale: ${MediaQuery.textScalerOf(context).scale(1.0)}',
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('scale: 2.0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'applies boldText override',
+      (WidgetTester tester) async {
+        final overrides =
+            ValueNotifier(const DeviceConfigOverrides(boldText: true));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: DeviceConfigWrapper(
+              overrides: overrides,
+              child: Builder(
+                builder: (context) {
+                  final bold = MediaQuery.boldTextOf(context);
+                  return Text('bold: $bold');
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('bold: true'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'rebuilds when overrides change',
+      (WidgetTester tester) async {
+        final overrides = ValueNotifier(const DeviceConfigOverrides());
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: DeviceConfigWrapper(
+              overrides: overrides,
+              child: Builder(
+                builder: (context) {
+                  return Text(
+                    'scale: ${MediaQuery.textScalerOf(context).scale(1.0)}',
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('scale: 1.0'), findsOneWidget);
+
+        overrides.value = const DeviceConfigOverrides(textScaleFactor: 3.0);
+        await tester.pump();
+
+        expect(find.text('scale: 3.0'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -299,6 +299,27 @@ class VmServiceConnector {
     return _callExtension('marionette.enterText', args);
   }
 
+  /// Sets device configuration overrides (textScaleFactor, boldText).
+  ///
+  /// Pass [reset] as `true` to clear all overrides and revert to platform
+  /// defaults. When [reset] is false, only the provided fields are updated.
+  ///
+  /// Throws [NotConnectedException] if not connected.
+  Future<Map<String, dynamic>> setDeviceConfig({
+    double? textScaleFactor,
+    bool? boldText,
+    bool reset = false,
+  }) {
+    final args = <String, dynamic>{};
+    if (reset) {
+      args['reset'] = true;
+    } else {
+      if (textScaleFactor != null) args['textScaleFactor'] = textScaleFactor;
+      if (boldText != null) args['boldText'] = boldText;
+    }
+    return _callExtension('marionette.setDeviceConfig', args);
+  }
+
   /// Simulates a swipe gesture.
   ///
   /// Supports two modes:

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
@@ -332,6 +332,97 @@ final class VmServiceContext {
           }
         },
       )
+      // Set device config overrides
+      ..registerTool(
+        'set_device_config',
+        description:
+            'Overrides device configuration for accessibility and responsive '
+            'testing. Supports textScaleFactor (controls text size, useful for '
+            'testing large-font accessibility) and boldText (simulates the '
+            'system bold-text accessibility setting). Set reset to true to '
+            'revert all overrides to platform defaults. '
+            'Requires an active connection established via connect.',
+        annotations: const ToolAnnotations(title: 'Set Device Config'),
+        inputSchema: ToolInputSchema(
+          properties: {
+            'text_scale_factor': JsonSchema.number(
+              description:
+                  'Text scale factor override. Must be > 0. '
+                  'For example, 1.0 is default, 1.5 is large text, '
+                  '2.0 is very large text.',
+            ),
+            'bold_text': JsonSchema.boolean(
+              description: 'Whether to enable bold text accessibility setting.',
+            ),
+            'reset': JsonSchema.boolean(
+              description:
+                  'Set to true to clear all overrides and revert to '
+                  'platform defaults.',
+            ),
+          },
+        ),
+        callback: (args, extra) async {
+          final reset = args['reset'] == true;
+          final rawTextScale = args['text_scale_factor'] as num?;
+          final boldText = args['bold_text'] as bool?;
+
+          if (!reset && rawTextScale == null && boldText == null) {
+            return CallToolResult(
+              isError: true,
+              content: [
+                const TextContent(
+                  text:
+                      'At least one parameter is required: '
+                      'text_scale_factor, bold_text, or reset.',
+                ),
+              ],
+            );
+          }
+
+          double? textScaleFactor;
+          if (rawTextScale != null) {
+            textScaleFactor = rawTextScale.toDouble();
+            if (textScaleFactor <= 0) {
+              return CallToolResult(
+                isError: true,
+                content: [
+                  const TextContent(
+                    text: 'text_scale_factor must be a positive number.',
+                  ),
+                ],
+              );
+            }
+          }
+
+          _logger.info(
+            'Setting device config: textScaleFactor=$textScaleFactor, '
+            'boldText=$boldText, reset=$reset',
+          );
+
+          try {
+            final response = await connector.setDeviceConfig(
+              textScaleFactor: textScaleFactor,
+              boldText: boldText,
+              reset: reset,
+            );
+            final message = response['message'] as String?;
+
+            return CallToolResult(
+              content: [
+                TextContent(
+                  text: message ?? 'Device config updated successfully',
+                ),
+              ],
+            );
+          } catch (err) {
+            _logger.warning('Failed to set device config', err);
+            return CallToolResult(
+              isError: true,
+              content: [TextContent(text: err.toString())],
+            );
+          }
+        },
+      )
       // Swipe gesture
       ..registerTool(
         'swipe',

--- a/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
+++ b/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
@@ -104,4 +104,33 @@ void main() {
       },
     );
   });
+
+  group('VmServiceConnector.setDeviceConfig', () {
+    late VmServiceConnector connector;
+
+    setUp(() {
+      connector = VmServiceConnector();
+    });
+
+    test('throws NotConnectedException when not connected', () async {
+      await expectLater(
+        connector.setDeviceConfig(textScaleFactor: 2.0),
+        throwsA(isA<NotConnectedException>()),
+      );
+    });
+
+    test('throws NotConnectedException with reset flag', () async {
+      await expectLater(
+        connector.setDeviceConfig(reset: true),
+        throwsA(isA<NotConnectedException>()),
+      );
+    });
+
+    test('throws NotConnectedException with boldText', () async {
+      await expectLater(
+        connector.setDeviceConfig(boldText: true),
+        throwsA(isA<NotConnectedException>()),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Add device configuration override support (`textScaleFactor`, `boldText`) across all three packages
- Uses `MediaQuery` wrapper injected via `wrapWithDefaultView` override — propagates through the entire widget tree via Flutter's `_MediaQueryFromView` `platformData` inheritance
- Supports setting, merging, and resetting individual overrides
- No app-level code changes required — works automatically with `MarionetteBinding`

## Changes

**marionette_flutter**
- `DeviceConfigService`: manages override state via `ValueNotifier<DeviceConfigOverrides>`
- `DeviceConfigWrapper`: root-level `StatelessWidget` that applies `MediaQuery` overrides using `TextScaler.linear` and `boldText`
- `MarionetteBinding`: initializes service, overrides `wrapWithDefaultView`, registers `marionette.setDeviceConfig` VM service extension with full validation
- 7 new tests: service state management (6) + wrapper widget behavior (4 including reactive rebuild)

**marionette_mcp**
- `VmServiceConnector`: `setDeviceConfig()` method with `textScaleFactor`, `boldText`, `reset` params
- `VmServiceContext`: `set_device_config` MCP tool with JSON schema, early validation (`> 0`), and empty-params guard
- 3 new tests: connector connection validation

**marionette_cli**
- `SetDeviceConfigCommand`: CLI command with `--text-scale-factor`, `--bold-text`, `--reset` options
- Registered in `MarionetteCommandRunner`

## Technical notes

- Locale override was investigated but is not feasible from binding level — `PlatformDispatcher.locales` is read-only (engine-set), and `Localizations.override` requires a parent `Localizations` widget that doesn't exist above `MaterialApp`
- `boldText` was added instead as a valuable accessibility testing property

## Test plan

- [x] `flutter test` (marionette_flutter): 43/43 passed
- [x] `dart test` (marionette_mcp): 9/9 passed
- [x] `flutter test` (marionette_cli): 27/27 passed
- [x] `dart analyze`: no issues across all packages
- [x] Live tested on macOS example app: textScale 2x, 3x + bold, reset, idempotent double-reset