### PR TITLE
feat: add right-click (secondary tap) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add `right_click` support across all layers (MCP tool, `marionette.rightClick` extension, `GestureDispatcher.rightClick`, and the `right-click` CLI command). Dispatches a mouse-kind pointer with the secondary button pressed to trigger context menus and `onSecondaryTap` handlers, mainly for desktop and web apps.
 - Surface `Semantics(label:)` and `Semantics(value:)` in `get_interactive_elements`. Widgets that render via inline-span trees (`Text.rich`, custom-painted text, etc.) where `toPlainText()` loses structure can now be made fully readable by agents through an explicit accessibility annotation, without altering the rendered widget.
 
 # 0.5.0

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Once connected, the AI agent has access to these tools:
 | `disconnect`               | Disconnect from the currently connected app.                                                                              |
 | `get_interactive_elements` | Returns a list of all interactive UI elements (buttons, inputs, etc.) visible on screen.                                  |
 | `tap`                      | Taps an element matching a specific key or visible text.                                                                  |
+| `right_click`              | Right-clicks (secondary mouse button) an element to trigger context menus / `onSecondaryTap` handlers (desktop/web).      |
 | `enter_text`               | Enters text into a text field matching a key.                                                                             |
 | `scroll_to`                | Scrolls the view until an element matching a key or text becomes visible.                                                 |
 | `get_logs`                 | Retrieves application logs collected since app start or the last hot reload (requires a `LogCollector` to be configured). |

--- a/example/lib/router.dart
+++ b/example/lib/router.dart
@@ -9,6 +9,7 @@ import 'screens/notifications_screen.dart';
 import 'screens/page_view_screen.dart';
 import 'screens/pinch_zoom_screen.dart';
 import 'screens/profile_screen.dart';
+import 'screens/right_click_screen.dart';
 import 'screens/settings_screen.dart';
 
 /// Page name → route path mapping used by the custom VM service extension.
@@ -22,6 +23,7 @@ const availablePages = <String, String>{
   'page_view': '/settings/page-view',
   'dismissible': '/settings/dismissible',
   'pinch_zoom': '/settings/pinch-zoom',
+  'right_click': '/settings/right-click',
 };
 
 final router = GoRouter(
@@ -58,6 +60,10 @@ final router = GoRouter(
             GoRoute(
               path: 'pinch-zoom',
               builder: (context, state) => const PinchZoomScreen(),
+            ),
+            GoRoute(
+              path: 'right-click',
+              builder: (context, state) => const RightClickScreen(),
             ),
           ],
         ),

