### PR TITLE
feat: add hot restart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Once connected, the AI agent has access to these tools:
 | `get_logs`                 | Retrieves application logs collected since app start or the last hot reload (requires a `LogCollector` to be configured). |
 | `take_screenshots`         | Captures screenshots of all active views and returns them as base64 images.                                               |
 | `hot_reload`               | Performs a hot reload of the Flutter app, applying code changes without losing state.                                     |
+| `hot_restart`              | Performs a hot restart of the Flutter app, fully restarting it from `main()` and resetting all state (requires `flutter run`). |
 
 ## Example Scenarios
 
@@ -579,6 +580,7 @@ marionette -i my-app record-video --output ./recording.webm
 marionette -i my-app record-video -o ./demo.webm -d 10
 marionette -i my-app get-logs
 marionette -i my-app hot-reload
+marionette -i my-app hot-restart
 
 # Instance management
 marionette list

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -344,6 +344,26 @@ Perform a hot reload of the Flutter app.
 
 ---
 
+### hot-restart
+
+Perform a hot restart of the Flutter app. Fully restarts the app from main()
+and resets all state. Use it for changes a hot reload cannot pick up (e.g.
+main()/bootstrap edits, global singletons, or state shape). Requires the app
+to be running via `flutter run`.
+
+  Requires: -i <instance> or --uri <ws-uri>
+
+  Example:
+    marionette -i my-app hot-restart
+
+  Output (stdout, exit 0):
+    Hot restart completed successfully.
+
+  Output on failure (stderr, exit 1):
+    Hot restart failed or is unavailable. Make sure the app is running via `flutter run`.
+
+---
+
 ### doctor
 
 Check connectivity of all registered instances.

--- a/packages/marionette_cli/lib/src/cli/commands/hot_restart_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/hot_restart_command.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:marionette_cli/src/cli/instance_command.dart';
+import 'package:marionette_cli/src/instance_registry.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+
+class HotRestartCommand extends InstanceCommand {
+  HotRestartCommand(this._registry);
+
+  final InstanceRegistry _registry;
+
+  @override
+  InstanceRegistry get registry => _registry;
+
+  @override
+  String get name => 'hot-restart';
+
+  @override
+  String get description =>
+      'Perform a hot restart of the Flutter app (resets state).';
+
+  @override
+  Future<int> execute(VmServiceConnector connector) async {
+    final restarted = await connector.hotRestart();
+
+    if (restarted) {
+      stdout.writeln('Hot restart completed successfully.');
+      return 0;
+    } else {
+      stderr.writeln(
+        'Hot restart failed or is unavailable. '
+        'Make sure the app is running via `flutter run`.',
+      );
+      return 1;
+    }
+  }
+}

--- a/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
+++ b/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
@@ -9,6 +9,7 @@ import 'package:marionette_cli/src/cli/commands/get_interactive_elements_command
 import 'package:marionette_cli/src/cli/commands/get_logs_command.dart';
 import 'package:marionette_cli/src/cli/commands/help_ai_command.dart';
 import 'package:marionette_cli/src/cli/commands/hot_reload_command.dart';
+import 'package:marionette_cli/src/cli/commands/hot_restart_command.dart';
 import 'package:marionette_cli/src/cli/commands/long_press_command.dart';
 import 'package:marionette_cli/src/cli/commands/list_command.dart';
 import 'package:marionette_cli/src/cli/commands/mcp_command.dart';
