### PR TITLE
feat: promote schema-bearing custom extensions to first-class MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,71 @@ Once connected, the AI agent has access to these tools:
 | `get_logs`                 | Retrieves application logs collected since app start or the last hot reload (requires a `LogCollector` to be configured). |
 | `take_screenshots`         | Captures screenshots of all active views and returns them as base64 images.                                               |
 | `hot_reload`               | Performs a hot reload of the Flutter app, applying code changes without losing state.                                     |
+| `list_custom_extensions`   | Lists the app-specific extensions registered via `registerMarionetteExtension` (see [Custom Extensions](#custom-extensions)). |
+| `call_custom_extension`    | Calls a custom extension that does not declare an `inputSchema` (the generic escape hatch).                               |
+
+In addition, any custom extension that declares an `inputSchema` appears as a **dedicated tool of its own**, named after the extension — see [Custom Extensions](#custom-extensions) below.
+
+## Custom Extensions
+
+Beyond the built-in tools, your app can expose its own actions to the agent by registering a custom VM service extension with `registerMarionetteExtension`. This is useful for app-specific operations the generic tools can't express — navigating by route name, seeding test data, toggling feature flags, and so on.
+
+### Declaring a schema (recommended)
+
+When an extension declares an `inputSchema`, the MCP server promotes it to a **first-class, individually-named tool** with a validated input schema. The agent discovers it in the tool list, gets argument hints and enum autocomplete, and invalid arguments are rejected before they ever reach your app:
+
+```dart
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+registerMarionetteExtension(
+  name: 'appNavigation.goToPage',
+  description: 'Navigates to a page by name.',
+  inputSchema: ExtensionInputSchema(
+    properties: {
+      'page': ExtensionParam.string(
+        description: 'The page to navigate to.',
+        enumValues: ['home', 'profile', 'settings'],
+      ),
+      'animate': ExtensionParam.boolean(
+        description: 'Whether to animate the transition.',
+        defaultValue: true,
+      ),
+    },
+    required: ['page'],
+  ),
+  callback: (params) async {
+    final page = params['page'];
+    if (page == null) {
+      return MarionetteExtensionResult.invalidParams('Missing required parameter: page');
+    }
+    // `params` always arrives as Map<String, String>; parse non-string values.
+    final animate = params['animate'] != 'false';
+    navigateTo(page, animate: animate); // your app's own navigation
+    return MarionetteExtensionResult.success({'page': page});
+  },
+);
+```
+
+The agent can now call `appNavigation.goToPage` directly — e.g. _"navigate to the profile page"_ — and a bad value like `page: "banana"` is rejected by schema validation.
+
+`ExtensionParam` supports `.string` (with optional `enumValues`), `.integer`, `.number`, and `.boolean`. **Schemas are restricted to flat scalar parameters** by design: custom extension arguments travel over the VM service as a `Map<String, String>`, so nested objects/arrays can't round-trip reliably as typed values.
+
+### No schema (the fallback)
+
+A schema is optional. An extension without one — e.g. a parameter-less action, or one whose inputs a scalar schema can't capture — stays fully supported: it is **not** promoted to its own tool, but remains reachable through the generic `call_custom_extension` tool and shows up in `list_custom_extensions`.
+
+```dart
+registerMarionetteExtension(
+  name: 'appNavigation.getPageInfo',
+  description: 'Returns the current page and the list of available pages.',
+  callback: (params) async => MarionetteExtensionResult.success({
+    'currentPage': currentPageName(),
+    'availablePages': allPageNames(),
+  }),
+);
+```
+
+> **Prefer declaring an `inputSchema`** whenever your parameters are flat scalars — you get validation and a dedicated, discoverable tool. Reach for the schema-less form only for parameter-less extensions or inputs a scalar schema can't express.
 
 ## Example Scenarios
 

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,17 +31,15 @@ void _registerNavigationExtensions() {
   registerMarionetteExtension(
     name: 'appNavigation.goToPage',
     description: 'Navigates to a page by name.',
-    inputSchema: {
-      'type': 'object',
-      'properties': {
-        'page': {
-          'type': 'string',
-          'description': 'Page name. One of: ${availablePages.keys.join(', ')}',
-          'enum': availablePages.keys.toList(),
-        },
+    inputSchema: ExtensionInputSchema(
+      properties: {
+        'page': ExtensionParam.string(
+          description: 'Page name. One of: ${availablePages.keys.join(', ')}',
+          enumValues: availablePages.keys.toList(),
+        ),
       },
-      'required': ['page'],
-    },
+      required: const ['page'],
+    ),
     callback: (params) async {
       final page = params['page'];
       if (page == null) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,7 @@ void _registerNavigationExtensions() {
   // `listChanged` tools capability), it appears alongside the built-in
   // marionette tools as `appNavigation.goToPage` with full argument
   // autocomplete.
+  registerMarionetteExtension(
     name: 'appNavigation.goToPage',
     description: 'Navigates to a page by name.',
     inputSchema: ExtensionInputSchema(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,10 +25,10 @@ void main() {
 
 void _registerNavigationExtensions() {
   // goToPage opts into the new dynamic-tool surface by declaring an
-  // inputSchema — when an MCP client supports tools/list_changed, it
-  // appears alongside the built-in marionette tools as
-  // `appNavigation.goToPage` with full argument autocomplete.
-  registerMarionetteExtension(
+  // inputSchema — when an MCP client supports dynamic tool lists (the
+  // `listChanged` tools capability), it appears alongside the built-in
+  // marionette tools as `appNavigation.goToPage` with full argument
+  // autocomplete.
     name: 'appNavigation.goToPage',
     description: 'Navigates to a page by name.',
     inputSchema: ExtensionInputSchema(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,10 +24,24 @@ void main() {
 }
 
 void _registerNavigationExtensions() {
+  // goToPage opts into the new dynamic-tool surface by declaring an
+  // inputSchema — when an MCP client supports tools/list_changed, it
+  // appears alongside the built-in marionette tools as
+  // `appNavigation.goToPage` with full argument autocomplete.
   registerMarionetteExtension(
     name: 'appNavigation.goToPage',
-    description: 'Navigates to a page by name. '
-        'Requires a "page" parameter with the page name.',
+    description: 'Navigates to a page by name.',
+    inputSchema: {
+      'type': 'object',
+      'properties': {
+        'page': {
+          'type': 'string',
+          'description': 'Page name. One of: ${availablePages.keys.join(', ')}',
+          'enum': availablePages.keys.toList(),
+        },
+      },
+      'required': ['page'],
+    },
     callback: (params) async {
       final page = params['page'];
       if (page == null) {
@@ -47,6 +61,10 @@ void _registerNavigationExtensions() {
     },
   );
 
+  // No inputSchema — getPageInfo takes no arguments, but the absence of a
+  // schema also exercises the schema-less code path. It stays reachable
+  // through `call_custom_extension` and does not get promoted to a
+  // first-class MCP tool.
   registerMarionetteExtension(
     name: 'appNavigation.getPageInfo',
     description: 'Returns the current page name, path, and a list of all '

--- a/packages/marionette_flutter/lib/marionette_flutter.dart
+++ b/packages/marionette_flutter/lib/marionette_flutter.dart
@@ -1,5 +1,6 @@
 library marionette_flutter;
 
+export 'src/binding/extension_schema.dart';
 export 'src/binding/marionette_binding.dart';
 export 'src/binding/marionette_configuration.dart';
 export 'src/binding/marionette_extension_result.dart';

--- a/packages/marionette_flutter/lib/src/binding/extension_schema.dart
+++ b/packages/marionette_flutter/lib/src/binding/extension_schema.dart
@@ -1,0 +1,245 @@
+import 'package:meta/meta.dart';
+
+/// Typed JSON Schema for the input parameters of a custom Marionette
+/// extension.
+///
+/// Equivalent of `ToolInputSchema` from the `mcp_dart` package, restricted to
+/// what the Dart VM service can actually carry: a flat object whose
+/// properties are scalar types. Nested objects/arrays cannot travel as a
+/// single VM service param (params are flattened to strings on the wire), so
+/// the type system makes that constraint a compile-time guarantee.
+///
+/// `toJson()` emits a JSON Schema object compatible with what
+/// `marionette_mcp` parses via `mcp_dart`'s `JsonSchema.fromJson` — devs
+/// don't have to memorize the JSON Schema field names.
+@immutable
+class ExtensionInputSchema {
+  const ExtensionInputSchema({
+    this.properties = const {},
+    this.required = const [],
+    this.title,
+    this.description,
+  });
+
+  /// Per-property schemas keyed by parameter name.
+  final Map<String, ExtensionParam> properties;
+
+  /// Names of properties that must be present.
+  final List<String> required;
+
+  /// Human-readable title for the schema. Optional.
+  final String? title;
+
+  /// Human-readable description for the schema. Optional.
+  final String? description;
+
+  /// Serializes to a JSON Schema object as expected by the MCP wire format
+  /// produced by `marionette.listExtensions`.
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      'type': 'object',
+      'properties': {
+        for (final entry in properties.entries) entry.key: entry.value.toJson(),
+      },
+      if (required.isNotEmpty) 'required': List<String>.from(required),
+    };
+  }
+}
+
+/// A typed schema for a single property of an [ExtensionInputSchema].
+///
+/// Mirrors the scalar factories of `mcp_dart`'s `JsonSchema` (`.string`,
+/// `.integer`, `.number`, `.boolean`). Non-scalar factories are deliberately
+/// absent — see [ExtensionInputSchema] for why.
+@immutable
+sealed class ExtensionParam {
+  const ExtensionParam({this.title, this.description});
+
+  /// Optional human-readable title for the property.
+  final String? title;
+
+  /// Optional human-readable description for the property.
+  final String? description;
+
+  /// A string property.
+  ///
+  /// `enumValues`, when set, restricts the property to that finite list of
+  /// strings. Unlike `mcp_dart`'s `JsonString`, the legacy `enumNames` field
+  /// is not exposed.
+  const factory ExtensionParam.string({
+    String? title,
+    String? description,
+    String? defaultValue,
+    int? minLength,
+    int? maxLength,
+    String? pattern,
+    String? format,
+    List<String>? enumValues,
+  }) = StringParam;
+
+  /// An integer property. All numeric bounds are integers.
+  const factory ExtensionParam.integer({
+    String? title,
+    String? description,
+    int? defaultValue,
+    int? minimum,
+    int? maximum,
+    int? exclusiveMinimum,
+    int? exclusiveMaximum,
+    int? multipleOf,
+  }) = IntegerParam;
+
+  /// A number property (any JSON number — int or double).
+  const factory ExtensionParam.number({
+    String? title,
+    String? description,
+    num? defaultValue,
+    num? minimum,
+    num? maximum,
+    num? exclusiveMinimum,
+    num? exclusiveMaximum,
+    num? multipleOf,
+  }) = NumberParam;
+
+  /// A boolean property.
+  const factory ExtensionParam.boolean({
+    String? title,
+    String? description,
+    bool? defaultValue,
+  }) = BooleanParam;
+
+  /// Serializes the property to a JSON Schema fragment.
+  Map<String, dynamic> toJson();
+}
+
+/// JSON Schema fragment for a string-valued extension parameter.
+class StringParam extends ExtensionParam {
+  const StringParam({
+    super.title,
+    super.description,
+    this.defaultValue,
+    this.minLength,
+    this.maxLength,
+    this.pattern,
+    this.format,
+    this.enumValues,
+  });
+
+  final String? defaultValue;
+  final int? minLength;
+  final int? maxLength;
+  final String? pattern;
+  final String? format;
+  final List<String>? enumValues;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      if (defaultValue != null) 'default': defaultValue,
+      'type': 'string',
+      if (minLength != null) 'minLength': minLength,
+      if (maxLength != null) 'maxLength': maxLength,
+      if (pattern != null) 'pattern': pattern,
+      if (format != null) 'format': format,
+      if (enumValues != null) 'enum': List<String>.from(enumValues!),
+    };
+  }
+}
+
+/// JSON Schema fragment for an integer-valued extension parameter.
+class IntegerParam extends ExtensionParam {
+  const IntegerParam({
+    super.title,
+    super.description,
+    this.defaultValue,
+    this.minimum,
+    this.maximum,
+    this.exclusiveMinimum,
+    this.exclusiveMaximum,
+    this.multipleOf,
+  });
+
+  final int? defaultValue;
+  final int? minimum;
+  final int? maximum;
+  final int? exclusiveMinimum;
+  final int? exclusiveMaximum;
+  final int? multipleOf;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      if (defaultValue != null) 'default': defaultValue,
+      'type': 'integer',
+      if (minimum != null) 'minimum': minimum,
+      if (maximum != null) 'maximum': maximum,
+      if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
+      if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
+      if (multipleOf != null) 'multipleOf': multipleOf,
+    };
+  }
+}
+
+/// JSON Schema fragment for a number-valued (int or double) extension
+/// parameter.
+class NumberParam extends ExtensionParam {
+  const NumberParam({
+    super.title,
+    super.description,
+    this.defaultValue,
+    this.minimum,
+    this.maximum,
+    this.exclusiveMinimum,
+    this.exclusiveMaximum,
+    this.multipleOf,
+  });
+
+  final num? defaultValue;
+  final num? minimum;
+  final num? maximum;
+  final num? exclusiveMinimum;
+  final num? exclusiveMaximum;
+  final num? multipleOf;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      if (defaultValue != null) 'default': defaultValue,
+      'type': 'number',
+      if (minimum != null) 'minimum': minimum,
+      if (maximum != null) 'maximum': maximum,
+      if (exclusiveMinimum != null) 'exclusiveMinimum': exclusiveMinimum,
+      if (exclusiveMaximum != null) 'exclusiveMaximum': exclusiveMaximum,
+      if (multipleOf != null) 'multipleOf': multipleOf,
+    };
+  }
+}
+
+/// JSON Schema fragment for a boolean-valued extension parameter.
+class BooleanParam extends ExtensionParam {
+  const BooleanParam({
+    super.title,
+    super.description,
+    this.defaultValue,
+  });
+
+  final bool? defaultValue;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+      if (defaultValue != null) 'default': defaultValue,
+      'type': 'boolean',
+    };
+  }
+}

--- a/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
@@ -82,7 +82,8 @@ void registerInfoExtensions({
             {
               'name': ext.name,
               if (ext.description != null) 'description': ext.description,
-              if (ext.inputSchema != null) 'inputSchema': ext.inputSchema,
+              if (ext.inputSchema != null)
+                'inputSchema': ext.inputSchema!.toJson(),
             },
         ],
       });

--- a/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
@@ -82,6 +82,7 @@ void registerInfoExtensions({
             {
               'name': ext.name,
               if (ext.description != null) 'description': ext.description,
+              if (ext.inputSchema != null) 'inputSchema': ext.inputSchema,
             },
         ],
       });

--- a/packages/marionette_flutter/lib/src/binding/register_extension.dart
+++ b/packages/marionette_flutter/lib/src/binding/register_extension.dart
@@ -67,6 +67,10 @@ List<ExtensionDetails> get customExtensionRegistry =>
 /// serializes parameters as strings, so nested objects/arrays cannot travel
 /// as a single param.
 ///
+/// Any property that declares a `defaultValue` is filled in (as its string
+/// form) before [callback] runs when the caller omits it, so the callback
+/// never has to reimplement the default it already declared.
+///
 /// The `ext.flutter.` prefix is added automatically to [name].
 ///
 /// Throws [ArgumentError] if [name] is empty or already contains the
@@ -96,5 +100,9 @@ void registerMarionetteExtension({
     ),
   );
 
-  registerInternalMarionetteExtension(name: name, callback: callback);
+  registerInternalMarionetteExtension(
+    name: name,
+    callback: callback,
+    inputSchema: inputSchema,
+  );
 }

--- a/packages/marionette_flutter/lib/src/binding/register_extension.dart
+++ b/packages/marionette_flutter/lib/src/binding/register_extension.dart
@@ -5,16 +5,48 @@ import 'package:marionette_flutter/src/binding/register_extension_internal.dart'
 typedef MarionetteExtensionCallback = Future<MarionetteExtensionResult>
     Function(Map<String, String> params);
 
+/// JSON Schema scalar types accepted in [ExtensionDetails.inputSchema]
+/// property definitions.
+///
+/// The Dart VM service flattens all parameter values to strings on the wire,
+/// so callbacks always receive `Map<String, String>` regardless of the
+/// declared schema type. Restricting properties to scalars makes that
+/// constraint explicit at registration time rather than surprising callers
+/// at call time.
+const _allowedScalarPropertyTypes = {
+  'string',
+  'integer',
+  'number',
+  'boolean',
+};
+
 /// Details about a registered custom extension.
 class ExtensionDetails {
-  /// Creates extension details with the given [name] and optional [description].
-  const ExtensionDetails({required this.name, this.description});
+  /// Creates extension details with the given [name], optional [description],
+  /// and optional [inputSchema].
+  const ExtensionDetails({
+    required this.name,
+    this.description,
+    this.inputSchema,
+  });
 
   /// The name of the extension (without the `ext.flutter.` prefix).
   final String name;
 
   /// An optional description of what the extension does.
   final String? description;
+
+  /// An optional JSON Schema describing the parameters accepted by the
+  /// extension.
+  ///
+  /// When provided, the MCP server promotes this extension to a first-class
+  /// MCP tool with this schema as its input contract — clients get
+  /// argument autocomplete and validation. When omitted, the extension is
+  /// only reachable via the generic `call_custom_extension` escape hatch.
+  ///
+  /// Must be a JSON Schema object (`{"type": "object", ...}`); see
+  /// [registerMarionetteExtension] for the validation rules.
+  final Map<String, dynamic>? inputSchema;
 }
 
 final List<ExtensionDetails> _customExtensionRegistry = [];
@@ -37,13 +69,28 @@ List<ExtensionDetails> get customExtensionRegistry =>
 /// does. This description is returned by the `list_custom_extensions` MCP tool
 /// so that MCP clients can discover available custom extensions.
 ///
+/// An optional [inputSchema] can be provided as a JSON Schema describing the
+/// extension's parameters. When supplied, the MCP server promotes the
+/// extension to a first-class MCP tool — clients see it alongside the
+/// built-in marionette tools with full argument autocomplete and validation.
+/// Without a schema, the extension stays reachable only through the generic
+/// `call_custom_extension` tool.
+///
+/// The [inputSchema], if provided, must:
+/// - have `"type": "object"` at the top level (MCP requires this);
+/// - declare each property's `type` as one of `string`, `integer`, `number`,
+///   or `boolean`. The Dart VM service serializes parameters as strings, so
+///   nested objects/arrays cannot travel as a single param — split them into
+///   multiple scalars or accept a JSON-encoded string.
+///
 /// The `ext.flutter.` prefix is added automatically to [name].
 ///
-/// Throws [ArgumentError] if [name] is empty or already contains the
-/// `ext.flutter.` prefix.
+/// Throws [ArgumentError] if [name] is empty, already contains the
+/// `ext.flutter.` prefix, or if [inputSchema] violates the rules above.
 void registerMarionetteExtension({
   required String name,
   String? description,
+  Map<String, dynamic>? inputSchema,
   required MarionetteExtensionCallback callback,
 }) {
   if (name.isEmpty) {
@@ -56,10 +103,63 @@ void registerMarionetteExtension({
       'must not include the "ext.flutter." prefix, it is added automatically',
     );
   }
+  if (inputSchema != null) {
+    _validateInputSchema(inputSchema);
+  }
 
   _customExtensionRegistry.add(
-    ExtensionDetails(name: name, description: description),
+    ExtensionDetails(
+      name: name,
+      description: description,
+      inputSchema: inputSchema,
+    ),
   );
 
   registerInternalMarionetteExtension(name: name, callback: callback);
+}
+
+void _validateInputSchema(Map<String, dynamic> inputSchema) {
+  final type = inputSchema['type'];
+  if (type != 'object') {
+    throw ArgumentError.value(
+      inputSchema,
+      'inputSchema',
+      'top-level "type" must be "object" (got ${type == null ? 'null' : '"$type"'})',
+    );
+  }
+
+  final properties = inputSchema['properties'];
+  if (properties != null && properties is! Map<String, dynamic>) {
+    throw ArgumentError.value(
+      inputSchema,
+      'inputSchema',
+      '"properties" must be a JSON object',
+    );
+  }
+
+  if (properties is Map<String, dynamic>) {
+    for (final entry in properties.entries) {
+      final propDef = entry.value;
+      if (propDef is! Map<String, dynamic>) {
+        throw ArgumentError.value(
+          inputSchema,
+          'inputSchema',
+          'property "${entry.key}" must be a JSON Schema object',
+        );
+      }
+      final propType = propDef['type'];
+      if (propType is! String ||
+          !_allowedScalarPropertyTypes.contains(propType)) {
+        throw ArgumentError.value(
+          inputSchema,
+          'inputSchema',
+          'property "${entry.key}" must declare a scalar "type" '
+              '(one of ${_allowedScalarPropertyTypes.join(", ")}); '
+              'got ${propType == null ? 'null' : '"$propType"'}. '
+              'The Dart VM service flattens parameter values to strings, '
+              'so nested objects/arrays cannot be represented in the schema.',
+        );
+      }
+    }
+  }
 }

--- a/packages/marionette_flutter/lib/src/binding/register_extension.dart
+++ b/packages/marionette_flutter/lib/src/binding/register_extension.dart
@@ -1,24 +1,10 @@
+import 'package:marionette_flutter/src/binding/extension_schema.dart';
 import 'package:marionette_flutter/src/binding/marionette_extension_result.dart';
 import 'package:marionette_flutter/src/binding/register_extension_internal.dart';
 
 /// Callback type for Marionette extension handlers.
 typedef MarionetteExtensionCallback = Future<MarionetteExtensionResult>
     Function(Map<String, String> params);
-
-/// JSON Schema scalar types accepted in [ExtensionDetails.inputSchema]
-/// property definitions.
-///
-/// The Dart VM service flattens all parameter values to strings on the wire,
-/// so callbacks always receive `Map<String, String>` regardless of the
-/// declared schema type. Restricting properties to scalars makes that
-/// constraint explicit at registration time rather than surprising callers
-/// at call time.
-const _allowedScalarPropertyTypes = {
-  'string',
-  'integer',
-  'number',
-  'boolean',
-};
 
 /// Details about a registered custom extension.
 class ExtensionDetails {
@@ -36,7 +22,7 @@ class ExtensionDetails {
   /// An optional description of what the extension does.
   final String? description;
 
-  /// An optional JSON Schema describing the parameters accepted by the
+  /// An optional typed JSON Schema describing the parameters accepted by the
   /// extension.
   ///
   /// When provided, the MCP server promotes this extension to a first-class
@@ -44,9 +30,9 @@ class ExtensionDetails {
   /// argument autocomplete and validation. When omitted, the extension is
   /// only reachable via the generic `call_custom_extension` escape hatch.
   ///
-  /// Must be a JSON Schema object (`{"type": "object", ...}`); see
-  /// [registerMarionetteExtension] for the validation rules.
-  final Map<String, dynamic>? inputSchema;
+  /// Built via [ExtensionInputSchema] / [ExtensionParam]; the underlying
+  /// JSON Schema is produced lazily by [ExtensionInputSchema.toJson].
+  final ExtensionInputSchema? inputSchema;
 }
 
 final List<ExtensionDetails> _customExtensionRegistry = [];
@@ -69,28 +55,26 @@ List<ExtensionDetails> get customExtensionRegistry =>
 /// does. This description is returned by the `list_custom_extensions` MCP tool
 /// so that MCP clients can discover available custom extensions.
 ///
-/// An optional [inputSchema] can be provided as a JSON Schema describing the
-/// extension's parameters. When supplied, the MCP server promotes the
-/// extension to a first-class MCP tool — clients see it alongside the
-/// built-in marionette tools with full argument autocomplete and validation.
-/// Without a schema, the extension stays reachable only through the generic
-/// `call_custom_extension` tool.
+/// An optional [inputSchema] can be provided as an [ExtensionInputSchema]
+/// describing the extension's parameters. When supplied, the MCP server
+/// promotes the extension to a first-class MCP tool — clients see it
+/// alongside the built-in marionette tools with full argument autocomplete
+/// and validation. Without a schema, the extension stays reachable only
+/// through the generic `call_custom_extension` tool.
 ///
-/// The [inputSchema], if provided, must:
-/// - have `"type": "object"` at the top level (MCP requires this);
-/// - declare each property's `type` as one of `string`, `integer`, `number`,
-///   or `boolean`. The Dart VM service serializes parameters as strings, so
-///   nested objects/arrays cannot travel as a single param — split them into
-///   multiple scalars or accept a JSON-encoded string.
+/// The schema is restricted at the type level to a flat object with scalar
+/// properties (`string`, `integer`, `number`, `boolean`). The Dart VM service
+/// serializes parameters as strings, so nested objects/arrays cannot travel
+/// as a single param.
 ///
 /// The `ext.flutter.` prefix is added automatically to [name].
 ///
-/// Throws [ArgumentError] if [name] is empty, already contains the
-/// `ext.flutter.` prefix, or if [inputSchema] violates the rules above.
+/// Throws [ArgumentError] if [name] is empty or already contains the
+/// `ext.flutter.` prefix.
 void registerMarionetteExtension({
   required String name,
   String? description,
-  Map<String, dynamic>? inputSchema,
+  ExtensionInputSchema? inputSchema,
   required MarionetteExtensionCallback callback,
 }) {
   if (name.isEmpty) {
@@ -103,9 +87,6 @@ void registerMarionetteExtension({
       'must not include the "ext.flutter." prefix, it is added automatically',
     );
   }
-  if (inputSchema != null) {
-    _validateInputSchema(inputSchema);
-  }
 
   _customExtensionRegistry.add(
     ExtensionDetails(
@@ -116,50 +97,4 @@ void registerMarionetteExtension({
   );
 
   registerInternalMarionetteExtension(name: name, callback: callback);
-}
-
-void _validateInputSchema(Map<String, dynamic> inputSchema) {
-  final type = inputSchema['type'];
-  if (type != 'object') {
-    throw ArgumentError.value(
-      inputSchema,
-      'inputSchema',
-      'top-level "type" must be "object" (got ${type == null ? 'null' : '"$type"'})',
-    );
-  }
-
-  final properties = inputSchema['properties'];
-  if (properties != null && properties is! Map<String, dynamic>) {
-    throw ArgumentError.value(
-      inputSchema,
-      'inputSchema',
-      '"properties" must be a JSON object',
-    );
-  }
-
-  if (properties is Map<String, dynamic>) {
-    for (final entry in properties.entries) {
-      final propDef = entry.value;
-      if (propDef is! Map<String, dynamic>) {
-        throw ArgumentError.value(
-          inputSchema,
-          'inputSchema',
-          'property "${entry.key}" must be a JSON Schema object',
-        );
-      }
-      final propType = propDef['type'];
-      if (propType is! String ||
-          !_allowedScalarPropertyTypes.contains(propType)) {
-        throw ArgumentError.value(
-          inputSchema,
-          'inputSchema',
-          'property "${entry.key}" must declare a scalar "type" '
-              '(one of ${_allowedScalarPropertyTypes.join(", ")}); '
-              'got ${propType == null ? 'null' : '"$propType"'}. '
-              'The Dart VM service flattens parameter values to strings, '
-              'so nested objects/arrays cannot be represented in the schema.',
-        );
-      }
-    }
-  }
 }

--- a/packages/marionette_flutter/lib/src/binding/register_extension_internal.dart
+++ b/packages/marionette_flutter/lib/src/binding/register_extension_internal.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
+import 'package:marionette_flutter/src/binding/extension_schema.dart';
 import 'package:marionette_flutter/src/binding/marionette_extension_result.dart';
 import 'package:marionette_flutter/src/binding/register_extension.dart';
 
@@ -13,11 +14,16 @@ import 'package:marionette_flutter/src/binding/register_extension.dart';
 ///
 /// The `ext.flutter.` prefix is added automatically to [name].
 ///
+/// When [inputSchema] is provided, any property that declares a default is
+/// filled in before [callback] runs if the caller omitted it — see
+/// [mergeSchemaDefaults]. Built-in extensions pass no schema.
+///
 /// Uses [developer.registerExtension] directly, bypassing Flutter's
 /// [BindingBase.registerServiceExtension].
 void registerInternalMarionetteExtension({
   required String name,
   required MarionetteExtensionCallback callback,
+  ExtensionInputSchema? inputSchema,
 }) {
   final methodName = 'ext.flutter.$name';
 
@@ -31,7 +37,7 @@ void registerInternalMarionetteExtension({
 
       late final MarionetteExtensionResult result;
       try {
-        result = await callback(parameters);
+        result = await callback(mergeSchemaDefaults(inputSchema, parameters));
       } on ArgumentError catch (e) {
         return developer.ServiceExtensionResponse.error(
           developer.ServiceExtensionResponse.invalidParams,
@@ -80,4 +86,35 @@ void registerInternalMarionetteExtension({
       }
     },
   );
+}
+
+/// Returns [parameters] with any defaults declared by [schema] filled in for
+/// keys the caller omitted. Values supplied by the caller always win.
+///
+/// VM service params arrive as a `Map<String, String>`, and the MCP server
+/// stringifies provided values (e.g. `true` → `"true"`, `42` → `"42"`). To
+/// keep callbacks from having to special-case where a value came from,
+/// defaults are stringified the same way: a string default passes through,
+/// everything else uses `toString()`. The `default` JSON Schema keyword is
+/// only advisory to clients, so applying it here makes it authoritative
+/// regardless of whether the client pre-fills it.
+@visibleForTesting
+Map<String, String> mergeSchemaDefaults(
+  ExtensionInputSchema? schema,
+  Map<String, String> parameters,
+) {
+  if (schema == null) return parameters;
+
+  final withDefaults = <String, String>{};
+  for (final entry in schema.properties.entries) {
+    final json = entry.value.toJson();
+    if (json.containsKey('default')) {
+      final value = json['default'];
+      withDefaults[entry.key] = value is String ? value : value.toString();
+    }
+  }
+
+  if (withDefaults.isEmpty) return parameters;
+  // Caller-supplied values override declared defaults.
+  return withDefaults..addAll(parameters);
 }

--- a/packages/marionette_flutter/test/extension_schema_test.dart
+++ b/packages/marionette_flutter/test/extension_schema_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+void main() {
+  group('ExtensionInputSchema.toJson', () {
+    test('emits an empty object schema by default', () {
+      const schema = ExtensionInputSchema();
+      expect(schema.toJson(), {
+        'type': 'object',
+        'properties': <String, dynamic>{},
+      });
+    });
+
+    test('omits "required" when no properties are required', () {
+      const schema = ExtensionInputSchema(
+        properties: {'name': ExtensionParam.string()},
+      );
+      expect(schema.toJson(), {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+        },
+      });
+    });
+
+    test('emits "required" when set', () {
+      const schema = ExtensionInputSchema(
+        properties: {'name': ExtensionParam.string()},
+        required: ['name'],
+      );
+      expect(schema.toJson()['required'], ['name']);
+    });
+
+    test('emits title and description when set', () {
+      const schema = ExtensionInputSchema(
+        title: 'Navigate',
+        description: 'Navigates to a named page.',
+      );
+      final json = schema.toJson();
+      expect(json['title'], 'Navigate');
+      expect(json['description'], 'Navigates to a named page.');
+    });
+  });
+
+  group('ExtensionParam.string', () {
+    test('emits "type": "string" with no other fields by default', () {
+      expect(const ExtensionParam.string().toJson(), {'type': 'string'});
+    });
+
+    test('emits all set metadata using JSON Schema field names', () {
+      const param = ExtensionParam.string(
+        title: 'Name',
+        description: 'A name.',
+        defaultValue: 'anon',
+        minLength: 1,
+        maxLength: 64,
+        pattern: r'^[a-z]+$',
+        format: 'email',
+        enumValues: ['a', 'b'],
+      );
+      expect(param.toJson(), {
+        'title': 'Name',
+        'description': 'A name.',
+        'default': 'anon',
+        'type': 'string',
+        'minLength': 1,
+        'maxLength': 64,
+        'pattern': r'^[a-z]+$',
+        'format': 'email',
+        'enum': ['a', 'b'],
+      });
+    });
+
+    test('serializes a runtime-built enum list', () {
+      // Mirrors the example app's pattern: enumValues comes from
+      // availablePages.keys.toList() rather than a const literal.
+      final values = ['home', 'profile', 'settings'];
+      final param = ExtensionParam.string(enumValues: values);
+      final json = param.toJson();
+      expect(json['enum'], ['home', 'profile', 'settings']);
+      // The list should be a copy — mutating the source must not affect
+      // already-serialized JSON.
+      values.add('extra');
+      expect(json['enum'], ['home', 'profile', 'settings']);
+    });
+  });
+
+  group('ExtensionParam.integer', () {
+    test('emits "type": "integer" with no other fields by default', () {
+      expect(const ExtensionParam.integer().toJson(), {'type': 'integer'});
+    });
+
+    test('emits numeric bounds and default using JSON Schema names', () {
+      const param = ExtensionParam.integer(
+        description: 'A slide index.',
+        defaultValue: 0,
+        minimum: 0,
+        maximum: 99,
+        exclusiveMinimum: -1,
+        exclusiveMaximum: 100,
+        multipleOf: 1,
+      );
+      expect(param.toJson(), {
+        'description': 'A slide index.',
+        'default': 0,
+        'type': 'integer',
+        'minimum': 0,
+        'maximum': 99,
+        'exclusiveMinimum': -1,
+        'exclusiveMaximum': 100,
+        'multipleOf': 1,
+      });
+    });
+  });
+
+  group('ExtensionParam.number', () {
+    test('emits "type": "number" with no other fields by default', () {
+      expect(const ExtensionParam.number().toJson(), {'type': 'number'});
+    });
+
+    test('preserves doubles through "default", bounds, and multipleOf', () {
+      const param = ExtensionParam.number(
+        defaultValue: 1.5,
+        minimum: 0.1,
+        maximum: 10.5,
+        multipleOf: 0.5,
+      );
+      expect(param.toJson(), {
+        'default': 1.5,
+        'type': 'number',
+        'minimum': 0.1,
+        'maximum': 10.5,
+        'multipleOf': 0.5,
+      });
+    });
+  });
+
+  group('ExtensionParam.boolean', () {
+    test('emits "type": "boolean" with no other fields by default', () {
+      expect(const ExtensionParam.boolean().toJson(), {'type': 'boolean'});
+    });
+
+    test('emits description and default when set', () {
+      const param = ExtensionParam.boolean(
+        description: 'Animate?',
+        defaultValue: true,
+      );
+      expect(param.toJson(), {
+        'description': 'Animate?',
+        'default': true,
+        'type': 'boolean',
+      });
+    });
+  });
+
+  test('end-to-end: typed DSL produces the same wire JSON as a raw map', () {
+    // Faithful reproduction of the example app's previous raw-map shape
+    // and the typed DSL replacement. Confirms the wire format is unchanged.
+    const expected = {
+      'type': 'object',
+      'properties': {
+        'page': {
+          'description': 'Page name. One of: home, profile, settings',
+          'type': 'string',
+          'enum': ['home', 'profile', 'settings'],
+        },
+      },
+      'required': ['page'],
+    };
+
+    const schema = ExtensionInputSchema(
+      properties: {
+        'page': ExtensionParam.string(
+          description: 'Page name. One of: home, profile, settings',
+          enumValues: ['home', 'profile', 'settings'],
+        ),
+      },
+      required: ['page'],
+    );
+
+    expect(schema.toJson(), expected);
+  });
+}

--- a/packages/marionette_flutter/test/register_extension_test.dart
+++ b/packages/marionette_flutter/test/register_extension_test.dart
@@ -29,61 +29,6 @@ void main() {
       );
     });
 
-    test('throws when inputSchema top-level type is not "object"', () {
-      expect(
-        () => registerMarionetteExtension(
-          name: 'broken',
-          inputSchema: const {'type': 'string'},
-          callback: (_) async => MarionetteExtensionResult.success({}),
-        ),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('top-level "type" must be "object"'),
-          ),
-        ),
-      );
-    });
-
-    test('throws when inputSchema property type is not scalar', () {
-      expect(
-        () => registerMarionetteExtension(
-          name: 'broken',
-          inputSchema: const {
-            'type': 'object',
-            'properties': {
-              'tags': {'type': 'array'},
-            },
-          },
-          callback: (_) async => MarionetteExtensionResult.success({}),
-        ),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('must declare a scalar "type"'),
-          ),
-        ),
-      );
-    });
-
-    test('throws when inputSchema property is not a JSON object', () {
-      expect(
-        () => registerMarionetteExtension(
-          name: 'broken',
-          inputSchema: const {
-            'type': 'object',
-            'properties': {
-              'oops': 'not-a-schema',
-            },
-          },
-          callback: (_) async => MarionetteExtensionResult.success({}),
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-    });
-
     test('accepts a valid scalar-only schema', () {
       // Validation must not throw — the underlying VM service registration
       // will fail outside a real isolate, which is expected here.
@@ -91,16 +36,15 @@ void main() {
         registerMarionetteExtension(
           name: 'reg.test.valid',
           description: 'A valid extension',
-          inputSchema: const {
-            'type': 'object',
-            'properties': {
-              'slideIndex': {'type': 'integer', 'minimum': 0},
-              'animate': {'type': 'boolean'},
-              'name': {'type': 'string'},
-              'speed': {'type': 'number'},
+          inputSchema: const ExtensionInputSchema(
+            properties: {
+              'slideIndex': ExtensionParam.integer(minimum: 0),
+              'animate': ExtensionParam.boolean(),
+              'name': ExtensionParam.string(),
+              'speed': ExtensionParam.number(),
             },
-            'required': ['slideIndex'],
-          },
+            required: ['slideIndex'],
+          ),
           callback: (_) async => MarionetteExtensionResult.success({}),
         );
       } catch (e) {
@@ -118,14 +62,40 @@ void main() {
     });
 
     test('preserves inputSchema verbatim', () {
-      const schema = {
-        'type': 'object',
-        'properties': {
-          'x': {'type': 'integer'},
+      const schema = ExtensionInputSchema(
+        properties: {
+          'x': ExtensionParam.integer(),
         },
-      };
+      );
       const details = ExtensionDetails(name: 'foo', inputSchema: schema);
       expect(details.inputSchema, same(schema));
+    });
+
+    test('inputSchema serializes to the expected wire format', () {
+      const details = ExtensionDetails(
+        name: 'appNavigation.goToPage',
+        inputSchema: ExtensionInputSchema(
+          properties: {
+            'page': ExtensionParam.string(
+              description: 'Page name.',
+              enumValues: ['home', 'settings'],
+            ),
+          },
+          required: ['page'],
+        ),
+      );
+
+      expect(details.inputSchema!.toJson(), {
+        'type': 'object',
+        'properties': {
+          'page': {
+            'description': 'Page name.',
+            'type': 'string',
+            'enum': ['home', 'settings'],
+          },
+        },
+        'required': ['page'],
+      });
     });
   });
 }

--- a/packages/marionette_flutter/test/register_extension_test.dart
+++ b/packages/marionette_flutter/test/register_extension_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+void main() {
+  group('registerMarionetteExtension validation', () {
+    test('throws when name is empty', () {
+      expect(
+        () => registerMarionetteExtension(
+          name: '',
+          callback: (_) async => MarionetteExtensionResult.success({}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when name has the ext.flutter. prefix', () {
+      expect(
+        () => registerMarionetteExtension(
+          name: 'ext.flutter.bad',
+          callback: (_) async => MarionetteExtensionResult.success({}),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must not include the "ext.flutter." prefix'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when inputSchema top-level type is not "object"', () {
+      expect(
+        () => registerMarionetteExtension(
+          name: 'broken',
+          inputSchema: const {'type': 'string'},
+          callback: (_) async => MarionetteExtensionResult.success({}),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('top-level "type" must be "object"'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when inputSchema property type is not scalar', () {
+      expect(
+        () => registerMarionetteExtension(
+          name: 'broken',
+          inputSchema: const {
+            'type': 'object',
+            'properties': {
+              'tags': {'type': 'array'},
+            },
+          },
+          callback: (_) async => MarionetteExtensionResult.success({}),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must declare a scalar "type"'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when inputSchema property is not a JSON object', () {
+      expect(
+        () => registerMarionetteExtension(
+          name: 'broken',
+          inputSchema: const {
+            'type': 'object',
+            'properties': {
+              'oops': 'not-a-schema',
+            },
+          },
+          callback: (_) async => MarionetteExtensionResult.success({}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('accepts a valid scalar-only schema', () {
+      // Validation must not throw — the underlying VM service registration
+      // will fail outside a real isolate, which is expected here.
+      try {
+        registerMarionetteExtension(
+          name: 'reg.test.valid',
+          description: 'A valid extension',
+          inputSchema: const {
+            'type': 'object',
+            'properties': {
+              'slideIndex': {'type': 'integer', 'minimum': 0},
+              'animate': {'type': 'boolean'},
+              'name': {'type': 'string'},
+              'speed': {'type': 'number'},
+            },
+            'required': ['slideIndex'],
+          },
+          callback: (_) async => MarionetteExtensionResult.success({}),
+        );
+      } catch (e) {
+        // The dart:developer registration may fail outside a VM service
+        // context — that's downstream of the validation we care about.
+        expect(e, isNot(isA<ArgumentError>()));
+      }
+    });
+  });
+
+  group('ExtensionDetails', () {
+    test('inputSchema defaults to null', () {
+      const details = ExtensionDetails(name: 'foo');
+      expect(details.inputSchema, isNull);
+    });
+
+    test('preserves inputSchema verbatim', () {
+      const schema = {
+        'type': 'object',
+        'properties': {
+          'x': {'type': 'integer'},
+        },
+      };
+      const details = ExtensionDetails(name: 'foo', inputSchema: schema);
+      expect(details.inputSchema, same(schema));
+    });
+  });
+}

--- a/packages/marionette_flutter/test/register_extension_test.dart
+++ b/packages/marionette_flutter/test/register_extension_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
+import 'package:marionette_flutter/src/binding/register_extension_internal.dart';
 
 void main() {
   group('registerMarionetteExtension validation', () {
@@ -96,6 +97,64 @@ void main() {
         },
         'required': ['page'],
       });
+    });
+  });
+
+  group('mergeSchemaDefaults', () {
+    const schema = ExtensionInputSchema(
+      properties: {
+        'name': ExtensionParam.string(defaultValue: 'guest'),
+        'count': ExtensionParam.integer(defaultValue: 3),
+        'ratio': ExtensionParam.number(defaultValue: 1.5),
+        'animate': ExtensionParam.boolean(defaultValue: true),
+        'page': ExtensionParam.string(), // no default
+      },
+    );
+
+    test('fills omitted params with their stringified defaults', () {
+      expect(mergeSchemaDefaults(schema, const {}), {
+        'name': 'guest',
+        'count': '3',
+        'ratio': '1.5',
+        'animate': 'true',
+      });
+    });
+
+    test('caller-supplied values override declared defaults', () {
+      expect(
+        mergeSchemaDefaults(schema, const {'count': '10', 'animate': 'false'}),
+        {
+          'name': 'guest',
+          'count': '10',
+          'ratio': '1.5',
+          'animate': 'false',
+        },
+      );
+    });
+
+    test('does not inject keys for properties without a default', () {
+      final merged = mergeSchemaDefaults(schema, const {});
+      expect(merged.containsKey('page'), isFalse);
+    });
+
+    test('passes parameters through verbatim when schema is null', () {
+      const params = {'a': '1'};
+      expect(mergeSchemaDefaults(null, params), same(params));
+    });
+
+    test('passes parameters through when no property declares a default', () {
+      const params = {'page': 'home'};
+      const noDefaults = ExtensionInputSchema(
+        properties: {'page': ExtensionParam.string()},
+      );
+      expect(mergeSchemaDefaults(noDefaults, params), same(params));
+    });
+
+    test('preserves caller params not described by the schema', () {
+      expect(
+        mergeSchemaDefaults(schema, const {'extra': 'kept'}),
+        containsPair('extra', 'kept'),
+      );
     });
   });
 }

--- a/packages/marionette_mcp/lib/src/mcp_server_runner.dart
+++ b/packages/marionette_mcp/lib/src/mcp_server_runner.dart
@@ -37,7 +37,13 @@ Future<int> runMcpServer({
   final server = McpServer(
     const Implementation(name: 'marionette-mcp', version: version),
     options: const McpServerOptions(
-      capabilities: ServerCapabilities(tools: ServerCapabilitiesTools()),
+      // listChanged: true advertises that the tool set can change at
+      // runtime — required for clients to refetch tools/list when an app
+      // connects with custom extensions registered via
+      // registerMarionetteExtension.
+      capabilities: ServerCapabilities(
+        tools: ServerCapabilitiesTools(listChanged: true),
+      ),
       instructions: _instructions,
     ),
   );

--- a/packages/marionette_mcp/lib/src/vm_service/dynamic_extension_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/dynamic_extension_tools.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:logging/logging.dart' as logging;
+import 'package:marionette_mcp/src/vm_service/tools/arg_coercion.dart';
 import 'package:marionette_mcp/src/vm_service/tools/tool_runner.dart';
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 import 'package:mcp_dart/mcp_dart.dart';
@@ -204,7 +205,7 @@ class DynamicExtensionTools {
   ToolFunction _buildCallback(String name) {
     return (args, extra) async {
       return runTool(_logger, 'call extension "$name"', () async {
-        final stringArgs = _coerceToStringMap(args);
+        final stringArgs = coerceToStringMap(args);
         final response = await _connector.callCustomExtension(
           name,
           stringArgs,
@@ -215,35 +216,4 @@ class DynamicExtensionTools {
       });
     };
   }
-}
-
-/// Coerces the typed JSON arguments validated against the extension's
-/// `inputSchema` into the `Map<String, String>` shape that the Dart VM
-/// service expects.
-///
-/// `int 42 → "42"`, `bool true → "true"`, `null → ""`, lists/maps →
-/// `jsonEncode(value)` so callbacks that opt into nested structures can
-/// still parse them. The Flutter callback is responsible for parsing
-/// scalars back into the right Dart type.
-///
-/// Public for testing — internal callers go through the closure inside
-/// [DynamicExtensionTools].
-Map<String, dynamic> coerceToStringMap(Map<String, dynamic> args) =>
-    _coerceToStringMap(args);
-
-Map<String, dynamic> _coerceToStringMap(Map<String, dynamic> args) {
-  final result = <String, dynamic>{};
-  for (final entry in args.entries) {
-    final value = entry.value;
-    if (value == null) {
-      result[entry.key] = '';
-    } else if (value is String) {
-      result[entry.key] = value;
-    } else if (value is num || value is bool) {
-      result[entry.key] = value.toString();
-    } else {
-      result[entry.key] = jsonEncode(value);
-    }
-  }
-  return result;
 }

--- a/packages/marionette_mcp/lib/src/vm_service/dynamic_extension_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/dynamic_extension_tools.dart
@@ -8,9 +8,14 @@ import 'package:mcp_dart/mcp_dart.dart';
 /// Registers MCP tools at runtime for each custom extension exposed by the
 /// connected Flutter app via `registerMarionetteExtension`.
 ///
-/// One call corresponds to one connection lifecycle: callers invoke
-/// [registerAll] after `connect` succeeds, then [disableAll] on `disconnect`
-/// to retire the registered tools.
+/// A single instance lives for the lifetime of the MCP server and is reused
+/// across connect/disconnect cycles. Callers invoke [registerAll] after
+/// `connect` succeeds, then [disableAll] on `disconnect` to retire the
+/// registered tools. On a subsequent [registerAll] previously-disabled tools
+/// are revived in place via [RegisteredTool.update] rather than re-registered
+/// — re-registering by name throws in mcp_dart 2.1.0 because [disable]
+/// leaves the entry in the server's tool map (and [RegisteredTool.remove]
+/// is broken — see [disableAll]).
 ///
 /// Only extensions that ship an `inputSchema` get promoted — schema-less
 /// extensions remain reachable through the generic `call_custom_extension`
@@ -27,11 +32,20 @@ class DynamicExtensionTools {
   final McpServer _server;
   final VmServiceConnector _connector;
   final logging.Logger _logger;
-  final List<RegisteredTool> _registered = [];
 
-  /// The tools registered by the most recent [registerAll] call that have
-  /// not yet been disabled. Exposed for tests.
-  List<RegisteredTool> get registeredTools => List.unmodifiable(_registered);
+  /// Every tool we have ever registered with the server, keyed by name.
+  /// Persists across connect/disconnect cycles so we can revive entries via
+  /// [RegisteredTool.update] instead of hitting the duplicate-name guard in
+  /// [McpServer.registerTool].
+  final Map<String, RegisteredTool> _pool = {};
+
+  /// Names that are currently enabled (i.e. promoted in this connect cycle).
+  final Set<String> _active = {};
+
+  /// The tools enabled by the most recent [registerAll] call that have not
+  /// yet been disabled. Exposed for tests.
+  List<RegisteredTool> get registeredTools =>
+      List.unmodifiable(_active.map((name) => _pool[name]!));
 
   /// Reads the connected app's custom extensions and promotes each one
   /// with an `inputSchema` to a first-class MCP tool.
@@ -87,13 +101,13 @@ class DynamicExtensionTools {
         continue;
       }
 
-      final tool = _registerOne(
+      final tool = _promote(
         name: name,
         description: description,
         schemaJson: schemaJson,
       );
       if (tool != null) {
-        _registered.add(tool);
+        _active.add(name);
         registered++;
       }
     }
@@ -105,25 +119,27 @@ class DynamicExtensionTools {
     );
   }
 
-  /// Disables every tool registered by [registerAll] and forgets them.
+  /// Disables every tool currently enabled by [registerAll] but keeps the
+  /// references in the pool so the next [registerAll] can revive them via
+  /// [RegisteredTool.update].
   ///
-  /// Uses [RegisteredTool.disable] rather than [RegisteredTool.remove] —
-  /// the latter is broken in mcp_dart 2.1.0 (`update(name: null)` never
-  /// deletes the entry from the registry). Disabled tools are filtered
-  /// out of `tools/list` and rejected on call, which is the behavior we
-  /// want.
+  /// We can't drop them from the server because [RegisteredTool.remove] is
+  /// broken in mcp_dart 2.1.0 (`update(name: null)` never deletes the entry
+  /// from the registry). Disabled tools are filtered out of `tools/list`
+  /// and rejected on call, which is the behavior we want; the registry
+  /// entry just stays squatting on its name and we re-enable it next time.
   void disableAll() {
-    if (_registered.isEmpty) return;
-    for (final tool in _registered) {
-      tool.disable();
+    if (_active.isEmpty) return;
+    for (final name in _active) {
+      _pool[name]!.disable();
     }
     _logger.info(
-      'Disabled ${_registered.length} dynamic extension tool(s) on disconnect.',
+      'Disabled ${_active.length} dynamic extension tool(s) on disconnect.',
     );
-    _registered.clear();
+    _active.clear();
   }
 
-  RegisteredTool? _registerOne({
+  RegisteredTool? _promote({
     required String name,
     required String? description,
     required Map<String, dynamic> schemaJson,
@@ -147,34 +163,57 @@ class DynamicExtensionTools {
       return null;
     }
 
+    final callback = _buildCallback(name);
+
+    final pooled = _pool[name];
+    if (pooled != null) {
+      // Previously seen — revive in place. Re-registering by name would
+      // throw because mcp_dart's `disable()` leaves the entry in the
+      // server's tool map.
+      pooled.update(
+        description: description,
+        inputSchema: schema,
+        callback: FunctionToolCallback(callback),
+        enabled: true,
+      );
+      return pooled;
+    }
+
     try {
-      return _server.registerTool(
+      final tool = _server.registerTool(
         name,
         description: description,
         inputSchema: schema,
-        callback: (args, extra) async {
-          return runTool(_logger, 'call extension "$name"', () async {
-            final stringArgs = _coerceToStringMap(args);
-            final response = await _connector.callCustomExtension(
-              name,
-              stringArgs,
-            );
-            return CallToolResult(
-              content: [TextContent(text: jsonEncode(response))],
-            );
-          });
-        },
+        callback: callback,
       );
+      _pool[name] = tool;
+      return tool;
     } on ArgumentError catch (err) {
       // mcp_dart throws ArgumentError on duplicate name — most likely a
       // collision with a built-in marionette tool (tap, scroll_to, etc.)
-      // or another already-registered custom extension.
+      // or another already-registered custom extension. We don't pool
+      // colliding names so subsequent reconnects re-emit the warning.
       _logger.warning(
         'Skipping extension "$name": MCP tool name collision. '
         'Rename the extension on the Flutter side. Details: ${err.message}',
       );
       return null;
     }
+  }
+
+  ToolFunction _buildCallback(String name) {
+    return (args, extra) async {
+      return runTool(_logger, 'call extension "$name"', () async {
+        final stringArgs = _coerceToStringMap(args);
+        final response = await _connector.callCustomExtension(
+          name,
+          stringArgs,
+        );
+        return CallToolResult(
+          content: [TextContent(text: jsonEncode(response))],
+        );
+      });
+    };
   }
 }
 

--- a/packages/marionette_mcp/lib/src/vm_service/dynamic_extension_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/dynamic_extension_tools.dart
@@ -1,0 +1,210 @@
+import 'dart:convert';
+
+import 'package:logging/logging.dart' as logging;
+import 'package:marionette_mcp/src/vm_service/tools/tool_runner.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+
+/// Registers MCP tools at runtime for each custom extension exposed by the
+/// connected Flutter app via `registerMarionetteExtension`.
+///
+/// One call corresponds to one connection lifecycle: callers invoke
+/// [registerAll] after `connect` succeeds, then [disableAll] on `disconnect`
+/// to retire the registered tools.
+///
+/// Only extensions that ship an `inputSchema` get promoted — schema-less
+/// extensions remain reachable through the generic `call_custom_extension`
+/// tool, preserving backward compatibility with apps that haven't migrated.
+class DynamicExtensionTools {
+  DynamicExtensionTools({
+    required McpServer server,
+    required VmServiceConnector connector,
+    required logging.Logger logger,
+  })  : _server = server,
+        _connector = connector,
+        _logger = logger;
+
+  final McpServer _server;
+  final VmServiceConnector _connector;
+  final logging.Logger _logger;
+  final List<RegisteredTool> _registered = [];
+
+  /// The tools registered by the most recent [registerAll] call that have
+  /// not yet been disabled. Exposed for tests.
+  List<RegisteredTool> get registeredTools => List.unmodifiable(_registered);
+
+  /// Reads the connected app's custom extensions and promotes each one
+  /// with an `inputSchema` to a first-class MCP tool.
+  ///
+  /// Tools whose name collides with a built-in (or another custom) tool
+  /// are skipped with a warning — the operator sees the conflict in logs
+  /// and renames their extension. Tools whose schema fails to parse are
+  /// likewise skipped with a warning.
+  Future<void> registerAll() async {
+    final Map<String, dynamic> response;
+    try {
+      response = await _connector.listExtensions();
+    } catch (err) {
+      _logger.warning(
+        'Failed to fetch custom extensions for dynamic registration; '
+        'skipping. Generic call_custom_extension still works.',
+        err,
+      );
+      return;
+    }
+
+    final extensionsRaw = response['extensions'];
+    if (extensionsRaw is! List) {
+      _logger.warning(
+        'marionette.listExtensions response missing "extensions" list; '
+        'got: $extensionsRaw',
+      );
+      return;
+    }
+
+    var registered = 0;
+    var skippedNoSchema = 0;
+    for (final ext in extensionsRaw) {
+      if (ext is! Map) {
+        _logger.warning('Skipping malformed extension entry: $ext');
+        continue;
+      }
+      final name = ext['name'];
+      if (name is! String || name.isEmpty) {
+        _logger.warning('Skipping extension with missing/invalid name: $ext');
+        continue;
+      }
+      final description = ext['description'] as String?;
+      final schemaJson = ext['inputSchema'];
+      if (schemaJson == null) {
+        skippedNoSchema++;
+        continue;
+      }
+      if (schemaJson is! Map<String, dynamic>) {
+        _logger.warning(
+          'Skipping extension "$name": inputSchema is not a JSON object',
+        );
+        continue;
+      }
+
+      final tool = _registerOne(
+        name: name,
+        description: description,
+        schemaJson: schemaJson,
+      );
+      if (tool != null) {
+        _registered.add(tool);
+        registered++;
+      }
+    }
+
+    _logger.info(
+      'Promoted $registered custom extension(s) to MCP tools '
+      '(${skippedNoSchema} schema-less extension(s) remain reachable via '
+      'call_custom_extension).',
+    );
+  }
+
+  /// Disables every tool registered by [registerAll] and forgets them.
+  ///
+  /// Uses [RegisteredTool.disable] rather than [RegisteredTool.remove] —
+  /// the latter is broken in mcp_dart 2.1.0 (`update(name: null)` never
+  /// deletes the entry from the registry). Disabled tools are filtered
+  /// out of `tools/list` and rejected on call, which is the behavior we
+  /// want.
+  void disableAll() {
+    if (_registered.isEmpty) return;
+    for (final tool in _registered) {
+      tool.disable();
+    }
+    _logger.info(
+      'Disabled ${_registered.length} dynamic extension tool(s) on disconnect.',
+    );
+    _registered.clear();
+  }
+
+  RegisteredTool? _registerOne({
+    required String name,
+    required String? description,
+    required Map<String, dynamic> schemaJson,
+  }) {
+    final ToolInputSchema schema;
+    try {
+      final parsed = JsonSchema.fromJson(schemaJson);
+      if (parsed is! ToolInputSchema) {
+        _logger.warning(
+          'Skipping extension "$name": inputSchema parsed to '
+          '${parsed.runtimeType} but MCP requires a JSON object schema.',
+        );
+        return null;
+      }
+      schema = parsed;
+    } catch (err) {
+      _logger.warning(
+        'Skipping extension "$name": failed to parse inputSchema',
+        err,
+      );
+      return null;
+    }
+
+    try {
+      return _server.registerTool(
+        name,
+        description: description,
+        inputSchema: schema,
+        callback: (args, extra) async {
+          return runTool(_logger, 'call extension "$name"', () async {
+            final stringArgs = _coerceToStringMap(args);
+            final response = await _connector.callCustomExtension(
+              name,
+              stringArgs,
+            );
+            return CallToolResult(
+              content: [TextContent(text: jsonEncode(response))],
+            );
+          });
+        },
+      );
+    } on ArgumentError catch (err) {
+      // mcp_dart throws ArgumentError on duplicate name — most likely a
+      // collision with a built-in marionette tool (tap, scroll_to, etc.)
+      // or another already-registered custom extension.
+      _logger.warning(
+        'Skipping extension "$name": MCP tool name collision. '
+        'Rename the extension on the Flutter side. Details: ${err.message}',
+      );
+      return null;
+    }
+  }
+}
+
+/// Coerces the typed JSON arguments validated against the extension's
+/// `inputSchema` into the `Map<String, String>` shape that the Dart VM
+/// service expects.
+///
+/// `int 42 → "42"`, `bool true → "true"`, `null → ""`, lists/maps →
+/// `jsonEncode(value)` so callbacks that opt into nested structures can
+/// still parse them. The Flutter callback is responsible for parsing
+/// scalars back into the right Dart type.
+///
+/// Public for testing — internal callers go through the closure inside
+/// [DynamicExtensionTools].
+Map<String, dynamic> coerceToStringMap(Map<String, dynamic> args) =>
+    _coerceToStringMap(args);
+
+Map<String, dynamic> _coerceToStringMap(Map<String, dynamic> args) {
+  final result = <String, dynamic>{};
+  for (final entry in args.entries) {
+    final value = entry.value;
+    if (value == null) {
+      result[entry.key] = '';
+    } else if (value is String) {
+      result[entry.key] = value;
+    } else if (value is num || value is bool) {
+      result[entry.key] = value.toString();
+    } else {
+      result[entry.key] = jsonEncode(value);
+    }
+  }
+  return result;
+}

--- a/packages/marionette_mcp/lib/src/vm_service/tools/arg_coercion.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/arg_coercion.dart
@@ -19,8 +19,8 @@ import 'dart:convert';
 /// Both the dynamically-promoted extension tools and the generic
 /// `call_custom_extension` escape hatch route through this so they produce
 /// identical wire args for the same input.
-Map<String, dynamic> coerceToStringMap(Map<String, dynamic> args) {
-  final result = <String, dynamic>{};
+Map<String, String> coerceToStringMap(Map<String, dynamic> args) {
+  final result = <String, String>{};
   for (final entry in args.entries) {
     final value = entry.value;
     if (value == null) {

--- a/packages/marionette_mcp/lib/src/vm_service/tools/arg_coercion.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/arg_coercion.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+/// Coerces JSON arguments into the `Map<String, String>` shape that the Dart
+/// VM service expects for custom extension calls.
+///
+/// Custom extension params travel over the VM service as a flat
+/// `Map<String, String>` — the `dart:developer` handler signature is
+/// `(String method, Map<String, String> parameters)`, and the VM
+/// force-stringifies every value before delivering it. We do the
+/// stringification here so the wire payload is well-formed regardless of how
+/// the value arrives:
+///
+/// `int 42 → "42"`, `bool true → "true"`, `null → ""`, lists/maps →
+/// `jsonEncode(value)` so callbacks that opt into nested structures receive
+/// valid JSON (not Dart's `toString()` form, e.g. `{x: 1}`, which is
+/// un-parseable). The Flutter callback is responsible for parsing scalars
+/// back into the right Dart type.
+///
+/// Both the dynamically-promoted extension tools and the generic
+/// `call_custom_extension` escape hatch route through this so they produce
+/// identical wire args for the same input.
+Map<String, dynamic> coerceToStringMap(Map<String, dynamic> args) {
+  final result = <String, dynamic>{};
+  for (final entry in args.entries) {
+    final value = entry.value;
+    if (value == null) {
+      result[entry.key] = '';
+    } else if (value is String) {
+      result[entry.key] = value;
+    } else if (value is num || value is bool) {
+      result[entry.key] = value.toString();
+    } else {
+      result[entry.key] = jsonEncode(value);
+    }
+  }
+  return result;
+}

--- a/packages/marionette_mcp/lib/src/vm_service/tools/extension_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/extension_tools.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:logging/logging.dart' as logging;
+import 'package:marionette_mcp/src/vm_service/tools/arg_coercion.dart';
 import 'package:marionette_mcp/src/vm_service/tools/tool_runner.dart';
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 import 'package:mcp_dart/mcp_dart.dart';
@@ -89,28 +90,44 @@ void registerExtensionTools(
           ),
           'args': JsonSchema.object(
             description: 'Optional key-value pairs to pass as arguments. '
-                'Values are passed as-is to the VM service extension.',
+                'Scalars are stringified and nested object/array values are '
+                'JSON-encoded before being sent to the VM service extension.',
             properties: {},
           ),
         },
         required: ['extension'],
       ),
-      callback: (args, extra) async {
-        final extensionName = args['extension'] as String;
-        final extensionArgs =
-            (args['args'] as Map<String, dynamic>?) ?? <String, dynamic>{};
-        logger.info(
-          'Calling custom extension: $extensionName with args: $extensionArgs',
-        );
-        return runTool(logger, 'call custom extension', () async {
-          final response = await connector.callCustomExtension(
-            extensionName,
-            extensionArgs,
-          );
-          return CallToolResult(
-            content: [TextContent(text: jsonEncode(response))],
-          );
-        });
-      },
+      callback: (args, extra) => callCustomExtension(connector, logger, args),
     );
+}
+
+/// Handles a `call_custom_extension` invocation: coerces the supplied `args`
+/// into the wire shape, forwards them to [connector], and wraps the response.
+///
+/// Extracted from the tool callback so the coercion contract can be exercised
+/// in isolation. Args go through [coerceToStringMap] — the same path the
+/// dynamically-promoted extension tools use — so both produce identical wire
+/// args: scalars are stringified and nested object/array values become valid
+/// JSON (not Dart's un-parseable `toString()` form).
+Future<CallToolResult> callCustomExtension(
+  VmServiceConnector connector,
+  logging.Logger logger,
+  Map<String, dynamic> args,
+) {
+  final extensionName = args['extension'] as String;
+  final extensionArgs = coerceToStringMap(
+    (args['args'] as Map<String, dynamic>?) ?? const <String, dynamic>{},
+  );
+  logger.info(
+    'Calling custom extension: $extensionName with args: $extensionArgs',
+  );
+  return runTool(logger, 'call custom extension', () async {
+    final response = await connector.callCustomExtension(
+      extensionName,
+      extensionArgs,
+    );
+    return CallToolResult(
+      content: [TextContent(text: jsonEncode(response))],
+    );
+  });
 }

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
@@ -18,9 +18,10 @@ final class VmServiceContext {
   final VmServiceConnector connector;
   final logging.Logger _logger;
 
-  /// Tracks the dynamic tools registered for the currently connected app —
-  /// reset on each connect, disabled on each disconnect.
-  DynamicExtensionTools? _dynamicTools;
+  /// Owns the registry of dynamic extension tools across the lifetime of
+  /// this context. Reused across connect/disconnect cycles so a previously
+  /// disabled tool can be revived in place — see [DynamicExtensionTools].
+  late final DynamicExtensionTools _dynamicTools;
 
   /// Registers all VM service related tools with the MCP server.
   ///
@@ -29,6 +30,11 @@ final class VmServiceContext {
   /// and don't fit the standard tool error-handling shape. Everything else
   /// is delegated to themed registration functions.
   void registerTools(McpServer server) {
+    _dynamicTools = DynamicExtensionTools(
+      server: server,
+      connector: connector,
+      logger: _logger,
+    );
     _registerConnectionTools(server);
     registerInspectionTools(server, connector, _logger);
     registerGestureTools(server, connector, _logger);
@@ -96,7 +102,7 @@ final class VmServiceContext {
             // Promote each schema-bearing custom extension into a first-class
             // MCP tool. Failures here are logged but don't fail the connect —
             // the generic call_custom_extension fallback keeps working.
-            await _registerDynamicTools(server);
+            await _registerDynamicTools();
 
             return CallToolResult(
               content: [
@@ -142,23 +148,12 @@ final class VmServiceContext {
       );
   }
 
-  Future<void> _registerDynamicTools(McpServer server) async {
+  Future<void> _registerDynamicTools() async {
     // A reconnect without a clean disconnect would leak the previous
     // batch — disable any leftovers before registering fresh ones.
-    _disableDynamicTools();
-    final dynamicTools = DynamicExtensionTools(
-      server: server,
-      connector: connector,
-      logger: _logger,
-    );
-    _dynamicTools = dynamicTools;
-    await dynamicTools.registerAll();
+    _dynamicTools.disableAll();
+    await _dynamicTools.registerAll();
   }
 
-  void _disableDynamicTools() {
-    final existing = _dynamicTools;
-    if (existing == null) return;
-    existing.disableAll();
-    _dynamicTools = null;
-  }
+  void _disableDynamicTools() => _dynamicTools.disableAll();
 }

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart' as logging;
 import 'package:marionette_mcp/src/version.g.dart' as v;
+import 'package:marionette_mcp/src/vm_service/dynamic_extension_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/extension_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/gesture_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/inspection_tools.dart';
@@ -16,6 +17,10 @@ final class VmServiceContext {
 
   final VmServiceConnector connector;
   final logging.Logger _logger;
+
+  /// Tracks the dynamic tools registered for the currently connected app —
+  /// reset on each connect, disabled on each disconnect.
+  DynamicExtensionTools? _dynamicTools;
 
   /// Registers all VM service related tools with the MCP server.
   ///
@@ -88,6 +93,11 @@ final class VmServiceContext {
               );
             }
 
+            // Promote each schema-bearing custom extension into a first-class
+            // MCP tool. Failures here are logged but don't fail the connect —
+            // the generic call_custom_extension fallback keeps working.
+            await _registerDynamicTools(server);
+
             return CallToolResult(
               content: [
                 TextContent(text: 'Successfully connected to app at $uri'),
@@ -112,6 +122,9 @@ final class VmServiceContext {
           _logger.info('Disconnecting from app');
 
           try {
+            // Retire dynamic tools before tearing down the connection so a
+            // mid-disconnect tools/list reflects only what's still callable.
+            _disableDynamicTools();
             await connector.disconnect();
             return CallToolResult(
               content: [
@@ -127,5 +140,25 @@ final class VmServiceContext {
           }
         },
       );
+  }
+
+  Future<void> _registerDynamicTools(McpServer server) async {
+    // A reconnect without a clean disconnect would leak the previous
+    // batch — disable any leftovers before registering fresh ones.
+    _disableDynamicTools();
+    final dynamicTools = DynamicExtensionTools(
+      server: server,
+      connector: connector,
+      logger: _logger,
+    );
+    _dynamicTools = dynamicTools;
+    await dynamicTools.registerAll();
+  }
+
+  void _disableDynamicTools() {
+    final existing = _dynamicTools;
+    if (existing == null) return;
+    existing.disableAll();
+    _dynamicTools = null;
   }
 }

--- a/packages/marionette_mcp/test/vm_service/dynamic_extension_tools_test.dart
+++ b/packages/marionette_mcp/test/vm_service/dynamic_extension_tools_test.dart
@@ -1,0 +1,255 @@
+import 'package:logging/logging.dart' as logging;
+import 'package:marionette_mcp/src/vm_service/dynamic_extension_tools.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+class _FakeConnector implements VmServiceConnector {
+  _FakeConnector({
+    required this.listExtensionsResponse,
+    this.listExtensionsError,
+  });
+
+  final Map<String, dynamic> listExtensionsResponse;
+  final Object? listExtensionsError;
+
+  /// Records every callCustomExtension(name, args) invocation.
+  final List<({String name, Map<String, dynamic> args})> calls = [];
+  Map<String, dynamic> nextCustomResponse = const {};
+
+  @override
+  Future<Map<String, dynamic>> listExtensions() async {
+    if (listExtensionsError != null) {
+      throw listExtensionsError!;
+    }
+    return listExtensionsResponse;
+  }
+
+  @override
+  Future<Map<String, dynamic>> callCustomExtension(
+    String extensionName, [
+    Map<String, dynamic> args = const {},
+  ]) async {
+    calls.add((name: extensionName, args: args));
+    return nextCustomResponse;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+McpServer _server() => McpServer(
+      const Implementation(name: 'test-server', version: '0.0.0'),
+      options: const McpServerOptions(
+        capabilities: ServerCapabilities(
+          tools: ServerCapabilitiesTools(listChanged: true),
+        ),
+      ),
+    );
+
+void main() {
+  group('DynamicExtensionTools.registerAll', () {
+    test('registers one tool per schema-bearing extension', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'deckNavigation.goToSlide',
+              'description': 'Navigate to a specific slide',
+              'inputSchema': {
+                'type': 'object',
+                'properties': {
+                  'slideIndex': {'type': 'integer'},
+                },
+                'required': ['slideIndex'],
+              },
+            },
+            {
+              'name': 'analytics.flush',
+              'inputSchema': {'type': 'object', 'properties': <String, dynamic>{}},
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+      await dynamicTools.registerAll();
+
+      final names = dynamicTools.registeredTools.map((t) => t.name).toSet();
+      expect(names, {'deckNavigation.goToSlide', 'analytics.flush'});
+    });
+
+    test('skips schema-less extensions', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {'name': 'legacy.ext', 'description': 'No schema'},
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+      await dynamicTools.registerAll();
+
+      expect(dynamicTools.registeredTools, isEmpty);
+    });
+
+    test('skips entries with malformed schema and keeps the rest', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            // Wrong inputSchema shape (string, not object).
+            {'name': 'broken', 'inputSchema': 'not-a-map'},
+            // Valid one — must still register.
+            {
+              'name': 'good',
+              'inputSchema': {'type': 'object', 'properties': <String, dynamic>{}},
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+      await dynamicTools.registerAll();
+
+      final names = dynamicTools.registeredTools.map((t) => t.name).toList();
+      expect(names, ['good']);
+    });
+
+    test('skips when name collides with an already-registered tool',
+        () async {
+      final server = _server()
+        ..registerTool(
+          'tap', // Pretend this is a built-in name.
+          description: 'built-in',
+          inputSchema: const ToolInputSchema(properties: {}),
+          callback: (_, __) async =>
+              CallToolResult(content: const [TextContent(text: 'ok')]),
+        );
+
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'tap',
+              'inputSchema': {'type': 'object', 'properties': <String, dynamic>{}},
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: server,
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+      await dynamicTools.registerAll();
+
+      // Collision — the dynamic registration should not add a second 'tap'.
+      expect(dynamicTools.registeredTools, isEmpty);
+    });
+
+    test('fails gracefully when listExtensions throws', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {},
+        listExtensionsError: const NotConnectedException(),
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+
+      // Must not propagate — connect should still succeed even if dynamic
+      // registration fails.
+      await dynamicTools.registerAll();
+      expect(dynamicTools.registeredTools, isEmpty);
+    });
+  });
+
+  group('DynamicExtensionTools.disableAll', () {
+    test('disables every registered tool and clears the list', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'a',
+              'inputSchema': {'type': 'object', 'properties': <String, dynamic>{}},
+            },
+            {
+              'name': 'b',
+              'inputSchema': {'type': 'object', 'properties': <String, dynamic>{}},
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+      await dynamicTools.registerAll();
+      final captured = dynamicTools.registeredTools.toList();
+      expect(captured.every((t) => t.enabled), isTrue);
+
+      dynamicTools.disableAll();
+
+      expect(dynamicTools.registeredTools, isEmpty);
+      expect(captured.every((t) => !t.enabled), isTrue);
+    });
+
+    test('is a no-op when nothing is registered', () {
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: _FakeConnector(listExtensionsResponse: const {}),
+        logger: logging.Logger.detached('test'),
+      );
+
+      // Must not throw.
+      dynamicTools.disableAll();
+      expect(dynamicTools.registeredTools, isEmpty);
+    });
+  });
+
+  group('coerceToStringMap', () {
+    test('passes string values through unchanged', () {
+      expect(coerceToStringMap({'k': 'v'}), {'k': 'v'});
+    });
+
+    test('stringifies numbers and booleans', () {
+      expect(
+        coerceToStringMap({'i': 42, 'd': 1.5, 'b': true}),
+        {'i': '42', 'd': '1.5', 'b': 'true'},
+      );
+    });
+
+    test('jsonEncodes nested structures', () {
+      expect(
+        coerceToStringMap({
+          'list': [1, 2],
+          'map': {'x': 1},
+        }),
+        {'list': '[1,2]', 'map': '{"x":1}'},
+      );
+    });
+
+    test('replaces null with the empty string', () {
+      expect(coerceToStringMap({'k': null}), {'k': ''});
+    });
+  });
+}

--- a/packages/marionette_mcp/test/vm_service/dynamic_extension_tools_test.dart
+++ b/packages/marionette_mcp/test/vm_service/dynamic_extension_tools_test.dart
@@ -433,31 +433,4 @@ void main() {
       expect(dynamicTools.registeredTools, isEmpty);
     });
   });
-
-  group('coerceToStringMap', () {
-    test('passes string values through unchanged', () {
-      expect(coerceToStringMap({'k': 'v'}), {'k': 'v'});
-    });
-
-    test('stringifies numbers and booleans', () {
-      expect(
-        coerceToStringMap({'i': 42, 'd': 1.5, 'b': true}),
-        {'i': '42', 'd': '1.5', 'b': 'true'},
-      );
-    });
-
-    test('jsonEncodes nested structures', () {
-      expect(
-        coerceToStringMap({
-          'list': [1, 2],
-          'map': {'x': 1},
-        }),
-        {'list': '[1,2]', 'map': '{"x":1}'},
-      );
-    });
-
-    test('replaces null with the empty string', () {
-      expect(coerceToStringMap({'k': null}), {'k': ''});
-    });
-  });
 }

--- a/packages/marionette_mcp/test/vm_service/dynamic_extension_tools_test.dart
+++ b/packages/marionette_mcp/test/vm_service/dynamic_extension_tools_test.dart
@@ -6,12 +6,17 @@ import 'package:test/test.dart';
 
 class _FakeConnector implements VmServiceConnector {
   _FakeConnector({
-    required this.listExtensionsResponse,
+    Map<String, dynamic> listExtensionsResponse = const {},
     this.listExtensionsError,
-  });
+  }) : _listExtensionsResponse = listExtensionsResponse;
 
-  final Map<String, dynamic> listExtensionsResponse;
+  Map<String, dynamic> _listExtensionsResponse;
   final Object? listExtensionsError;
+
+  /// Replace the response that the next [listExtensions] call returns.
+  /// Lets tests model what the app exposes across consecutive connect cycles.
+  set listExtensionsResponse(Map<String, dynamic> value) =>
+      _listExtensionsResponse = value;
 
   /// Records every callCustomExtension(name, args) invocation.
   final List<({String name, Map<String, dynamic> args})> calls = [];
@@ -22,7 +27,7 @@ class _FakeConnector implements VmServiceConnector {
     if (listExtensionsError != null) {
       throw listExtensionsError!;
     }
-    return listExtensionsResponse;
+    return _listExtensionsResponse;
   }
 
   @override
@@ -222,6 +227,209 @@ void main() {
 
       // Must not throw.
       dynamicTools.disableAll();
+      expect(dynamicTools.registeredTools, isEmpty);
+    });
+  });
+
+  group('DynamicExtensionTools reconnect', () {
+    test(
+        're-registers same extension after disable without name collision '
+        'and revives the same RegisteredTool instance', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'foo',
+              'description': 'first',
+              'inputSchema': {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+
+      // Cycle 1.
+      await dynamicTools.registerAll();
+      expect(dynamicTools.registeredTools, hasLength(1));
+      final firstInstance = dynamicTools.registeredTools.single;
+      expect(firstInstance.enabled, isTrue);
+
+      // Disconnect — emulates the disable-on-disconnect path.
+      dynamicTools.disableAll();
+      expect(dynamicTools.registeredTools, isEmpty);
+      expect(firstInstance.enabled, isFalse);
+
+      // Cycle 2 with the same payload — must not throw, must revive in
+      // place.
+      await dynamicTools.registerAll();
+
+      expect(dynamicTools.registeredTools, hasLength(1));
+      final secondInstance = dynamicTools.registeredTools.single;
+      expect(
+        identical(firstInstance, secondInstance),
+        isTrue,
+        reason: 'reconnect should reuse the pooled RegisteredTool',
+      );
+      expect(secondInstance.enabled, isTrue);
+    });
+
+    test('reflects changed description and inputSchema on revival', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'foo',
+              'description': 'v1',
+              'inputSchema': {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+
+      await dynamicTools.registerAll();
+      final tool = dynamicTools.registeredTools.single;
+      expect(tool.description, 'v1');
+      expect(tool.inputSchema?.properties, isEmpty);
+
+      dynamicTools.disableAll();
+
+      connector.listExtensionsResponse = const {
+        'extensions': [
+          {
+            'name': 'foo',
+            'description': 'v2',
+            'inputSchema': {
+              'type': 'object',
+              'properties': {
+                'count': {'type': 'integer'},
+              },
+              'required': ['count'],
+            },
+          },
+        ],
+      };
+      await dynamicTools.registerAll();
+
+      expect(tool.description, 'v2');
+      expect(tool.inputSchema?.properties?.keys, ['count']);
+    });
+
+    test(
+        'extensions that disappear on reconnect stay disabled and leave the '
+        'present ones enabled', () async {
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'foo',
+              'inputSchema': {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            },
+            {
+              'name': 'bar',
+              'inputSchema': {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: _server(),
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+
+      await dynamicTools.registerAll();
+      final byName = {
+        for (final t in dynamicTools.registeredTools) t.name: t,
+      };
+      expect(byName.keys, containsAll(['foo', 'bar']));
+
+      dynamicTools.disableAll();
+
+      // App now exposes only `foo`.
+      connector.listExtensionsResponse = const {
+        'extensions': [
+          {
+            'name': 'foo',
+            'inputSchema': {
+              'type': 'object',
+              'properties': <String, dynamic>{},
+            },
+          },
+        ],
+      };
+      await dynamicTools.registerAll();
+
+      final activeNames =
+          dynamicTools.registeredTools.map((t) => t.name).toSet();
+      expect(activeNames, {'foo'});
+      expect(byName['foo']!.enabled, isTrue);
+      expect(byName['bar']!.enabled, isFalse);
+    });
+
+    test('built-in name collisions are skipped on every cycle', () async {
+      final server = _server()
+        ..registerTool(
+          'tap', // Pretend this is a built-in name.
+          description: 'built-in',
+          inputSchema: const ToolInputSchema(properties: {}),
+          callback: (_, __) async =>
+              CallToolResult(content: const [TextContent(text: 'ok')]),
+        );
+
+      final connector = _FakeConnector(
+        listExtensionsResponse: const {
+          'extensions': [
+            {
+              'name': 'tap',
+              'inputSchema': {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            },
+          ],
+        },
+      );
+
+      final dynamicTools = DynamicExtensionTools(
+        server: server,
+        connector: connector,
+        logger: logging.Logger.detached('test'),
+      );
+
+      await dynamicTools.registerAll();
+      expect(dynamicTools.registeredTools, isEmpty);
+
+      dynamicTools.disableAll();
+
+      // Second cycle with the same colliding extension — still skipped,
+      // and we still don't fall over because the collision name is not
+      // pooled (so we re-attempt registerTool, which throws and is
+      // caught again).
+      await dynamicTools.registerAll();
       expect(dynamicTools.registeredTools, isEmpty);
     });
   });

--- a/packages/marionette_mcp/test/vm_service/tools/arg_coercion_test.dart
+++ b/packages/marionette_mcp/test/vm_service/tools/arg_coercion_test.dart
@@ -1,0 +1,31 @@
+import 'package:marionette_mcp/src/vm_service/tools/arg_coercion.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('coerceToStringMap', () {
+    test('passes string values through unchanged', () {
+      expect(coerceToStringMap({'k': 'v'}), {'k': 'v'});
+    });
+
+    test('stringifies numbers and booleans', () {
+      expect(
+        coerceToStringMap({'i': 42, 'd': 1.5, 'b': true}),
+        {'i': '42', 'd': '1.5', 'b': 'true'},
+      );
+    });
+
+    test('jsonEncodes nested structures', () {
+      expect(
+        coerceToStringMap({
+          'list': [1, 2],
+          'map': {'x': 1},
+        }),
+        {'list': '[1,2]', 'map': '{"x":1}'},
+      );
+    });
+
+    test('replaces null with the empty string', () {
+      expect(coerceToStringMap({'k': null}), {'k': ''});
+    });
+  });
+}

--- a/packages/marionette_mcp/test/vm_service/tools/extension_tools_test.dart
+++ b/packages/marionette_mcp/test/vm_service/tools/extension_tools_test.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+
+import 'package:logging/logging.dart' as logging;
+import 'package:marionette_mcp/src/vm_service/tools/extension_tools.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+/// Captures the args forwarded to [callCustomExtension] so we can assert on the
+/// exact wire shape produced by the coercion step.
+class _CapturingConnector implements VmServiceConnector {
+  final List<({String name, Map<String, dynamic> args})> calls = [];
+  Map<String, dynamic> nextResponse = const {'ok': true};
+
+  @override
+  Future<Map<String, dynamic>> callCustomExtension(
+    String extensionName, [
+    Map<String, dynamic> args = const {},
+  ]) async {
+    calls.add((name: extensionName, args: args));
+    return nextResponse;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+void main() {
+  group('callCustomExtension', () {
+    late _CapturingConnector connector;
+    late logging.Logger logger;
+
+    setUp(() {
+      connector = _CapturingConnector();
+      logger = logging.Logger.detached('test');
+    });
+
+    test('forwards the extension name', () async {
+      await callCustomExtension(connector, logger, {
+        'extension': 'appNavigation.goToPage',
+      });
+
+      expect(connector.calls.single.name, 'appNavigation.goToPage');
+    });
+
+    test('stringifies scalar args before sending', () async {
+      await callCustomExtension(connector, logger, {
+        'extension': 'x',
+        'args': {'i': 42, 'd': 1.5, 'b': true, 's': 'hi'},
+      });
+
+      expect(connector.calls.single.args, {
+        'i': '42',
+        'd': '1.5',
+        'b': 'true',
+        's': 'hi',
+      });
+    });
+
+    test('jsonEncodes nested object/array args (not Dart toString)', () async {
+      await callCustomExtension(connector, logger, {
+        'extension': 'x',
+        'args': {
+          'range': {'min': 1, 'max': 9},
+          'tags': ['a', 'b'],
+        },
+      });
+
+      // The bug being fixed: previously these arrived as Dart's `{min: 1, ...}`
+      // / `[a, b]` toString() form. They must now be valid JSON.
+      expect(connector.calls.single.args, {
+        'range': '{"min":1,"max":9}',
+        'tags': '["a","b"]',
+      });
+      // And it must round-trip through a JSON parser.
+      expect(
+        jsonDecode(connector.calls.single.args['range'] as String),
+        {'min': 1, 'max': 9},
+      );
+    });
+
+    test('replaces null arg values with the empty string', () async {
+      await callCustomExtension(connector, logger, {
+        'extension': 'x',
+        'args': {'maybe': null},
+      });
+
+      expect(connector.calls.single.args, {'maybe': ''});
+    });
+
+    test('sends an empty map when args are omitted', () async {
+      await callCustomExtension(connector, logger, {'extension': 'x'});
+
+      expect(connector.calls.single.args, isEmpty);
+    });
+
+    test('wraps the connector response as JSON text content', () async {
+      connector.nextResponse = const {'result': 'done'};
+
+      final result = await callCustomExtension(connector, logger, {
+        'extension': 'x',
+      });
+
+      final content = result.content.single as TextContent;
+      expect(jsonDecode(content.text), {'result': 'done'});
+    });
+  });
+}


### PR DESCRIPTION
## What

Custom Marionette extensions registered in a Flutter app can now declare a typed
input schema. When they do, `marionette_mcp` promotes them to **first-class,
dynamically-registered MCP tools** — instead of being reachable only through the
generic `call_custom_extension` escape hatch.

## Why

Previously, every custom extension was invoked through a single catch-all tool,
so the agent had no visibility into a given extension's parameters and no
validation. Promoting schema-bearing extensions to real MCP tools gives them
proper names, descriptions, and validated input schemas, making them
discoverable and far easier for an agent to call correctly.

## How

- **`marionette_flutter` — typed schema DSL** (`extension_schema.dart`):
  A new `ExtensionInputSchema` / `ExtensionParam` API lets extensions declare a
  flat object of scalar params (string/integer/number/boolean). The type system
  enforces the flat-scalar constraint at compile time, since VM service params
  are flattened to strings on the wire. `toJson()` emits JSON Schema compatible
  with what `marionette_mcp` parses via `mcp_dart`.
- **`register_extension.dart`**: extensions can now attach a schema, surfaced
  through `marionette.listExtensions`.
- **`marionette_mcp` — dynamic tool registration** (`dynamic_extension_tools.dart`):
  discovers schema-bearing extensions and registers them as individual MCP tools
  on connect.
- **Reconnect handling**: on reconnect, previously-disabled dynamic tools are
  revived rather than re-registered (avoids duplicate-registration errors).
- Updated the example app to demonstrate a schema-bearing extension.

## Tests

- `extension_schema_test.dart` — schema serialization/DSL
- `register_extension_test.dart` — registration + schema exposure
- `dynamic_extension_tools_test.dart` — MCP-side discovery, registration, and reconnect revival

## Notes

Includes regenerated example iOS files (`f8d4188`) from a `flutter run`.