--- a/example/lib/screens/right_click_screen.dart
+++ b/example/lib/screens/right_click_screen.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+class RightClickScreen extends StatefulWidget {
+  const RightClickScreen({super.key});
+
+  @override
+  State<RightClickScreen> createState() => _RightClickScreenState();
+}
+
+class _RightClickScreenState extends State<RightClickScreen> {
+  int _count = 0;
+  Offset? _lastPosition;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Right Click'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              key: const ValueKey('right_click_count'),
+              'Right-clicks: $_count',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: GestureDetector(
+                key: const ValueKey('right_click_target'),
+                onSecondaryTapUp: (details) {
+                  setState(() {
+                    _count++;
+                    _lastPosition = details.globalPosition;
+                  });
+                },
+                child: Container(
+                  width: 280,
+                  height: 280,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.ads_click,
+                        size: 64,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Right-click me',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Use the secondary mouse button\nor the right_click MCP tool',
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              _lastPosition == null
+                  ? 'No right-click yet'
+                  : 'Last position: '
+                      '(${_lastPosition!.dx.toStringAsFixed(0)}, '
+                      '${_lastPosition!.dy.toStringAsFixed(0)})',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: FilledButton.tonal(
+              onPressed: () => setState(() {
+                _count = 0;
+                _lastPosition = null;
+              }),
+              child: const Text('Reset'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/screens/settings_screen.dart
+++ b/example/lib/screens/settings_screen.dart
@@ -53,6 +53,14 @@ class SettingsScreen extends StatelessWidget {
             onTap: () => context.go('/settings/pinch-zoom'),
           ),
           const Divider(),
+          ListTile(
+            leading: const Icon(Icons.ads_click_outlined),
+            title: const Text('Right Click'),
+            subtitle: const Text('Test secondary (right) click gesture'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.go('/settings/right-click'),
+          ),
+          const Divider(),
           const ListTile(
             leading: Icon(Icons.palette_outlined),
             title: Text('Appearance'),

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -155,6 +155,31 @@ Tap an element. Provide exactly one matching strategy.
 
 ---
 
+### right-click
+
+Right-click an element (secondary mouse button). Triggers context menus and
+GestureDetector onSecondaryTap / onSecondaryTapUp handlers. Mainly for desktop
+and web apps. Provide exactly one matching strategy.
+
+  Requires: -i <instance> or --uri <ws-uri>
+
+  Options:
+    --key <string>    Match by ValueKey<String> (most reliable)
+    --text <string>   Match by visible text content
+    --type <string>   Match by widget type name (e.g., ElevatedButton)
+    --x <number>      X screen coordinate (use with --y)
+    --y <number>      Y screen coordinate (use with --x)
+
+  Examples:
+    marionette -i my-app right-click --key file_item
+    marionette -i my-app right-click --text "Document"
+    marionette -i my-app right-click --x 100 --y 200
+
+  Output (stdout):
+    Right-clicked element matching {key: file_item}
+
+---
+
 ### enter-text
 
 Enter text into a text field.

--- a/packages/marionette_cli/lib/src/cli/commands/right_click_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/right_click_command.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:marionette_cli/src/cli/instance_command.dart';
+import 'package:marionette_cli/src/cli/matcher_builder.dart';
+import 'package:marionette_cli/src/instance_registry.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+
+class RightClickCommand extends InstanceCommand {
+  RightClickCommand(this._registry) {
+    argParser
+      ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('text', help: 'Visible text content of the element.')
+      ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
+      ..addOption('x', help: 'X coordinate for positional right-click.')
+      ..addOption('y', help: 'Y coordinate for positional right-click.');
+  }
+
+  final InstanceRegistry _registry;
+
+  @override
+  InstanceRegistry get registry => _registry;
+
+  @override
+  String get name => 'right-click';
+
+  @override
+  String get description =>
+      'Right-click an element by key, text, type, or coordinates.';
+
+  @override
+  Future<int> execute(VmServiceConnector connector) async {
+    final matcher = buildMatcherFromArgs(
+      key: argResults?['key'] as String?,
+      text: argResults?['text'] as String?,
+      type: argResults?['type'] as String?,
+      x: _parseNum(argResults?['x'] as String?),
+      y: _parseNum(argResults?['y'] as String?),
+    );
+
+    if (matcher.isEmpty) {
+      usageException(
+        'At least one matcher required: --key, --text, --type, or --x/--y.',
+      );
+    }
+
+    final response = await connector.rightClick(matcher);
+    final message =
+        response['message'] as String? ?? 'Successfully right-clicked';
+    stdout.writeln(message);
+    return 0;
+  }
+
+  num? _parseNum(String? value) {
+    if (value == null) return null;
+    return num.tryParse(value);
+  }
+}

--- a/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
+++ b/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
@@ -16,6 +16,7 @@ import 'package:marionette_cli/src/cli/commands/pinch_zoom_command.dart';
 import 'package:marionette_cli/src/cli/commands/record_video_command.dart';
 import 'package:marionette_cli/src/cli/commands/press_back_button_command.dart';
 import 'package:marionette_cli/src/cli/commands/register_command.dart';
+import 'package:marionette_cli/src/cli/commands/right_click_command.dart';
 import 'package:marionette_cli/src/cli/commands/scroll_to_command.dart';
 import 'package:marionette_cli/src/cli/commands/take_screenshots_command.dart';
 import 'package:marionette_cli/src/cli/commands/tap_command.dart';
@@ -51,6 +52,7 @@ class MarionetteCommandRunner extends CommandRunner<int> {
     addCommand(ListCommand(_registry));
     addCommand(ElementsCommand(_registry));
     addCommand(TapCommand(_registry));
+    addCommand(RightClickCommand(_registry));
     addCommand(DoubleTapCommand(_registry));
     addCommand(LongPressCommand(_registry));
     addCommand(PinchZoomCommand(_registry));

--- a/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
+++ b/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
@@ -28,6 +28,7 @@ void main() {
         'list',
         'get-interactive-elements',
         'tap',
+        'right-click',
         'double-tap',
         'long-press',
         'pinch-zoom',

--- a/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
@@ -8,8 +8,8 @@ import 'package:marionette_flutter/src/services/scroll_simulator.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
 
-/// Registers gesture-based `marionette.*` extensions: tap, doubleTap,
-/// longPress, swipe, pinchZoom, scrollTo.
+/// Registers gesture-based `marionette.*` extensions: tap, rightClick,
+/// doubleTap, longPress, swipe, pinchZoom, scrollTo.
 void registerGestureExtensions({
   required GestureDispatcher gestureDispatcher,
   required WidgetFinder widgetFinder,
@@ -23,6 +23,17 @@ void registerGestureExtensions({
       await gestureDispatcher.tap(matcher, widgetFinder, configuration);
       return MarionetteExtensionResult.success({
         'message': 'Tapped element matching: ${matcher.toJson()}',
+      });
+    },
+  );
+
+  registerInternalMarionetteExtension(
+    name: 'marionette.rightClick',
+    callback: (params) async {
+      final matcher = WidgetMatcher.fromJson(params);
+      await gestureDispatcher.rightClick(matcher, widgetFinder, configuration);
+      return MarionetteExtensionResult.success({
+        'message': 'Right-clicked element matching: ${matcher.toJson()}',
       });
     },
   );

--- a/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
+++ b/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
@@ -78,6 +78,91 @@ class GestureDispatcher {
     await _handlePointerEventRecord(records);
   }
 
+  /// Simulates a right-click (secondary mouse button click) on an element that
+  /// matches the given [matcher].
+  ///
+  /// Unlike [tap], this dispatches a mouse-kind pointer with
+  /// [kSecondaryButton] pressed, which is what Flutter's tap recognizers
+  /// require to fire `onSecondaryTap` / `onSecondaryTapUp` handlers and to
+  /// open context menus. Mainly relevant for desktop and web apps.
+  ///
+  /// If [matcher] is a [CoordinatesMatcher], clicks directly at the specified
+  /// coordinates without searching the widget tree (fast path).
+  Future<void> rightClick(
+    WidgetMatcher matcher,
+    WidgetFinder widgetFinder,
+    MarionetteConfiguration configuration,
+  ) async {
+    // Fast path for coordinate-based right-clicking
+    if (matcher is CoordinatesMatcher) {
+      await _dispatchSecondaryTapAtPosition(matcher.offset);
+      return;
+    }
+
+    final element = widgetFinder.findHittableElement(matcher, configuration);
+
+    if (element == null) {
+      throw Exception('Element matching ${matcher.toJson()} not found');
+    } else {
+      await _dispatchSecondaryTapAtElement(element);
+    }
+  }
+
+  Future<void> _dispatchSecondaryTapAtElement(Element element) async {
+    final renderObject = element.renderObject;
+
+    if (renderObject is! RenderBox) {
+      throw Exception('Element does not have a RenderBox');
+    }
+
+    if (!renderObject.hasSize) {
+      throw Exception('RenderBox does not have a size yet');
+    }
+
+    final center = renderObject.size.center(Offset.zero);
+    final globalPosition = renderObject.localToGlobal(center);
+
+    await _dispatchSecondaryTapAtPosition(globalPosition);
+  }
+
+  Future<void> _dispatchSecondaryTapAtPosition(Offset globalPosition) async {
+    final pointerId = _nextPointerId++;
+
+    final records = [
+      // Mouse pointer down with the secondary button pressed
+      [
+        PointerAddedEvent(
+          position: globalPosition,
+          kind: PointerDeviceKind.mouse,
+          device: _kDeviceId,
+        ),
+        PointerDownEvent(
+          pointer: pointerId,
+          position: globalPosition,
+          kind: PointerDeviceKind.mouse,
+          buttons: kSecondaryButton,
+          device: _kDeviceId,
+        ),
+      ],
+      // Release (buttons defaults to 0 = no buttons pressed), then remove
+      [
+        PointerUpEvent(
+          pointer: pointerId,
+          position: globalPosition,
+          kind: PointerDeviceKind.mouse,
+          device: _kDeviceId,
+        ),
+        PointerRemovedEvent(
+          position: globalPosition,
+          kind: PointerDeviceKind.mouse,
+          device: _kDeviceId,
+        ),
+      ],
+    ];
+
+    await _handlePointerEventRecord(records);
+  }
+
   /// Simulates a double tap on an element that matches the given [matcher].
   ///
   /// Two taps are dispatched with [delay] between them.

--- a/packages/marionette_flutter/test/gesture_dispatcher_test.dart
+++ b/packages/marionette_flutter/test/gesture_dispatcher_test.dart
@@ -92,6 +92,96 @@ void main() {
     );
   });
 
+  group('GestureDispatcher.rightClick', () {
+    testWidgets(
+      'should dispatch a mouse-kind secondary-button down/up sequence',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(home: Scaffold(body: Center(child: Text('Hello')))),
+        );
+
+        final events = <PointerEvent>[];
+        GestureBinding.instance.pointerRouter.addGlobalRoute(events.add);
+        addTearDown(
+          () => GestureBinding.instance.pointerRouter
+              .removeGlobalRoute(events.add),
+        );
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.rightClick(
+              const CoordinatesMatcher(100, 100),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+            ));
+        await tester.pump();
+
+        expect(events, isNotEmpty, reason: 'Should have dispatched events');
+
+        // Verify correct event sequence: Added, Down, Up, Removed
+        final addedEvents = events.whereType<PointerAddedEvent>().toList();
+        final downEvents = events.whereType<PointerDownEvent>().toList();
+        final upEvents = events.whereType<PointerUpEvent>().toList();
+        final removedEvents = events.whereType<PointerRemovedEvent>().toList();
+
+        expect(addedEvents, hasLength(1));
+        expect(downEvents, hasLength(1));
+        expect(upEvents, hasLength(1));
+        expect(removedEvents, hasLength(1));
+
+        // The down event must be a mouse with the secondary button pressed,
+        // which is what triggers onSecondaryTap handlers and context menus.
+        expect(downEvents.single.kind, PointerDeviceKind.mouse);
+        expect(downEvents.single.buttons, kSecondaryButton);
+
+        // All events should use a mouse kind and a non-zero device id so they
+        // do not collide with the real macOS mouse at device 0.
+        for (final event in events) {
+          expect(event.kind, PointerDeviceKind.mouse);
+          expect(
+            event.device,
+            isNot(equals(0)),
+            reason: '${event.runtimeType} should use a unique device id',
+          );
+        }
+      },
+    );
+
+    testWidgets(
+      'should trigger onSecondaryTapUp on the matched widget',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var secondaryTapped = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: GestureDetector(
+                  onSecondaryTapUp: (_) => secondaryTapped = true,
+                  child: const Text('Target'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.rightClick(
+              const TextMatcher('Target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+            ));
+        await tester.pump();
+
+        expect(
+          secondaryTapped,
+          isTrue,
+          reason: 'Right-click should fire onSecondaryTapUp',
+        );
+      },
+    );
+  });
+
   group('GestureDispatcher - Bug B5: macOS pointer device collision', () {
     testWidgets(
       'should use a unique device id (not 0) to avoid colliding with the real mouse',

--- a/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
@@ -4,8 +4,8 @@ import 'package:marionette_mcp/src/vm_service/tools/tool_runner.dart';
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 import 'package:mcp_dart/mcp_dart.dart';
 
-/// Registers gesture-based MCP tools: tap, double_tap, long_press, swipe,
-/// pinch_zoom, scroll_to, press_back_button.
+/// Registers gesture-based MCP tools: tap, right_click, double_tap,
+/// long_press, swipe, pinch_zoom, scroll_to, press_back_button.
 void registerGestureTools(
   McpServer server,
   VmServiceConnector connector,
@@ -55,6 +55,55 @@ void registerGestureTools(
           final message = response['message'] as String?;
           return CallToolResult(
             content: [TextContent(text: message ?? 'Successfully tapped')],
+          );
+        });
+      },
+    )
+    ..registerTool(
+      'right_click',
+      description:
+          'Simulates a right-click (secondary mouse button click) on an element in the Flutter app that matches the given criteria. This dispatches a mouse-kind pointer with the secondary button pressed, which is what triggers context menus and GestureDetector onSecondaryTap / onSecondaryTapUp handlers. Mainly relevant for desktop and web Flutter apps. You can match elements by their key (a ValueKey<String>), by their text content (but not accessibility!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, text, type, or coordinates. Prefer using the key if available, as it is more reliable. Requires an active connection established via connect.',
+      annotations: const ToolAnnotations(title: 'Right-Click Element'),
+      inputSchema: ToolInputSchema(
+        properties: {
+          'key': JsonSchema.string(
+            description:
+                'The key of the element to right-click. You can get the key of an element by calling get_interactive_elements.',
+          ),
+          'text': JsonSchema.string(
+            description:
+                'The visible text content of the element to right-click. Use this for elements that display text like buttons or labels.',
+          ),
+          'type': JsonSchema.string(
+            description:
+                'The widget type name of the element to right-click (e.g., "ElevatedButton", "IconButton"). Use this to match elements by their Flutter widget type.',
+          ),
+          'coordinates': JsonSchema.object(
+            description:
+                'Screen coordinates to right-click at. Use this to right-click at a specific position on the screen.',
+            properties: {
+              'x': JsonSchema.number(
+                description:
+                    'The x coordinate (horizontal position from left).',
+              ),
+              'y': JsonSchema.number(
+                description: 'The y coordinate (vertical position from top).',
+              ),
+            },
+            required: ['x', 'y'],
+          ),
+        },
+      ),
+      callback: (args, extra) async {
+        final matcher = buildMatcher(args);
+        logger.info('Right-clicking with matcher: $matcher');
+        return runTool(logger, 'right click', () async {
+          final response = await connector.rightClick(matcher);
+          final message = response['message'] as String?;
+          return CallToolResult(
+            content: [
+              TextContent(text: message ?? 'Successfully right-clicked'),
+            ],
           );
         });
       },

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -265,6 +265,19 @@ class VmServiceConnector {
     return _callExtension('marionette.tap', matcher);
   }
 
+  /// Right-clicks (secondary mouse button) an element matching the criteria.
+  ///
+  /// [matcher] should contain one of:
+  /// - 'key': matches by `ValueKey<String>`
+  /// - 'text': matches by visible text content
+  /// - 'type': matches by widget type name
+  /// - 'x' and 'y': screen coordinates for clicking at a specific position
+  ///
+  /// Throws [NotConnectedException] if not connected.
+  Future<Map<String, dynamic>> rightClick(Map<String, dynamic> matcher) {
+    return _callExtension('marionette.rightClick', matcher);
+  }
+
   /// Double taps an element matching the given criteria.
   ///
   /// [matcher] should contain one of:


### PR DESCRIPTION
## Context

Marionette had no way to trigger a **secondary (right) mouse click**, which Flutter desktop/web apps use for context menus, `GestureDetector.onSecondaryTap*`, selection menus, etc. Every existing gesture dispatches touch-style pointer events with no `buttons` flag and no `PointerDeviceKind`, so a secondary tap couldn't be expressed.

This adds a dedicated `right_click` gesture, mirroring `tap` across every layer.

## What changed

The data flow mirrors `tap`: `right_click` MCP tool → `VmServiceConnector.rightClick` → `marionette.rightClick` extension → `GestureDispatcher.rightClick`. The matcher path (key / text / type / coordinates) is reused unchanged.

The only real difference is the pointer payload: a **mouse-kind** down event with `buttons: kSecondaryButton`, which is what Flutter's tap recognizers require to fire `onSecondaryTap` / `onSecondaryTapUp`.

- **Dispatcher** — `GestureDispatcher.rightClick` + secondary-tap dispatch helper (uses a non-zero device id, consistent with the existing macOS device-0 collision guard).
- **Flutter extension** — registers `marionette.rightClick`.
- **MCP** — `right_click` tool (same input schema as `tap`) + `VmServiceConnector.rightClick`.
- **CLI** — new `right-click` command, registered in the runner.
- **Docs** — README tools table, `help-ai` reference, CHANGELOG.

## Testing

- New `GestureDispatcher.rightClick` unit tests: assert the down event is `kind == mouse` + `buttons == kSecondaryButton` with an intact Added/Down/Up/Removed sequence, and a widget-level test confirming `onSecondaryTapUp` fires.
- `flutter test` dispatcher suite — 19/19 pass.
- `flutter analyze` (marionette_flutter / marionette_mcp / marionette_cli) — clean.
- `dart test` for `marionette_mcp` — 116/116 pass.
- **End-to-end on macOS desktop** against the example app via the CLI: right-click incremented a secondary-tap counter (0 → 1 → 2), while a primary `tap` on the same target left it unchanged — confirming the secondary-button distinction.