@@ -63,6 +64,7 @@ class MarionetteCommandRunner extends CommandRunner<int> {
     addCommand(RecordVideoCommand(_registry));
     addCommand(LogsCommand(_registry));
     addCommand(HotReloadCommand(_registry));
+    addCommand(HotRestartCommand(_registry));
     addCommand(DoctorCommand(_registry));
     addCommand(HelpAiCommand());
     addCommand(McpCommand());

--- a/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
+++ b/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
@@ -39,6 +39,7 @@ void main() {
         'record-video',
         'get-logs',
         'hot-reload',
+        'hot-restart',
         'doctor',
         'help-ai',
         'mcp',

--- a/packages/marionette_mcp/lib/src/mcp_server_runner.dart
+++ b/packages/marionette_mcp/lib/src/mcp_server_runner.dart
@@ -8,7 +8,7 @@ import 'package:marionette_mcp/src/vm_service/vm_service_context.dart';
 import 'package:mcp_dart/mcp_dart.dart';
 
 const _instructions = '''
-Marionette MCP enables AI agents to interact with Flutter apps running in debug mode. It provides tools to inspect UI elements, tap buttons, enter text, scroll, take screenshots, retrieve logs, and perform hot reloads.
+Marionette MCP enables AI agents to interact with Flutter apps running in debug mode. It provides tools to inspect UI elements, tap buttons, enter text, scroll, take screenshots, retrieve logs, and perform hot reloads and hot restarts.
 
 Usage:
 1. Start the Flutter app in debug mode and note the VM service URI (e.g., ws://127.0.0.1:8181/ws).
@@ -17,6 +17,7 @@ Usage:
 4. Interact with elements using "tap", "enter_text", or "scroll_to" tools.
 5. Use "take_screenshots" to see the current app state and "get_logs" to debug issues.
 6. Use "hot_reload" after making code changes to reload the app without losing state.
+7. Use "hot_restart" to fully restart the app from main() and reset all state — needed for changes a hot reload cannot pick up (e.g. main()/bootstrap edits, global singletons, or state shape). Requires the app to be running via `flutter run`.
 
 Important: Elements are matched by their key (ValueKey<String>) or text content. Keys are more reliable. If you cannot locate a widget, you may need to add a ValueKey to it in the Flutter source code. For example: `ElevatedButton(key: ValueKey('submit_button'), ...)`.
 ''';

--- a/packages/marionette_mcp/lib/src/vm_service/tools/system_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/system_tools.dart
@@ -3,45 +3,82 @@ import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 import 'package:mcp_dart/mcp_dart.dart';
 
 /// Registers MCP tools that control the Flutter app's dev workflow rather
-/// than its UI: `hot_reload`.
+/// than its UI: `hot_reload` and `hot_restart`.
 void registerSystemTools(
   McpServer server,
   VmServiceConnector connector,
   logging.Logger logger,
 ) {
-  server.registerTool(
-    'hot_reload',
-    description:
-        'Performs a hot reload of the Flutter app. This reloads the Dart code without restarting the app, preserving the current state. Useful after making code changes to see them reflected in the running app. Requires an active connection established via connect.',
-    annotations: const ToolAnnotations(title: 'Hot Reload'),
-    inputSchema: const ToolInputSchema(properties: {}),
-    callback: (args, extra) async {
-      logger.info('Performing hot reload');
+  server
+    ..registerTool(
+      'hot_reload',
+      description:
+          'Performs a hot reload of the Flutter app. This reloads the Dart code without restarting the app, preserving the current state. Useful after making code changes to see them reflected in the running app. Requires an active connection established via connect.',
+      annotations: const ToolAnnotations(title: 'Hot Reload'),
+      inputSchema: const ToolInputSchema(properties: {}),
+      callback: (args, extra) async {
+        logger.info('Performing hot reload');
 
-      try {
-        final reloaded = await connector.hotReload();
-        if (reloaded) {
+        try {
+          final reloaded = await connector.hotReload();
+          if (reloaded) {
+            return CallToolResult(
+              content: [
+                const TextContent(text: 'Hot reload completed successfully'),
+              ],
+            );
+          }
           return CallToolResult(
+            isError: true,
             content: [
-              const TextContent(text: 'Hot reload completed successfully'),
+              TextContent(
+                text: 'Hot reload failed. The app may need a full restart.',
+              ),
             ],
           );
+        } catch (err) {
+          logger.warning('Failed to perform hot reload', err);
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Hot reload failed: $err')],
+          );
         }
-        return CallToolResult(
-          isError: true,
-          content: [
-            TextContent(
-              text: 'Hot reload failed. The app may need a full restart.',
-            ),
-          ],
-        );
-      } catch (err) {
-        logger.warning('Failed to perform hot reload', err);
-        return CallToolResult(
-          isError: true,
-          content: [TextContent(text: 'Hot reload failed: $err')],
-        );
-      }
-    },
-  );
+      },
+    )
+    ..registerTool(
+      'hot_restart',
+      description:
+          'Performs a hot restart of the Flutter app. This fully restarts the app from main() and resets all state. Use it instead of hot_reload after changes a reload cannot pick up (e.g. changes to main()/bootstrap, global singletons, or state shape). Requires the app to be running via `flutter run` and an active connection established via connect.',
+      annotations: const ToolAnnotations(title: 'Hot Restart'),
+      inputSchema: const ToolInputSchema(properties: {}),
+      callback: (args, extra) async {
+        logger.info('Performing hot restart');
+
+        try {
+          final restarted = await connector.hotRestart();
+          if (restarted) {
+            return CallToolResult(
+              content: [
+                const TextContent(text: 'Hot restart completed successfully'),
+              ],
+            );
+          }
+          return CallToolResult(
+            isError: true,
+            content: [
+              TextContent(
+                text: 'Hot restart failed or is unavailable. Make sure the '
+                    'app is running via `flutter run`.',
+              ),
+            ],
+          );
+        } catch (err) {
+          logger.warning('Failed to perform hot restart', err);
+          return CallToolResult(
+            isError: true,
+            content: [TextContent(text: 'Hot restart failed: $err')],
+          );
+        }
+      },
+    );
 }

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -449,37 +449,97 @@ class VmServiceConnector {
     }
   }
 
+  /// Performs a hot restart of the Flutter app.
+  ///
+  /// Unlike [hotReload], a hot restart fully restarts the app from `main()`
+  /// and resets all state. There is no native VM service RPC for this — it
+  /// relies on the `hotRestart` service that `flutter run` registers over the
+  /// VM service. Returns `false` if that service is not available (e.g. the
+  /// app was not launched via `flutter run`).
+  ///
+  /// On success the root isolate is replaced, so the cached isolate id is
+  /// re-resolved to the freshly started isolate before returning.
+  ///
+  /// Throws [NotConnectedException] if not connected.
+  Future<bool> hotRestart() async {
+    _ensureConnected();
+
+    _logger.info('Performing hot restart');
+
+    try {
+      final method = await waitForServiceRegistration('hotRestart');
+      if (method == null) {
+        _logger.warning(
+          'hotRestart service not registered; app must be run via flutter run',
+        );
+        return false;
+      }
+
+      final result = await _service!.callMethod(method, isolateId: _isolateId!);
+      _logger.fine('Hot restart completed: result=${result.json}');
+      final success = result.json?['type'] == 'Success';
+
+      if (success) {
+        // The previous isolate was torn down and replaced. Re-resolve the new
+        // isolate, retrying while it boots and re-registers its extensions.
+        _isolateId = await _findIsolateWithMarionetteExtensions(
+          attempts: 10,
+          delay: const Duration(milliseconds: 500),
+        );
+        _logger.info('Reconnected to isolate after hot restart: $_isolateId');
+      }
+
+      return success;
+    } catch (err) {
+      _logger.severe('Hot restart failed', err);
+      rethrow;
+    }
+  }
+
   /// Finds the first isolate that has the marionette extensions.
   ///
-  /// Throws an exception if no suitable isolate is found.
-  Future<String> _findIsolateWithMarionetteExtensions() async {
-    final vm = await _service!.getVM();
-    if (vm.isolates == null || vm.isolates!.isEmpty) {
-      throw Exception('No isolates found in the VM');
-    }
+  /// After a hot restart the root isolate is replaced and registers its
+  /// extensions asynchronously, so this polls up to [attempts] times with a
+  /// [delay] between tries before giving up.
+  ///
+  /// Throws an exception if no suitable isolate is found within the retries.
+  Future<String> _findIsolateWithMarionetteExtensions({
+    int attempts = 1,
+    Duration delay = const Duration(milliseconds: 500),
+  }) async {
+    for (var attempt = 0; attempt < attempts; attempt++) {
+      if (attempt > 0) {
+        await Future<void>.delayed(delay);
+      }
 
-    // Find the first isolate that has the marionette.getLogs extension
-    for (final isolateRef in vm.isolates!) {
-      if (isolateRef.id == null) {
+      final vm = await _service!.getVM();
+      if (vm.isolates == null || vm.isolates!.isEmpty) {
         continue;
       }
 
-      try {
-        final isolate = await _service!.getIsolate(isolateRef.id!);
-        final hasExtension = isolate.extensionRPCs?.any(
-              (ext) => ext == 'ext.flutter.marionette.getLogs',
-            ) ??
-            false;
-
-        if (hasExtension) {
-          return isolateRef.id!;
+      // Find the first isolate that has the marionette.getLogs extension
+      for (final isolateRef in vm.isolates!) {
+        if (isolateRef.id == null) {
+          continue;
         }
-      } catch (err) {
-        _logger.warning(
-          'Failed to check extensions for isolate ${isolateRef.id}',
-          err,
-        );
-        continue;
+
+        try {
+          final isolate = await _service!.getIsolate(isolateRef.id!);
+          final hasExtension = isolate.extensionRPCs?.any(
+                (ext) => ext == 'ext.flutter.marionette.getLogs',
+              ) ??
+              false;
+
+          if (hasExtension) {
+            return isolateRef.id!;
+          }
+        } catch (err) {
+          _logger.warning(
+            'Failed to check extensions for isolate ${isolateRef.id}',
+            err,
+          );
+          continue;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #75 

## What

Adds a `hot_restart` MCP tool and a `hot-restart` CLI command, mirroring the existing hot reload feature across all layers (connector, MCP tool, CLI command, server instructions, docs, tests).

Unlike hot reload — which reloads Dart code while preserving state — **hot restart fully restarts the app from `main()` and resets all state**. It's the right tool after changes a reload cannot pick up: `main()`/bootstrap edits, global singletons, or changes to state shape.

## Why

`hot_reload` was the only dev-workflow tool exposed, so an agent had no way to do a full restart without manual intervention. This closes that gap.

## How it works

- Hot restart has **no native VM Service RPC**. It relies on the `hotRestart` service that `flutter run` registers over the VM Service (analogous to how `hot_reload` resolves `reloadSources`). If that service isn't registered (app not run via `flutter run`), the tool/command returns a clear failure rather than hanging.
- **Isolate re-resolution:** a hot restart tears down the root isolate and starts a fresh one, so the connector's cached isolate id goes stale. After a successful restart the connector re-resolves the new isolate, polling (10×500ms) while it boots and re-registers its marionette extensions — so subsequent tool calls keep working without a reconnect.
- **No `marionette_flutter` changes:** hot restart re-runs `main()`, recreating the binding and re-registering all extensions. (`reassembleApplication`, the hot-reload hook, is not invoked on hot restart.)

## Changes

- `vm_service_connector.dart` — new `hotRestart()`; `_findIsolateWithMarionetteExtensions` now supports retry/polling.
- `system_tools.dart` — register `hot_restart` MCP tool alongside `hot_reload`.
- `mcp_server_runner.dart` — instructions mention `hot_restart` and when to prefer it.
- `marionette_cli` — new `hot_restart_command.dart`, registered in the runner, documented in `help-ai`.
- `README.md` — tool table row + CLI example.
- Command-registration test updated to expect `hot-restart`.

## Verification

- `dart analyze` clean (marionette_mcp, marionette_cli); `dart format` clean.
- Full unit suites pass: **marionette_cli 88**, **marionette_mcp 116** (includes updated command-registration test).
- **Not yet done:** live end-to-end against the example app (`flutter run` → `connect` → `hot_restart`, confirming state resets and the connection survives the isolate swap). Worth running before merge.