### PR TITLE
docs: restructure README into slim landing page + docs/ guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The official [Dart & Flutter MCP server](https://docs.flutter.dev/ai/mcp-server)
    }
    ```
 
-2. **Install the bridge** — activate the MCP server (or the [CLI](https://github.com/leancodepl/marionette_mcp/blob/main/docs/cli.md)):
+2. **Install the bridge** — activate the MCP server (for the CLI alternative, see the [CLI guide](https://github.com/leancodepl/marionette_mcp/blob/main/docs/cli.md)):
 
    ```bash
    dart pub global activate marionette_mcp

--- a/README.md
+++ b/README.md
@@ -21,576 +21,81 @@ The official [Dart & Flutter MCP server](https://docs.flutter.dev/ai/mcp-server)
 
 ## Quick Start
 
-**Note: Your Flutter app must be prepared to be compatible with this MCP.**
-
-1. **Prepare your Flutter app** - Add the `marionette_flutter` package and initialize `MarionetteBinding` in your `main.dart`.
-2. **Install the MCP server** - Add `marionette_mcp` to your projects `dev_dependencies`.
-3. **Configure your AI tool** - Add the MCP server command (`dart run marionette_mcp`) to your tool's configuration (Claude Code, Copilot, Cursor, Gemini CLI).
-4. **Run your app in debug mode** - Look for the VM service URI in the console (e.g., `ws://127.0.0.1:12345/ws`).
-5. **Connect and interact** - Ask your AI agent (Claude, Copilot, or any MCP-compatible assistant) to connect to your app using the URI and start interacting.
-
-## Installation
-
-### 1. Add MCP Server Package
-
-Run the following command to activate the `marionette_mcp` [global tool](https://dart.dev/tools/pub/cmd/pub-global):
-
-```bash
-dart pub global activate marionette_mcp
-```
-
 > [!NOTE]
-> You can also install the package as a dev-dependency using
->
-> ```bash
-> dart pub add dev:marionette_mcp
-> ```
->
-> Then invoke the MCP server as `dart run marionette_mcp`.
-> It might be necessary to change the working directory, so that `dart run` is able to find `marionette_mcp`.
-> You can do it like so: `cd ${workspaceFolder}/packages/mypackage && dart run marionette_mcp` (it will vary between tooling).
->
-> If it does not work, we suggest using the global tool method.
+> Your Flutter app must be prepared to be compatible with Marionette. The steps below are the short version — the [Getting Started guide](https://github.com/leancodepl/marionette_mcp/blob/main/docs/getting-started.md) walks through each one.
 
-### 2. Add Flutter Package
+1. **Prepare your app** — add `marionette_flutter` and initialize `MarionetteBinding` in `main.dart`:
 
-Run the following command in your Flutter app directory:
+   ```bash
+   flutter pub add marionette_flutter
+   ```
 
-```bash
-flutter pub add marionette_flutter
-```
+   ```dart
+   void main() {
+     if (kDebugMode) {
+       MarionetteBinding.ensureInitialized();
+     } else {
+       WidgetsFlutterBinding.ensureInitialized();
+     }
+     runApp(const MyApp());
+   }
+   ```
 
-## Flutter App Integration
+2. **Install the bridge** — activate the MCP server (or the [CLI](https://github.com/leancodepl/marionette_mcp/blob/main/docs/cli.md)):
 
-You need to initialize the `MarionetteBinding` in your app. This binding registers the necessary VM service extensions that the MCP server communicates with.
+   ```bash
+   dart pub global activate marionette_mcp
+   ```
 
-### Basic Setup
+3. **Configure your AI tool** — e.g. for Claude Code:
 
-If your app uses standard Flutter widgets (like `ElevatedButton`, `TextField`, `Text`, etc.), the default configuration works out of the box.
+   ```bash
+   claude mcp add --transport stdio marionette -- marionette_mcp
+   ```
 
-```dart
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:marionette_flutter/marionette_flutter.dart';
+   Other tools (Cursor, Gemini CLI, Copilot, Antigravity): see [Configuring your AI tool](https://github.com/leancodepl/marionette_mcp/blob/main/docs/mcp-tools.md#configuring-your-ai-tool).
 
-void main() {
-  // Initialize Marionette only in debug mode
-  if (kDebugMode) {
-    MarionetteBinding.ensureInitialized();
-  } else {
-    WidgetsFlutterBinding.ensureInitialized();
-  }
+4. **Run your app in debug mode** — `flutter run`, then copy the VM service URI from the console (e.g. `ws://127.0.0.1:9101/ws`).
 
-  runApp(const MyApp());
-}
-```
+5. **Connect and interact** — ask your agent to connect using that URI and start driving the app.
 
 > [!IMPORTANT]
-> **`MarionetteBinding` must be the only binding initialized in the process.**
-> Flutter allows only one `WidgetsBinding` per app. If another binding (e.g. `AutomatedTestWidgetsFlutterBinding` from `flutter test`, or `IntegrationTestWidgetsFlutterBinding`) is already initialized, calling `MarionetteBinding.ensureInitialized()` will throw a binding assertion error.
->
-> This commonly happens when your test calls `main()` and `kDebugMode` is `true` during tests. You can work around it in several ways:
->
-> **Option A – Check the `FLUTTER_TEST` environment variable**
->
-> ```dart
-> import 'dart:io' show Platform;
->
-> final bool isFlutterTest = Platform.environment.containsKey('FLUTTER_TEST');
-> if (kDebugMode && !isFlutterTest) {
->   MarionetteBinding.ensureInitialized();
-> } else {
->   WidgetsFlutterBinding.ensureInitialized();
-> }
-> ```
->
-> **Option B – Use a separate entrypoint for tests**
->
-> Keep `MarionetteBinding` in your production `main()` (`lib/main.dart`) and create a different entrypoint for tests (e.g. `lib/main_test.dart` or `test/app_test.dart`) that does **not** initialize `MarionetteBinding`.
+> Standard Material widgets work out of the box. **If your app uses a custom design system, configuration is required** — otherwise the agent can't see or tap your custom buttons and fields. Start with the [Production Setup Checklist](https://github.com/leancodepl/marionette_mcp/blob/main/docs/configuration.md#production-setup-checklist).
 
-### Log Collection (`get_logs`)
+## What you can do
 
-Marionette supports flexible log collection through the `LogCollector` interface. You can choose from several options depending on your logging setup:
+Once connected, an agent can drive your app with a small, focused toolset: inspect the widget tree (`get_interactive_elements`), `tap` / `double_tap` / `long_press` / `swipe` / `pinch_zoom` / `scroll_to`, `enter_text`, `press_back_button`, `take_screenshots`, read `get_logs`, and `hot_reload`. Full list: [MCP Tools](https://github.com/leancodepl/marionette_mcp/blob/main/docs/mcp-tools.md).
 
-#### Option 1: Using the `logging` package
+Some real-world prompts:
 
-If your app uses Dart's [`logging`](https://pub.dev/packages/logging) package:
+> "I implemented the Forgot Password screen — connect, navigate to login, tap 'Forgot Password', enter a valid email, submit, and check the logs that the API call fired."
 
-```bash
-flutter pub add marionette_logging
-```
+> "I refactored the routing. Run a smoke test: cycle through all bottom-nav tabs and verify each screen loads without exceptions in the logs."
 
-```dart
-import 'package:flutter/foundation.dart';
-import 'package:logging/logging.dart';
-import 'package:marionette_flutter/marionette_flutter.dart';
-import 'package:marionette_logging/marionette_logging.dart';
+> "Investigate the unresponsive 'Clear Cache' button on Settings — find it via `get_interactive_elements`, tap it, and analyze the logs."
 
-void main() {
-  if (kDebugMode) {
-    MarionetteBinding.ensureInitialized(
-      MarionetteConfiguration(logCollector: LoggingLogCollector()),
-    );
-  } else {
-    WidgetsFlutterBinding.ensureInitialized();
-  }
+## Documentation
 
-  Logger.root.level = Level.ALL;
-  runApp(const MyApp());
-}
-```
+| Guide | What's inside |
+| --- | --- |
+| [Getting Started](https://github.com/leancodepl/marionette_mcp/blob/main/docs/getting-started.md) | Zero-to-driving in 5 steps. |
+| [Flutter Setup](https://github.com/leancodepl/marionette_mcp/blob/main/docs/flutter-setup.md) | The binding, debug-only init, the single-binding rule. |
+| [Configuration](https://github.com/leancodepl/marionette_mcp/blob/main/docs/configuration.md) | **Custom design systems, production checklist, complete `main.dart`.** |
+| [Log Collection](https://github.com/leancodepl/marionette_mcp/blob/main/docs/logging.md) | Wire up `get_logs` (`logging`, `logger`, or custom). |
+| [Semantics](https://github.com/leancodepl/marionette_mcp/blob/main/docs/semantics.md) | Make custom-painted / rich content readable to agents. |
+| [MCP Tools](https://github.com/leancodepl/marionette_mcp/blob/main/docs/mcp-tools.md) | Full tool reference + AI-tool configuration. |
+| [CLI](https://github.com/leancodepl/marionette_mcp/blob/main/docs/cli.md) | Drive Marionette from any shell-capable agent. |
+| [Troubleshooting](https://github.com/leancodepl/marionette_mcp/blob/main/docs/troubleshooting.md) | Common gotchas and limitations. |
 
-#### Option 2: Using the `logger` package
+## Packages
 
-If your app uses the [`logger`](https://pub.dev/packages/logger) package:
-
-```bash
-flutter pub add marionette_logger
-```
-
-```dart
-import 'package:flutter/foundation.dart';
-import 'package:logger/logger.dart';
-import 'package:marionette_flutter/marionette_flutter.dart';
-import 'package:marionette_logger/marionette_logger.dart';
-
-void main() {
-  final logCollector = LoggerLogCollector();
-
-  if (kDebugMode) {
-    MarionetteBinding.ensureInitialized(
-      MarionetteConfiguration(logCollector: logCollector),
-    );
-  } else {
-    WidgetsFlutterBinding.ensureInitialized();
-  }
-
-  final logger = Logger(
-    output: MultiOutput([ConsoleOutput(), logCollector]),
-  );
-
-  runApp(const MyApp());
-}
-```
-
-#### Option 3: Custom logging with `PrintLogCollector`
-
-For other logging solutions or custom setups, use `PrintLogCollector`:
-
-```dart
-import 'package:flutter/foundation.dart';
-import 'package:marionette_flutter/marionette_flutter.dart';
-
-void main() {
-  final collector = PrintLogCollector();
-
-  if (kDebugMode) {
-    MarionetteBinding.ensureInitialized(
-      MarionetteConfiguration(logCollector: collector),
-    );
-  } else {
-    WidgetsFlutterBinding.ensureInitialized();
-  }
-
-  // Hook into your logging system
-  myLogger.onLog((message) => collector.addLog(message));
-
-  runApp(const MyApp());
-}
-```
-
-#### No logging
-
-If you don't need log collection, simply omit the `logCollector` parameter. The `get_logs` tool will return a helpful message explaining how to enable it.
-
-### Custom Design System
-
-If you use custom widgets in your design system, you can configure Marionette to recognize them as interactive elements or extract text from them.
-
-**Why `isInteractiveWidget`?** A typical Flutter screen has hundreds of widgets in its tree - `Padding`, `Container`, `Column`, `SizedBox`, etc. When the AI agent calls `get_interactive_elements`, Marionette filters this down to only actionable targets: buttons, text fields, switches, sliders, etc. This gives the agent a concise, manageable list instead of an overwhelming dump of layout widgets.
-
-By default, Marionette recognizes standard Flutter widgets like `ElevatedButton`, `TextField`, and `Switch`. If your app uses custom widgets (e.g., `MyPrimaryButton` that wraps styling around a `GestureDetector`), Marionette won't know they're tappable unless you tell it. The `isInteractiveWidget` callback lets you mark your custom widget types as interactive, so they appear in the element list and can be targeted by `tap` and other tools.
-
-**Why `extractText`?** The `extractText` callback serves two purposes:
-
-1. **Element discovery**: Widgets with extractable text are automatically included in the interactive elements tree returned by `get_interactive_elements`, even if they are not explicitly interactive. The extracted text appears in the element's `text` field, helping the AI agent understand what each element displays.
-
-2. **Text-based matching**: The `tap`, `scroll_to`, and other interaction tools can match elements by their text content using the `text` parameter (e.g., `tap(text: "Submit")`).
-
-By default, Marionette extracts text from standard Flutter widgets (`Text`, `RichText`, `EditableText`, `TextField`, `TextFormField`) for both purposes above. `Semantics(label:|value:)` annotations are surfaced in `get_interactive_elements` as a **discovery-only** fallback — they are intentionally not consulted by the matcher path, so wrapping a control in `Semantics` will not cause `tap`/`scroll_to`/`enter_text` to redirect to the wrapper instead of the inner widget. Use `extractText` to add support for your custom widgets. The callback receives the `Element` (access the widget via `element.widget`), which lets you walk the element subtree — essential when widget properties like labels or placeholders are `Widget` instances rather than plain strings.
-
-```dart
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:marionette_flutter/marionette_flutter.dart';
-import 'package:my_app/design_system/text.dart';
-import 'package:my_app/design_system/input_decorator.dart';
-import 'package:my_app/design_system/text_field.dart';
-
-void main() {
-  if (kDebugMode) {
-    MarionetteBinding.ensureInitialized(
-      MarionetteConfiguration(
-        // Identify your custom interactive widgets
-        isInteractiveWidget: (type) =>
-            type == MyPrimaryButton || type == MyTextField,
-
-        // Extract text from your custom widgets.
-        // MyText.data is a String, so we can read it directly.
-        // MyTextField.label is a Widget, so we need Element access
-        // to walk the tree and find the rendered text.
-        extractText: (element) {
-          final widget = element.widget;
-          if (widget is MyText) return widget.data;
-          if (widget is MyTextField) {
-            return _extractMyTextFieldText(element, widget);
-          }
-          return null;
-        },
-      ),
-    );
-  } else {
-    WidgetsFlutterBinding.ensureInitialized();
-  }
-
-  runApp(const MyApp());
-}
-
-/// Extracts label text from a MyTextField by walking the element tree.
-/// The label lives inside a MyInputDecorator child widget, so we first
-/// find the decorator by type, then extract the rendered text from its
-/// label widget.
-String? _extractMyTextFieldText(Element element, MyTextField widget) {
-  // Find the MyInputDecorator descendant that holds the label
-  final decorator = _findElementOfType<MyInputDecorator>(element);
-  if (decorator != null) {
-    final decoratorWidget = decorator.widget as MyInputDecorator;
-    if (decoratorWidget.label != null) {
-      final label = _findTextInWidgetSlot(decorator, decoratorWidget.label!);
-      if (label != null) return label;
-    }
-  }
-
-  // Fall back to current value
-  return widget.controller?.text;
-}
-
-/// Finds the first descendant Element whose widget is type [T].
-Element? _findElementOfType<T extends Widget>(Element root) {
-  Element? found;
-  root.visitChildren((child) {
-    if (found != null) return;
-    if (child.widget is T) {
-      found = child;
-    } else {
-      found = _findElementOfType<T>(child);
-    }
-  });
-  return found;
-}
-
-/// Finds the Element for [targetWidget] under [parent], then
-/// collects all rendered text beneath it.
-String? _findTextInWidgetSlot(Element parent, Widget targetWidget) {
-  Element? slotElement;
-  parent.visitChildren((child) {
-    if (slotElement != null) return;
-    if (identical(child.widget, targetWidget)) {
-      slotElement = child;
-    } else {
-      slotElement = _findElementForWidget(child, targetWidget);
-    }
-  });
-  if (slotElement == null) return null;
-
-  final buffer = StringBuffer();
-  _collectText(slotElement!, buffer);
-  final result = buffer.toString().trim();
-  return result.isEmpty ? null : result;
-}
-
-Element? _findElementForWidget(Element root, Widget target) {
-  Element? found;
-  root.visitChildren((child) {
-    if (found != null) return;
-    if (identical(child.widget, target)) {
-      found = child;
-    } else {
-      found = _findElementForWidget(child, target);
-    }
-  });
-  return found;
-}
-
-void _collectText(Element element, StringBuffer buffer) {
-  final widget = element.widget;
-  if (widget is Text && widget.data != null) {
-    if (buffer.isNotEmpty) buffer.write(' ');
-    buffer.write(widget.data);
-    return;
-  }
-  if (widget is RichText) {
-    final plain = widget.text.toPlainText();
-    if (plain.isNotEmpty) {
-      if (buffer.isNotEmpty) buffer.write(' ');
-      buffer.write(plain);
-    }
-    return;
-  }
-  element.visitChildren((child) => _collectText(child, buffer));
-}
-```
-
-### Making complex content readable via `Semantics`
-
-Most rich content is already extracted out of the box — `Text.rich` and `RichText` flatten their span tree via `toPlainText()`, so an agent reads the rendered plaintext without any extra annotation. `Semantics` is the escape hatch for the cases where that plaintext isn't enough or doesn't exist:
-
-- **Custom-painted text** — `CustomPaint` and direct `TextPainter` rendering bypass the `Text` widget entirely, so there is nothing for `toPlainText()` to flatten.
-- **Lossy `WidgetSpan` content** — `toPlainText()` cannot reach text rendered inside `WidgetSpan` children, so anything composed that way (badges, inline icons-with-text, embedded widgets) is invisible.
-- **Raw-source preservation** — when you want the agent to see the markdown/markup source you parsed, not the rendered plaintext (e.g. so it can reason about structure), `Semantics(label: rawSource)` carries that through.
-
-The fix is the same primitive screen readers already rely on: wrap the visual widget in `Semantics` and supply an explicit `label` (or `value`). Marionette surfaces these annotations in `get_interactive_elements` as `Type: Semantics, text: "<label>"`, giving agents a stable, structured channel alongside whatever `toPlainText()` already produced.
-
-```dart
-// Pattern B: structural label + dynamic value. Both the screen reader
-// ("Volume, 70 percent") and the agent (Type: Semantics, text:
-// "Volume: 70%") get clean, human-friendly strings.
-Semantics(
-  label: 'Volume',
-  value: '70%',
-  child: CustomPaint(painter: _VolumeBarPainter(level: 0.7)),
-)
-```
-
-When both `label` and `value` are set, Marionette joins them as `'label: value'` in the discovery output, so widgets with dynamic state (sliders, progress bars, gauges) keep their current value visible to agents instead of dropping it.
-
-This works without any `extractText` configuration. `Semantics` annotations are surfaced as a **discovery-only** fallback in `get_interactive_elements` — they are not consulted by the matcher path used by `tap`/`scroll_to`/`enter_text`, so wrapping a control in `Semantics(label: ...)` will not cause gestures to be redirected to the wrapper. `Semantics` widgets without an explicit `label` or `value` (i.e. framework-generated annotations with no user-visible content) are not reported, so the output stays quiet by default.
-
-The same technique works for tables, lists, charts, badges, and any custom-rendered content where you want to give an agent a single authoritative summary instead of asking it to reconstruct meaning from a flat list of cells.
-
-#### Accessibility trade-off: keep `label` human-friendly
-
-Whatever you put in `Semantics.label` is announced verbatim by VoiceOver and TalkBack. Stuffing markup, raw markdown, or machine-readable identifiers into `label` so the agent can read them will degrade the experience for screen-reader users — `**bold**` is read as "star star bold star star", not "bold". Two patterns avoid the trade-off:
-
-- **Pattern A — clean label, render via `Text.rich`.** Keep `label` as the human-friendly string and let `Text.rich.toPlainText()` cover the rendered version. Both the agent and the screen reader get clean text; the agent simply sees two complementary entries (`Type: Semantics` + `Type: Text`).
-- **Pattern B — structural label + dynamic value.** Use `label` for what the control *is* and `value` for its current state. Marionette emits the combined `'label: value'` for agents; screen readers announce the pair the same way they announce a native slider.
-
-If your `label` is genuinely not human-readable (e.g. you really do want the agent to see raw markup), prefer a custom widget with `extractText` so the markup never reaches the accessibility tree.
-
-#### Screenshot sizing
-
-By default, Marionette will downscale screenshots to fit within 2000×2000
-physical pixels. You can override this via `maxScreenshotSize` in
-`MarionetteConfiguration` (set it to `null` to disable resizing).
-
-## Tool Configuration
-
-Add the MCP server to your AI coding assistant's configuration.
-
-### Cursor
-
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=marionette&config=eyJlbnYiOnt9LCJjb21tYW5kIjoibWFyaW9uZXR0ZV9tY3AgIn0%3D)
-
-Or manually add to your project's `.cursor/mcp.json` or your global `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "marionette": {
-      "command": "marionette_mcp",
-      "args": []
-    }
-  }
-}
-```
-
-### Google Antigravity
-
-Open the MCP store, click “Manage MCP Servers”, then “View raw config” and add to the opened `mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "marionette": {
-      "command": "marionette_mcp",
-      "args": []
-    }
-  }
-}
-```
-
-### Gemini CLI
-
-Add to your `~/.gemini/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "marionette": {
-      "command": "marionette_mcp",
-      "args": []
-    }
-  }
-}
-```
-
-### Claude Code
-
-You can run the following command to add it:
-
-```bash
-claude mcp add --transport stdio marionette -- marionette_mcp
-```
-
-### Copilot
-
-Add to your `mcp.json`:
-
-```json
-{
-  "servers": {
-    "marionette": {
-      "command": "marionette_mcp",
-      "args": []
-    }
-  }
-}
-```
-
-## Available Tools
-
-Once connected, the AI agent has access to these tools:
-
-| Tool                       | Description                                                                                                               |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `connect`                  | Connect to a Flutter app via its VM service URI (e.g., `ws://127.0.0.1:54321/ws`).                                        |
-| `disconnect`               | Disconnect from the currently connected app.                                                                              |
-| `get_interactive_elements` | Returns a list of all interactive UI elements (buttons, inputs, etc.) visible on screen.                                  |
-| `tap`                      | Taps an element matching a specific key or visible text.                                                                  |
-| `enter_text`               | Enters text into a text field matching a key.                                                                             |
-| `scroll_to`                | Scrolls the view until an element matching a key or text becomes visible.                                                 |
-| `get_logs`                 | Retrieves application logs collected since app start or the last hot reload (requires a `LogCollector` to be configured). |
-| `take_screenshots`         | Captures screenshots of all active views and returns them as base64 images.                                               |
-| `hot_reload`               | Performs a hot reload of the Flutter app, applying code changes without losing state.                                     |
-
-## Example Scenarios
-
-Marionette MCP shines when used by coding agents to verify their work or explore the app. Here are some real-world scenarios:
-
-### 1. Verify a New Feature
-
-**Context:** You just asked the agent to implement a "Forgot Password" flow.
-**Prompt:**
-
-> "Now that you've implemented the Forgot Password screen, let's verify it. Connect to the app, navigate to the login screen, tap 'Forgot Password', enter a valid email, and submit. Check the logs to ensure the API call was made successfully."
-
-### 2. Post-Refactor Smoke Test
-
-**Context:** You performed a large refactor on the navigation logic.
-**Prompt:**
-
-> "I've refactored the routing. Please run a quick smoke test: connect to the app, cycle through all tabs in the bottom navigation bar, and verify that each screen loads without throwing exceptions in the logs."
-
-### 3. Debugging UI Issues
-
-**Context:** Users reported a button is unresponsive on the Settings page.
-**Prompt:**
-
-> "Investigate the 'Clear Cache' button on the Settings page. Connect to the app, navigate there, find the button using `get_interactive_elements`, tap it, and analyze the logs to see if an error is occurring or if the tap is being ignored."
-
-## How It Works
-
-1. **Initialization**: Your Flutter app initializes `MarionetteBinding`, which registers custom VM service extensions (`ext.flutter.marionette.*`).
-2. **Connection**: The MCP server connects to your app's VM Service URL.
-3. **Interaction**: When an AI agent calls a tool (like `tap`), the MCP server translates this into a call to the corresponding VM service extension in your app.
-4. **Execution**: The Flutter app executes the action (e.g., simulates a tap gesture) and returns the result.
-
-## Assumptions & Limitations
-
-- **Prefer pasting the VM Service URI manually**: While some tooling can sometimes discover or infer the VM Service endpoint, the most reliable workflow is to copy the `ws://.../ws` URI from your `flutter run` output (or DevTools link) and paste it to the agent when calling `connect`.
-
-- **The agent may not know your app**: Marionette can “see” the widget tree and interact with UI elements, but it doesn’t automatically understand your product’s flows, naming conventions, or edge cases. If you want reliable navigation and assertions, provide extra context in the prompt (what screen to reach, expected labels/keys, preconditions, and the goal of the interaction).
-
-- **“Your mileage may vary” interactions**: Some actions are implemented via best-effort simulation of user behavior (gestures, focus, text entry, scrolling). Depending on platform, custom widgets, overlays, or app-specific gesture handling, results may vary. If a flow is flaky, consider exposing clearer widget keys, simplifying hit targets, or adding custom `MarionetteConfiguration` hooks for your design system. And if you hit something that consistently doesn’t behave as expected, a small repro in an issue helps us improve it.
-
-## Marionette CLI
-
-### Why a CLI?
-
-The MCP server works great with tools that support MCP natively (Cursor, Claude Code, etc.), but many enterprise environments have restrictions on which AI models can be used and which protocols are allowed. Not every team can run an MCP server.
-
-The CLI bridges this gap. Any AI agent that can execute shell commands — even smaller, less capable models — can drive a Flutter app through Marionette if given a clear reference document. A well-structured `.md` file describing each command's syntax, expected outputs, and exit codes is often all a constrained agent needs to work autonomously. This makes the CLI the most portable and universally compatible way to integrate Marionette into AI workflows.
-
-### Installation
-
-Install the CLI globally from [pub.dev](https://pub.dev/packages/marionette_cli):
-
-```bash
-dart pub global activate marionette_cli
-```
-
-This adds the `marionette` executable to your PATH (ensure `~/.pub-cache/bin` is on your PATH).
-
-### Teaching AI Agents to Use the CLI
-
-For an AI agent to use the CLI effectively, it needs a reference describing every command, its arguments, expected outputs, and exit codes. The `help-ai` command prints exactly that — a comprehensive, machine-readable reference designed for AI consumption:
-
-```bash
-marionette help-ai
-```
-
-Have the agent run this once at the start of a session, capture the output, and use it as a guide for all subsequent interactions. You can also pipe it to a file and include it in your project as a Cursor rule, Agent Skill (`SKILL.md`) or system prompt:
-
-```bash
-marionette help-ai > .cursor/rules/marionette-cli.md
-```
-
-### Direct URI Mode (Stateless)
-
-Pass the VM service URI directly with `--uri` — no registration, no cleanup, no files on disk:
-
-```bash
-marionette --uri ws://127.0.0.1:8181/ws get-interactive-elements
-marionette --uri ws://127.0.0.1:8181/ws tap --key submit_button
-marionette --uri ws://127.0.0.1:8181/ws take-screenshots --output ./screenshot.png
-marionette --uri ws://127.0.0.1:8181/ws record-video --output ./recording.webm
-```
-
-`--uri` and `--instance` are mutually exclusive. Use `--uri` for one-off interactions and `--instance` when targeting the same app repeatedly.
-
-### Named Instance Mode (Stateful)
-
-For repeated interactions with the same app, register it as a named instance to avoid passing the URI every time:
-
-```bash
-# Register Flutter app instances (use the VM service URI from flutter run output)
-marionette register my-app ws://127.0.0.1:8181/ws
-marionette register other-app ws://127.0.0.1:9090/ws
-
-# Interact with a specific instance
-marionette -i my-app get-interactive-elements
-marionette -i my-app tap --key submit_button
-marionette -i my-app tap --text "Submit"
-marionette -i my-app enter-text --key email_field --input "test@example.com"
-marionette -i my-app scroll-to --text "Bottom Item"
-marionette -i my-app take-screenshots --output ./screenshot.png
-marionette -i my-app record-video --output ./recording.webm
-marionette -i my-app record-video -o ./demo.webm -d 10
-marionette -i my-app get-logs
-marionette -i my-app hot-reload
-
-# Instance management
-marionette list
-marionette unregister my-app
-marionette doctor              # Check connectivity of all instances
-```
-
-## Troubleshooting
-
-- **"Not connected to any app"**: Ensure the AI agent has called `connect` with the valid VM Service URI before using other tools.
-- **Finding the URI**: Run your Flutter app in debug mode (`flutter run`). Look for a line like: `The Flutter DevTools debugger and profiler on iPhone 15 Pro is available at: http://127.0.0.1:9101?uri=ws://127.0.0.1:9101/ws`. Use the `ws://...` part.
-- **Release Mode**: Marionette only works in debug (and profile) mode because it relies on the VM Service. It will not work in release builds.
-- **Elements not found**: Ensure your widgets are visible. If using custom widgets, make sure they are configured in `MarionetteConfiguration`.
+| Package | Role |
+| --- | --- |
+| [`marionette_flutter`](https://pub.dev/packages/marionette_flutter) | The binding you add to your Flutter app. **Required.** |
+| [`marionette_mcp`](https://pub.dev/packages/marionette_mcp) | MCP server bridging AI agents to your running app. |
+| [`marionette_cli`](https://pub.dev/packages/marionette_cli) | CLI alternative for shell-only / restricted environments. |
+| [`marionette_logging`](https://pub.dev/packages/marionette_logging) | `LogCollector` adapter for the `logging` package. |
+| [`marionette_logger`](https://pub.dev/packages/marionette_logger) | `LogCollector` adapter for the `logger` package. |
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,100 @@
+# Marionette CLI
+
+## Why a CLI?
+
+The MCP server works great with tools that support MCP natively (Cursor, Claude Code, etc.), but many enterprise environments restrict which AI models can be used and which protocols are allowed. Not every team can run an MCP server.
+
+The CLI bridges this gap. Any AI agent that can execute shell commands — even smaller, less capable models — can drive a Flutter app through Marionette if given a clear reference document. A well-structured `.md` file describing each command's syntax, expected outputs, and exit codes is often all a constrained agent needs to work autonomously. This makes the CLI the most portable and universally compatible way to integrate Marionette into AI workflows.
+
+> The CLI requires the same Flutter-side setup as the MCP server — your app must initialize `MarionetteBinding`. See [Flutter Setup](./flutter-setup.md).
+
+## Installation
+
+Install globally from [pub.dev](https://pub.dev/packages/marionette_cli):
+
+```bash
+dart pub global activate marionette_cli
+```
+
+This adds the `marionette` executable to your PATH (ensure `~/.pub-cache/bin` is on your PATH).
+
+## Teaching AI agents to use the CLI
+
+For an agent to use the CLI effectively, it needs a reference describing every command, its arguments, expected outputs, and exit codes. The `help-ai` command prints exactly that — a comprehensive, machine-readable reference designed for AI consumption:
+
+```bash
+marionette help-ai
+```
+
+Have the agent run this once at the start of a session, capture the output, and use it as a guide. You can also pipe it to a file and include it as a Cursor rule, an Agent Skill (`SKILL.md`), or a system prompt:
+
+```bash
+marionette help-ai > .cursor/rules/marionette-cli.md
+```
+
+## Direct URI mode (stateless)
+
+Pass the VM service URI directly with `--uri` — no registration, no cleanup, no files on disk:
+
+```bash
+marionette --uri ws://127.0.0.1:8181/ws get-interactive-elements
+marionette --uri ws://127.0.0.1:8181/ws tap --key submit_button
+marionette --uri ws://127.0.0.1:8181/ws take-screenshots --output ./screenshot.png
+marionette --uri ws://127.0.0.1:8181/ws record-video --output ./recording.webm
+```
+
+`--uri` and `--instance` are mutually exclusive. Use `--uri` for one-off interactions and `--instance` when targeting the same app repeatedly.
+
+## Named instance mode (stateful)
+
+For repeated interactions, register the app once under a name so you don't repeat the URI:
+
+```bash
+# Register Flutter app instances (use the VM service URI from `flutter run`)
+marionette register my-app ws://127.0.0.1:8181/ws
+marionette register other-app ws://127.0.0.1:9090/ws
+
+# Interact with a specific instance
+marionette -i my-app get-interactive-elements
+marionette -i my-app tap --key submit_button
+marionette -i my-app tap --text "Submit"
+marionette -i my-app enter-text --key email_field --input "test@example.com"
+marionette -i my-app scroll-to --text "Bottom Item"
+marionette -i my-app take-screenshots --output ./screenshot.png
+marionette -i my-app record-video --output ./recording.webm
+marionette -i my-app record-video -o ./demo.webm -d 10
+marionette -i my-app get-logs
+marionette -i my-app hot-reload
+
+# Instance management
+marionette list
+marionette unregister my-app
+marionette doctor              # Check connectivity of all instances
+```
+
+## Command reference
+
+Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds>` (default 5).
+
+| Command | Purpose |
+| --- | --- |
+| `get-interactive-elements` | List interactive UI elements. |
+| `tap` | Tap an element (`--key`, `--text`, `--type`, or `--x`/`--y`). |
+| `double-tap` | Double tap (matchers + `--delay`). |
+| `long-press` | Long press (matchers + `--duration`). |
+| `pinch-zoom` | Pinch zoom (matchers + `--scale`, `--start-distance`). |
+| `enter-text` | Enter text (`--key` or `--focused`, plus `--input`). |
+| `scroll-to` | Scroll to an element (`--key` or `--text`). |
+| `press-back-button` | Simulate the system back button. |
+| `take-screenshots` | Capture a screenshot (`-o/--output`, `--open`). |
+| `record-video` | Record video (`-o/--output`, `-d/--duration`, `--width`, `--height`, `--ffmpeg-path`, `--open`, …). |
+| `get-logs` | Retrieve app logs. |
+| `hot-reload` | Hot reload the app. |
+| `register <name> <uri>` | Register a named instance. |
+| `unregister [<name>` &#124; `--all` &#124; `--stale]` | Remove instance(s). |
+| `list` | List registered instances. |
+| `doctor` | Check connectivity of all instances. |
+| `help-ai` | Print the AI-oriented command reference. |
+| `mcp` | Run the MCP server (`-l/--log-level`, `--log-file`, `--sse-port`). |
+
+> The `swipe` gesture is currently available via the [MCP server](./mcp-tools.md#gestures) only, not the CLI.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,251 @@
+# Configuration
+
+`MarionetteConfiguration` is how you teach Marionette about your app. **If your app uses a custom design system, this page is mandatory, not optional.** Most "Marionette can't find my button / can't type in my field" problems are missing configuration, not bugs.
+
+Start with the [Production Setup Checklist](#production-setup-checklist), then drill into the callback that addresses your symptom.
+
+## Production Setup Checklist
+
+Each callback fixes a specific failure mode. Map your symptom to the fix:
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Your custom buttons / controls don't appear in `get_interactive_elements` | The widget type isn't recognized as interactive | Add it to [`isInteractiveWidget`](#isinteractivewidget) |
+| `tap(text:)` / `scroll_to(text:)` can't find a custom field or label by its text | Text isn't being extracted from the widget | Implement [`extractText`](#extracttext) for that widget |
+| `get_logs` returns a "no LogCollector configured" message | No log collector is wired up | Set [`logCollector`](./logging.md) |
+| Custom-painted text, badges, or charts are invisible to the agent | The text never reaches a `Text` widget | Annotate with [`Semantics`](./semantics.md) |
+| Widget coverage looks low / the agent can't reach nested content | Over-aggressive traversal stopping | **Leave [`shouldStopTraversal`](#shouldstoptraversal) `null`** — do not filter scroll containers |
+
+A complete `main.dart` that wires all of these together is at the [bottom of this page](#complete-production-maindart).
+
+## What works out of the box
+
+With no configuration, Marionette recognizes the standard Flutter widgets.
+
+**Interactive (returned by `get_interactive_elements`, targetable by `tap`):** `Checkbox`, `CheckboxListTile`, `DropdownButton`, `DropdownButtonFormField`, `ElevatedButton`, `FilledButton`, `FloatingActionButton`, `GestureDetector`, `IconButton`, `InkWell`, `OutlinedButton`, `PopupMenuButton`, `Radio`, `RadioListTile`, `Slider`, `Switch`, `SwitchListTile`, `TextButton`, `TextField`, `TextFormField`, `ButtonStyleButton`.
+
+**Text extraction (used for `tap(text:)` matching and shown in element output):** `Text`, `RichText`, `EditableText`, `TextField`, `TextFormField`.
+
+If your widgets wrap or replace these — e.g. a `MyPrimaryButton` built on a `GestureDetector`, or a `MyText` that isn't a `Text` — Marionette won't know about them until you tell it. That's what the callbacks below are for.
+
+## Configuration reference
+
+`MarionetteConfiguration` is passed to `MarionetteBinding.ensureInitialized(...)` as an optional positional argument. All fields are optional and named:
+
+| Field | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `isInteractiveWidget` | `bool Function(Type type)?` | `null` | Mark app-specific widget types as interactive. |
+| `extractText` | `String? Function(Element element)?` | `null` | Extract display text from app-specific widgets. |
+| `logCollector` | `LogCollector?` | `null` | Capture app logs for `get_logs`. See [Logging](./logging.md). |
+| `shouldStopTraversal` | `bool Function(Type type)?` | `null` | Stop descending below given widget types. **Rarely needed** — see below. |
+| `maxScreenshotSize` | `Size?` | `Size(2000, 2000)` | Downscale screenshots to fit; `null` disables resizing. |
+
+Your callbacks run **after** the built-in checks — you're extending the defaults, not replacing them.
+
+### `isInteractiveWidget`
+
+A typical screen has hundreds of widgets (`Padding`, `Container`, `Column`, `SizedBox`, …). `get_interactive_elements` filters that down to actionable targets so the agent gets a concise list instead of an overwhelming dump. Custom widgets aren't on the built-in list, so mark them:
+
+```dart
+MarionetteConfiguration(
+  isInteractiveWidget: (type) =>
+      type == MyPrimaryButton || type == MyTextField,
+)
+```
+
+Now `MyPrimaryButton` and `MyTextField` appear in the element list and can be targeted by `tap` and friends.
+
+### `extractText`
+
+`extractText` serves two purposes:
+
+1. **Element discovery** — widgets with extractable text are included in `get_interactive_elements` (even if not interactive), and the text appears in the element's `text` field so the agent knows what each element shows.
+2. **Text-based matching** — `tap`, `scroll_to`, and `enter_text` can match by visible text via the `text` parameter (e.g. `tap(text: "Submit")`).
+
+The callback receives the `Element` (access the widget via `element.widget`), which lets you walk the subtree — essential when a label or placeholder is itself a `Widget` rather than a plain `String`.
+
+```dart
+MarionetteConfiguration(
+  extractText: (element) {
+    final widget = element.widget;
+    if (widget is MyText) return widget.data;          // data is a String
+    if (widget is MyTextField) {
+      return _extractMyTextFieldText(element, widget);  // label is a Widget
+    }
+    return null;
+  },
+)
+```
+
+<details>
+<summary>Full example: extracting text from a custom field whose label is a widget</summary>
+
+When a custom field's label lives inside a child widget (not a plain string), walk the element tree to find the rendered text:
+
+```dart
+/// Extracts label text from a MyTextField by walking the element tree.
+/// The label lives inside a MyInputDecorator child widget, so we first
+/// find the decorator by type, then extract the rendered text from its
+/// label widget.
+String? _extractMyTextFieldText(Element element, MyTextField widget) {
+  final decorator = _findElementOfType<MyInputDecorator>(element);
+  if (decorator != null) {
+    final decoratorWidget = decorator.widget as MyInputDecorator;
+    if (decoratorWidget.label != null) {
+      final label = _findTextInWidgetSlot(decorator, decoratorWidget.label!);
+      if (label != null) return label;
+    }
+  }
+  // Fall back to current value
+  return widget.controller?.text;
+}
+
+/// Finds the first descendant Element whose widget is type [T].
+Element? _findElementOfType<T extends Widget>(Element root) {
+  Element? found;
+  root.visitChildren((child) {
+    if (found != null) return;
+    if (child.widget is T) {
+      found = child;
+    } else {
+      found = _findElementOfType<T>(child);
+    }
+  });
+  return found;
+}
+
+/// Finds the Element for [targetWidget] under [parent], then
+/// collects all rendered text beneath it.
+String? _findTextInWidgetSlot(Element parent, Widget targetWidget) {
+  Element? slotElement;
+  parent.visitChildren((child) {
+    if (slotElement != null) return;
+    if (identical(child.widget, targetWidget)) {
+      slotElement = child;
+    } else {
+      slotElement = _findElementForWidget(child, targetWidget);
+    }
+  });
+  if (slotElement == null) return null;
+
+  final buffer = StringBuffer();
+  _collectText(slotElement!, buffer);
+  final result = buffer.toString().trim();
+  return result.isEmpty ? null : result;
+}
+
+Element? _findElementForWidget(Element root, Widget target) {
+  Element? found;
+  root.visitChildren((child) {
+    if (found != null) return;
+    if (identical(child.widget, target)) {
+      found = child;
+    } else {
+      found = _findElementForWidget(child, target);
+    }
+  });
+  return found;
+}
+
+void _collectText(Element element, StringBuffer buffer) {
+  final widget = element.widget;
+  if (widget is Text && widget.data != null) {
+    if (buffer.isNotEmpty) buffer.write(' ');
+    buffer.write(widget.data);
+    return;
+  }
+  if (widget is RichText) {
+    final plain = widget.text.toPlainText();
+    if (plain.isNotEmpty) {
+      if (buffer.isNotEmpty) buffer.write(' ');
+      buffer.write(plain);
+    }
+    return;
+  }
+  element.visitChildren((child) => _collectText(child, buffer));
+}
+```
+
+</details>
+
+> Custom-rendered content with no underlying `Text` (custom paint, `WidgetSpan`, charts) needs a different tool — see [Semantics](./semantics.md).
+
+### `shouldStopTraversal`
+
+> [!WARNING]
+> **Most apps should leave this `null`.** It is an easy footgun.
+
+`shouldStopTraversal` tells Marionette to stop descending **below** a widget type during tree traversal. The widget itself is still discovered — only its descendants are skipped. By default Marionette stops at interactive leaf widgets (and `Text`) but keeps descending through `GestureDetector` and `InkWell`, which usually wrap content.
+
+It is tempting to add scroll containers here to "reduce traversal cost." **Don't.** In production testing on a large app, filtering scroll containers *reduced* widget coverage from **25.8% to 17.8%** — the agent lost sight of everything below the stop point, including content it needed to act on.
+
+Only add a type after profiling shows a real, measured win, and never a scrolling container. If you're not sure, leave it `null`.
+
+### `maxScreenshotSize`
+
+By default screenshots are downscaled to fit within `2000 × 2000` physical pixels to keep payloads manageable. Override it, or set it to `null` to disable resizing:
+
+```dart
+MarionetteConfiguration(maxScreenshotSize: Size(1280, 1280))
+```
+
+## Complete production `main.dart`
+
+A copy-pasteable starting point that wires every callback plus a log hook. Adapt the widget types to your design system.
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+// Your design system + logging.
+import 'package:my_app/design_system/button.dart';
+import 'package:my_app/design_system/text.dart';
+import 'package:my_app/design_system/text_field.dart';
+
+void main() {
+  if (kDebugMode) {
+    final logCollector = PrintLogCollector();
+
+    MarionetteBinding.ensureInitialized(
+      MarionetteConfiguration(
+        // 1. Recognize your custom interactive widgets.
+        isInteractiveWidget: (type) =>
+            type == MyPrimaryButton || type == MyTextField,
+
+        // 2. Extract text so agents can match by visible label.
+        extractText: (element) {
+          final widget = element.widget;
+          if (widget is MyText) return widget.data;
+          if (widget is MyTextField) {
+            return _extractMyTextFieldText(element, widget);
+          }
+          return null;
+        },
+
+        // 3. Collect logs for get_logs.
+        logCollector: logCollector,
+
+        // 4. Leave shouldStopTraversal null unless profiling proves a win.
+
+        // 5. (Optional) tune screenshot size.
+        // maxScreenshotSize: const Size(1280, 1280),
+      ),
+    );
+
+    // Route your app's logs into the collector.
+    debugPrint = (message, {wrapWidth}) {
+      if (message != null) logCollector.addLog(message);
+      debugPrintSynchronously(message, wrapWidth: wrapWidth);
+    };
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  runApp(const MyApp());
+}
+
+// _extractMyTextFieldText and helpers: see the "Full example" above.
+```
+
+> Prefer the `logging` or `logger` package over a `debugPrint` hook? See [Log Collection](./logging.md) for first-class adapters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,10 +233,14 @@ void main() {
       ),
     );
 
-    // Route your app's logs into the collector.
+    // Route your app's logs into the collector. Tee into the existing
+    // debugPrint implementation rather than replacing it — this preserves
+    // Flutter's default throttling (debugPrintThrottled) instead of forcing
+    // synchronous output, which can degrade performance under heavy logging.
+    final defaultDebugPrint = debugPrint;
     debugPrint = (message, {wrapWidth}) {
       if (message != null) logCollector.addLog(message);
-      debugPrintSynchronously(message, wrapWidth: wrapWidth);
+      defaultDebugPrint(message, wrapWidth: wrapWidth);
     };
   } else {
     WidgetsFlutterBinding.ensureInitialized();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ Now `MyPrimaryButton` and `MyTextField` appear in the element list and can be ta
 `extractText` serves two purposes:
 
 1. **Element discovery** — widgets with extractable text are included in `get_interactive_elements` (even if not interactive), and the text appears in the element's `text` field so the agent knows what each element shows.
-2. **Text-based matching** — `tap`, `scroll_to`, and `enter_text` can match by visible text via the `text` parameter (e.g. `tap(text: "Submit")`).
+2. **Text-based matching** — `tap` and `scroll_to` can match by visible text via the `text` parameter (e.g. `tap(text: "Submit")`). (`enter_text` is the exception: it targets a field by `key`, or by focusing it first via `tap` and passing `focused_element: true` — it has no `text` matcher.)
 
 The callback receives the `Element` (access the widget via `element.widget`), which lets you walk the subtree — essential when a label or placeholder is itself a `Widget` rather than a plain `String`.
 

--- a/docs/flutter-setup.md
+++ b/docs/flutter-setup.md
@@ -1,0 +1,61 @@
+# Flutter Setup
+
+How to wire `MarionetteBinding` into your app, and the one rule you must not break.
+
+## The binding
+
+`MarionetteBinding.ensureInitialized()` registers the VM service extensions (`ext.flutter.marionette.*`) that the MCP server and CLI talk to. Initialize it in `main()`, gated on `kDebugMode` so it never ships in release builds:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+void main() {
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized();
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  runApp(const MyApp());
+}
+```
+
+`ensureInitialized` takes an optional positional `MarionetteConfiguration`. Omitting it (as above) uses the defaults. To recognize custom widgets, collect logs, or tune screenshots, pass a configuration — see [Configuration](./configuration.md).
+
+## Basic setup works for raw Material widgets only
+
+The zero-config setup above recognizes the **standard Flutter widgets**: buttons (`ElevatedButton`, `TextButton`, `IconButton`, …), `TextField`/`TextFormField`, `Switch`, `Checkbox`, `Slider`, and a few more, plus text from `Text`/`RichText`. See the full built-in lists in [Configuration → What works out of the box](./configuration.md#what-works-out-of-the-box).
+
+> [!IMPORTANT]
+> If your app uses a **custom design system** — wrapped buttons, custom text fields, bespoke controls — the defaults will **not** see them, and the agent won't be able to find or tap them by text. This is the single most common source of "it doesn't work" reports. If that's you (it's most production apps), go straight to the [Production Setup Checklist](./configuration.md#production-setup-checklist).
+
+## Single-binding rule
+
+Flutter allows only **one** `WidgetsBinding` per process. `MarionetteBinding` is a binding. If another binding (e.g. `AutomatedTestWidgetsFlutterBinding` from `flutter test`, or `IntegrationTestWidgetsFlutterBinding`) is already initialized, calling `MarionetteBinding.ensureInitialized()` throws a binding assertion error.
+
+This commonly bites when your test calls `main()` and `kDebugMode` is `true` during tests. Two ways to avoid it:
+
+### Option A — Skip Marionette under `flutter test`
+
+```dart
+import 'dart:io' show Platform;
+
+final isFlutterTest = Platform.environment.containsKey('FLUTTER_TEST');
+if (kDebugMode && !isFlutterTest) {
+  MarionetteBinding.ensureInitialized();
+} else {
+  WidgetsFlutterBinding.ensureInitialized();
+}
+```
+
+### Option B — Use a separate test entrypoint
+
+Keep `MarionetteBinding` in your production `main()` (`lib/main.dart`) and create a different entrypoint for tests (e.g. `lib/main_test.dart`) that does **not** initialize `MarionetteBinding`.
+
+## Next steps
+
+- [Configuration](./configuration.md) — custom widgets, the production checklist, and a complete `main.dart`.
+- [Log Collection](./logging.md) — wire up `get_logs`.
+- [Troubleshooting](./troubleshooting.md) — common gotchas.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,97 @@
+# Getting Started
+
+This guide takes you from zero to driving a running Flutter app with an AI agent in a few minutes. It covers the happy path: standard Material widgets, no custom configuration. If your app uses a custom design system, you'll also want [Configuration](./configuration.md) — but start here first.
+
+## Overview
+
+Marionette has two halves:
+
+- **`marionette_flutter`** — a package you add to your Flutter app. It installs a binding that exposes VM service extensions the tooling talks to.
+- **`marionette_mcp`** (or **`marionette_cli`**) — the bridge your AI agent runs. It connects to your app's VM service and translates agent requests into actions.
+
+You always need `marionette_flutter` in the app. Whether you use the MCP server or the CLI depends on your agent — see [MCP Tools](./mcp-tools.md) and the [CLI guide](./cli.md).
+
+## 1. Add the Flutter package
+
+In your Flutter app directory:
+
+```bash
+flutter pub add marionette_flutter
+```
+
+## 2. Initialize the binding
+
+Initialize `MarionetteBinding` in your `main()`, **only in debug mode**. For an app built from standard Material widgets, the defaults work out of the box:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+void main() {
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized();
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  runApp(const MyApp());
+}
+```
+
+> [!IMPORTANT]
+> `MarionetteBinding` must be the **only** binding initialized in the process. If your tests call `main()` while `kDebugMode` is true, this will clash with the test binding. See [Flutter Setup](./flutter-setup.md#single-binding-rule) for the fix.
+
+## 3. Install the agent bridge
+
+Activate the MCP server as a global tool:
+
+```bash
+dart pub global activate marionette_mcp
+```
+
+Then register it with your AI tool. The exact command varies — see [Configuring your AI tool](./mcp-tools.md#configuring-your-ai-tool). For Claude Code:
+
+```bash
+claude mcp add --transport stdio marionette -- marionette_mcp
+```
+
+> Working in a constrained environment that can't run an MCP server? Use the [CLI](./cli.md) instead — any agent that can run shell commands can drive Marionette.
+
+## 4. Run your app and grab the VM service URI
+
+Run your app in debug mode:
+
+```bash
+flutter run
+```
+
+Look for the VM service URI in the console — the `ws://...` part:
+
+```
+The Flutter DevTools debugger and profiler ... is available at:
+http://127.0.0.1:9101?uri=ws://127.0.0.1:9101/ws
+```
+
+Here the URI you want is `ws://127.0.0.1:9101/ws`.
+
+> [!TIP]
+> Pasting the URI manually is the most reliable workflow. Some tooling can infer it, but copy-pasting from `flutter run` output avoids surprises.
+
+## 5. Connect and interact
+
+Ask your agent to connect and explore. For example:
+
+> "Connect to the app at `ws://127.0.0.1:9101/ws`, list the interactive elements, then tap the button labeled 'Sign in'."
+
+Under the hood the agent will:
+
+1. Call `connect` with the URI.
+2. Call `get_interactive_elements` to see what's on screen.
+3. Call `tap` (by key or visible text) to act.
+
+That's the full loop. From here:
+
+- **Using custom widgets?** Most real apps do. Continue to [Configuration](./configuration.md) — it explains why custom buttons/fields are invisible by default and how the [Production Setup Checklist](./configuration.md#production-setup-checklist) fixes it.
+- **Want logs?** See [Log Collection](./logging.md).
+- **Something not working?** See [Troubleshooting](./troubleshooting.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,102 @@
+# Log Collection
+
+The `get_logs` tool lets an agent read the logs your app emitted since start or since the last hot reload — invaluable for confirming an API call fired, spotting an exception, or debugging why a tap did nothing.
+
+Logs are off by default. Wire up a `LogCollector` via `MarionetteConfiguration(logCollector: ...)`. Pick the option that matches how your app logs.
+
+## Option 1 — the `logging` package
+
+If your app uses Dart's [`logging`](https://pub.dev/packages/logging) package:
+
+```bash
+flutter pub add marionette_logging
+```
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+import 'package:marionette_logging/marionette_logging.dart';
+
+void main() {
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized(
+      MarionetteConfiguration(logCollector: LoggingLogCollector()),
+    );
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  Logger.root.level = Level.ALL;
+  runApp(const MyApp());
+}
+```
+
+`LoggingLogCollector` subscribes to `Logger.root.onRecord` and formats each record with timestamp, level, logger name, error, and stack trace.
+
+## Option 2 — the `logger` package
+
+If your app uses the [`logger`](https://pub.dev/packages/logger) package:
+
+```bash
+flutter pub add marionette_logger
+```
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+import 'package:marionette_logger/marionette_logger.dart';
+
+void main() {
+  final logCollector = LoggerLogCollector();
+
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized(
+      MarionetteConfiguration(logCollector: logCollector),
+    );
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  final logger = Logger(
+    output: MultiOutput([ConsoleOutput(), logCollector]),
+  );
+
+  runApp(const MyApp());
+}
+```
+
+`LoggerLogCollector` is both a `LogCollector` and a `logger` `LogOutput`, so the single object plugs into both `MarionetteConfiguration` and your `Logger`.
+
+## Option 3 — anything else (`PrintLogCollector`)
+
+For custom logging setups, `PrintLogCollector` (shipped in `marionette_flutter`) gives you a manual `addLog` you can call from wherever your logs flow:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+
+void main() {
+  final collector = PrintLogCollector();
+
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized(
+      MarionetteConfiguration(logCollector: collector),
+    );
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  // Hook into your logging system.
+  myLogger.onLog((message) => collector.addLog(message));
+
+  runApp(const MyApp());
+}
+```
+
+A common variant is to route Flutter's own `debugPrint` into the collector — see the [complete production `main.dart`](./configuration.md#complete-production-maindart).
+
+## No logging
+
+If you don't need logs, omit `logCollector`. `get_logs` will return a message explaining how to enable it.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,128 @@
+# MCP Tools
+
+Once your agent is connected (see [Configuring your AI tool](#configuring-your-ai-tool)), it has access to the tools below. Marionette keeps the surface area intentionally small and high-signal: a handful of actions that return the minimum actionable data, to keep prompts focused and context sizes under control.
+
+## Tool reference
+
+### Connection
+
+| Tool | Description |
+| --- | --- |
+| `connect` | Connect to a Flutter app via its VM service URI (e.g. `ws://127.0.0.1:8181/ws`). Must be called before any other tool. Verifies the `marionette_flutter` binding version matches the server. |
+| `disconnect` | Disconnect from the currently connected app. |
+
+### Inspection
+
+| Tool | Description |
+| --- | --- |
+| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, and identifying properties. The agent's primary way to "see" the screen. |
+| `take_screenshots` | Capture screenshots of all active views, returned as base64 PNGs. |
+| `get_logs` | Retrieve app logs collected since start or the last hot reload. Requires a [`LogCollector`](./logging.md). |
+
+### Gestures
+
+| Tool | Description |
+| --- | --- |
+| `tap` | Tap an element matched by `key`, `text`, `type`, or `coordinates`. Prefer `key`. Tapping a text field focuses it. |
+| `double_tap` | Double tap an element (optional `delay` between taps, default 100 ms). |
+| `long_press` | Long press an element (optional `duration`, default 600 ms) — context menus, reorderable lists. |
+| `swipe` | Swipe/drag. Element-based (`key`/`text` + `direction` + optional `distance`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
+| `pinch_zoom` | Pinch to zoom an element. `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
+| `press_back_button` | Simulate the system back button (Android back / iOS swipe-back). Works with Navigator, GoRouter, etc. |
+| `scroll_to` | Scroll until an element matching `key` or `text` becomes visible. |
+
+### Text input
+
+| Tool | Description |
+| --- | --- |
+| `enter_text` | Enter text into a field. Target by `key`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required. |
+
+### Custom extensions
+
+| Tool | Description |
+| --- | --- |
+| `list_custom_extensions` | List custom VM service extensions the app registered (outside Marionette's built-ins). |
+| `call_custom_extension` | Call one by name (without the `ext.flutter.` prefix), passing key-value args. An escape hatch for app-specific extensions — e.g. jump straight to a deep route. See the [example app](https://github.com/leancodepl/marionette_mcp/tree/main/example). |
+
+### Dev workflow
+
+| Tool | Description |
+| --- | --- |
+| `hot_reload` | Hot reload the app — apply code changes without losing state. |
+
+## How it works
+
+1. **Initialization** — your app initializes `MarionetteBinding`, which registers custom VM service extensions (`ext.flutter.marionette.*`).
+2. **Connection** — the MCP server connects to your app's VM Service URL and checks that the binding version matches.
+3. **Interaction** — when the agent calls a tool (e.g. `tap`), the server translates it into a call to the corresponding VM service extension.
+4. **Execution** — the Flutter app performs the action (e.g. simulates a tap gesture) and returns the result.
+
+## Configuring your AI tool
+
+Install the server as a global tool first:
+
+```bash
+dart pub global activate marionette_mcp
+```
+
+> Prefer a dev-dependency? Run `dart pub add dev:marionette_mcp` and invoke the server as `dart run marionette_mcp` (you may need to `cd` into the package directory so `dart run` resolves it). If that's fiddly, the global tool is the simplest path.
+
+Then register it with your tool:
+
+### Claude Code
+
+```bash
+claude mcp add --transport stdio marionette -- marionette_mcp
+```
+
+### Cursor
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=marionette&config=eyJlbnYiOnt9LCJjb21tYW5kIjoibWFyaW9uZXR0ZV9tY3AgIn0%3D)
+
+Or add to your project's `.cursor/mcp.json` (or global `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "marionette": { "command": "marionette_mcp", "args": [] }
+  }
+}
+```
+
+### Google Antigravity
+
+Open the MCP store → "Manage MCP Servers" → "View raw config", and add to `mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "marionette": { "command": "marionette_mcp", "args": [] }
+  }
+}
+```
+
+### Gemini CLI
+
+Add to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "marionette": { "command": "marionette_mcp", "args": [] }
+  }
+}
+```
+
+### Copilot
+
+Add to your `mcp.json`:
+
+```json
+{
+  "servers": {
+    "marionette": { "command": "marionette_mcp", "args": [] }
+  }
+}
+```
+
+> Can't run an MCP server (enterprise restrictions, an agent that only runs shell commands)? Use the [CLI](./cli.md) instead.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,0 +1,39 @@
+# Making Complex Content Readable via `Semantics`
+
+Most rich content is already extracted out of the box — `Text.rich` and `RichText` flatten their span tree via `toPlainText()`, so an agent reads the rendered plaintext without any extra annotation. `Semantics` is the escape hatch for the cases where that plaintext isn't enough or doesn't exist:
+
+- **Custom-painted text** — `CustomPaint` and direct `TextPainter` rendering bypass the `Text` widget entirely, so there is nothing for `toPlainText()` to flatten.
+- **Lossy `WidgetSpan` content** — `toPlainText()` cannot reach text rendered inside `WidgetSpan` children, so anything composed that way (badges, inline icons-with-text, embedded widgets) is invisible.
+- **Raw-source preservation** — when you want the agent to see the markdown/markup source you parsed, not the rendered plaintext (e.g. so it can reason about structure), `Semantics(label: rawSource)` carries that through.
+
+The fix is the same primitive screen readers already rely on: wrap the visual widget in `Semantics` and supply an explicit `label` (or `value`). Marionette surfaces these annotations in `get_interactive_elements` as `Type: Semantics, text: "<label>"`, giving agents a stable, structured channel alongside whatever `toPlainText()` already produced.
+
+```dart
+// Structural label + dynamic value. Both the screen reader
+// ("Volume, 70 percent") and the agent (Type: Semantics, text:
+// "Volume: 70%") get clean, human-friendly strings.
+Semantics(
+  label: 'Volume',
+  value: '70%',
+  child: CustomPaint(painter: _VolumeBarPainter(level: 0.7)),
+)
+```
+
+When both `label` and `value` are set, Marionette joins them as `'label: value'` in the discovery output, so widgets with dynamic state (sliders, progress bars, gauges) keep their current value visible to agents instead of dropping it.
+
+This works without any `extractText` configuration. The same technique works for tables, lists, charts, badges, and any custom-rendered content where you want to give an agent a single authoritative summary instead of asking it to reconstruct meaning from a flat list of cells.
+
+## Discovery-only contract
+
+`Semantics` annotations are surfaced as a **discovery-only** fallback in `get_interactive_elements` — they are **not** consulted by the matcher path used by `tap`, `scroll_to`, and `enter_text`. So wrapping a control in `Semantics(label: ...)` will **not** cause gestures to be redirected to the wrapper instead of the inner widget.
+
+`Semantics` widgets without an explicit `label` or `value` (framework-generated annotations with no user-visible content) are **not** reported, so the output stays quiet by default.
+
+## Accessibility trade-off: keep `label` human-friendly
+
+Whatever you put in `Semantics.label` is announced verbatim by VoiceOver and TalkBack. Stuffing markup, raw markdown, or machine-readable identifiers into `label` so the agent can read them will degrade the experience for screen-reader users — `**bold**` is read as "star star bold star star", not "bold". Two patterns avoid the trade-off:
+
+- **Pattern A — clean label, render via `Text.rich`.** Keep `label` as the human-friendly string and let `Text.rich.toPlainText()` cover the rendered version. Both the agent and the screen reader get clean text; the agent simply sees two complementary entries (`Type: Semantics` + `Type: Text`).
+- **Pattern B — structural label + dynamic value.** Use `label` for what the control *is* and `value` for its current state. Marionette emits the combined `'label: value'` for agents; screen readers announce the pair the same way they announce a native slider.
+
+If your `label` is genuinely not human-readable (e.g. you really do want the agent to see raw markup), prefer a custom widget with [`extractText`](./configuration.md#extracttext) so the markup never reaches the accessibility tree.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,30 @@
+# Troubleshooting
+
+## Common gotchas
+
+Most "Marionette doesn't work" reports trace back to missing configuration. Match your symptom:
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Custom buttons / controls don't show up in `get_interactive_elements` | Custom widget type isn't recognized as interactive | Add it to [`isInteractiveWidget`](./configuration.md#isinteractivewidget) |
+| `tap(text:)` / `scroll_to(text:)` can't find a custom field or label | Text isn't extracted from the widget | Implement [`extractText`](./configuration.md#extracttext) |
+| Custom-painted text, badges, charts are invisible to the agent | Text never reaches a `Text` widget | Annotate with [`Semantics`](./semantics.md) |
+| `get_logs` says no collector is configured | No `LogCollector` wired up | See [Log Collection](./logging.md) |
+| Widget coverage looks low / agent can't reach nested content | Over-aggressive `shouldStopTraversal` | **Leave it `null`** — never filter scroll containers ([why](./configuration.md#shouldstoptraversal)) |
+| Binding assertion error on startup, often in tests | Two `WidgetsBinding`s initialized | See the [single-binding rule](./flutter-setup.md#single-binding-rule) |
+| `connect` fails with a version mismatch | `marionette_mcp`/`marionette_cli` and `marionette_flutter` are different versions | Align both packages to the same version |
+
+## Quick fixes
+
+- **"Not connected to any app"** — ensure the agent called `connect` with a valid VM Service URI before any other tool.
+- **Finding the URI** — run your app in debug mode (`flutter run`) and look for a line like `... is available at: http://127.0.0.1:9101?uri=ws://127.0.0.1:9101/ws`. Use the `ws://...` part.
+- **Release mode** — Marionette only works in **debug and profile** mode because it relies on the VM Service. It will not work in release builds.
+- **Elements not found** — make sure the widget is actually visible on screen. If it's a custom widget, confirm it's covered by your [`MarionetteConfiguration`](./configuration.md).
+
+## Assumptions & limitations
+
+- **Prefer pasting the VM Service URI manually.** Some tooling can discover or infer the endpoint, but the most reliable workflow is to copy the `ws://.../ws` URI from your `flutter run` output (or a DevTools link) and paste it to the agent when calling `connect`.
+
+- **The agent may not know your app.** Marionette can "see" the widget tree and interact with UI, but it doesn't automatically understand your product's flows, naming conventions, or edge cases. For reliable navigation and assertions, give the agent context in the prompt: what screen to reach, expected labels/keys, preconditions, and the goal of the interaction.
+
+- **"Your mileage may vary" interactions.** Some actions are best-effort simulations of user behavior (gestures, focus, text entry, scrolling). Depending on platform, custom widgets, overlays, or app-specific gesture handling, results may vary. If a flow is flaky, consider exposing clearer widget keys, simplifying hit targets, or adding custom [`MarionetteConfiguration`](./configuration.md) hooks for your design system. If something consistently misbehaves, a small repro in an [issue](https://github.com/leancodepl/marionette_mcp/issues) helps us improve it.


### PR DESCRIPTION
Resolves #69.

## Why

The root `README.md` was a 624-line monolith. The Bukeer team reported that **12 of 14** integration friction points were missing configuration, not bugs — the README documented the requirements but buried them so they read as optional. Exploration also surfaced two correctness problems: the tool reference was stale (listed 9 MCP tools; the server exposes 16), and `shouldStopTraversal` was undocumented despite being a real callback the issue flags as a footgun.

## What changed

**Slim root README (624 → 129 lines).** All marketing chrome kept verbatim (banner, badges, tagline, promo gif, "Maintained by LeanCode" footer). New body: condensed pitch, 5-step Quick Start with the "custom design system requires config" warning surfaced up top, a tool overview with example prompts, a Documentation index, and a Packages table. Doc links are **absolute GitHub URLs** because the per-package READMEs are symlinks to this file (relative links would break on pub.dev).

**New `docs/` guides:**
- `getting-started.md` — zero-to-driving happy path
- `flutter-setup.md` — the binding, debug-only init, the single-binding rule
- `configuration.md` — the production hub: **Production Setup Checklist** (symptom→callback table), full `MarionetteConfiguration` reference, built-in widget lists, the `extractText` deep-dive, **correct `shouldStopTraversal` guidance** (warns against the 25.8%→17.8% scroll-container footgun), and a complete production `main.dart`
- `logging.md`, `semantics.md`, `mcp-tools.md`, `cli.md`, `troubleshooting.md`

**Drift fixed:**
- Documented all **16 MCP tools** (was 9 — added `double_tap`, `long_press`, `swipe`, `pinch_zoom`, `press_back_button`, `list_custom_extensions`, `call_custom_extension`).
- Documented the missing CLI commands; noted `swipe` is MCP-only.
- Documented `shouldStopTraversal` and `maxScreenshotSize`; added a binding-version-mismatch gotcha.

## Out of scope

The issue's secondary asks (compact `get_interactive_elements` output, autoconnect helper) need code, not docs — not addressed here.

## Notes for reviewers

- Per-package READMEs are symlinks to the root, so all 5 auto-track the new content.
- Header and footer are byte-identical to the previous README (verified).
- All intra-docs links and anchors resolve (verified).