### PR TITLE
feat: add swipe command to the CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,7 @@ marionette -i my-app tap --key submit_button
 marionette -i my-app tap --text "Submit"
 marionette -i my-app enter-text --key email_field --input "test@example.com"
 marionette -i my-app scroll-to --text "Bottom Item"
+marionette -i my-app swipe --type PageView --direction left
 marionette -i my-app take-screenshots --output ./screenshot.png
 marionette -i my-app record-video --output ./recording.webm
 marionette -i my-app record-video -o ./demo.webm -d 10
@@ -84,6 +85,7 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | `double-tap` | Double tap (matchers + `--delay`). |
 | `long-press` | Long press (matchers + `--duration`). |
 | `pinch-zoom` | Pinch zoom (matchers + `--scale`, `--start-distance`). |
+| `swipe` | Swipe/drag (matchers + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
 | `enter-text` | Enter text (`--key` or `--focused`, plus `--input`). |
 | `scroll-to` | Scroll to an element (`--key` or `--text`). |
 | `press-back-button` | Simulate the system back button. |
@@ -97,5 +99,3 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | `doctor` | Check connectivity of all instances. |
 | `help-ai` | Print the AI-oriented command reference. |
 | `mcp` | Run the MCP server (`-l/--log-level`, `--log-file`, `--sse-port`). |
-
-> The `swipe` gesture is currently available via the [MCP server](./mcp-tools.md#gestures) only, not the CLI.

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -248,7 +248,7 @@ Use either element-based mode (matcher + direction) or coordinate-based mode.
     marionette -i my-app swipe --start-x 300 --start-y 400 --end-x 50 --end-y 400
 
   Output (stdout):
-    Swiped left on element matching {type: PageView}
+    Swiped left on element matching: {type: PageView}
     Swiped from (300.0, 400.0) to (50.0, 400.0)
 
 ---

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -222,6 +222,37 @@ Simulate a system back button press (Android back / iOS swipe-back).
 
 ---
 
+### swipe
+
+Swipe/drag on the app. Useful for PageView, Dismissible, Drawer, and Slider.
+Use either element-based mode (matcher + direction) or coordinate-based mode.
+
+  Requires: -i <instance> or --uri <ws-uri>
+
+  Element-based options:
+    --key <string>        Match by ValueKey<String> (most reliable)
+    --text <string>       Match by visible text content
+    --type <string>       Match by widget type name (e.g., PageView)
+    --direction <dir>     left, right, up, or down (required for this mode)
+    --distance <number>   Swipe distance in pixels (default: 200)
+
+  Coordinate-based options (all required together):
+    --start-x <number>    Start X coordinate
+    --start-y <number>    Start Y coordinate
+    --end-x <number>      End X coordinate
+    --end-y <number>      End Y coordinate
+
+  Examples:
+    marionette -i my-app swipe --type PageView --direction left
+    marionette -i my-app swipe --key carousel --direction right --distance 300
+    marionette -i my-app swipe --start-x 300 --start-y 400 --end-x 50 --end-y 400
+
+  Output (stdout):
+    Swiped left on element matching {type: PageView}
+    Swiped from (300.0, 400.0) to (50.0, 400.0)
+
+---
+
 ### scroll-to
 
 Scroll until an element becomes visible.

--- a/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
@@ -21,10 +21,13 @@ class SwipeCommand extends InstanceCommand {
         help: 'Swipe distance in pixels for element-based mode.',
         defaultsTo: '200',
       )
-      ..addOption('start-x', help: 'Start X coordinate for coordinate-based swipe.')
-      ..addOption('start-y', help: 'Start Y coordinate for coordinate-based swipe.')
+      ..addOption('start-x',
+          help: 'Start X coordinate for coordinate-based swipe.')
+      ..addOption('start-y',
+          help: 'Start Y coordinate for coordinate-based swipe.')
       ..addOption('end-x', help: 'End X coordinate for coordinate-based swipe.')
-      ..addOption('end-y', help: 'End Y coordinate for coordinate-based swipe.');
+      ..addOption('end-y',
+          help: 'End Y coordinate for coordinate-based swipe.');
   }
 
   final InstanceRegistry _registry;

--- a/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:marionette_cli/src/cli/instance_command.dart';
+import 'package:marionette_cli/src/cli/matcher_builder.dart';
+import 'package:marionette_cli/src/instance_registry.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+
+class SwipeCommand extends InstanceCommand {
+  SwipeCommand(this._registry) {
+    argParser
+      ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('text', help: 'Visible text content of the element.')
+      ..addOption('type', help: 'Widget type name (e.g., PageView).')
+      ..addOption(
+        'direction',
+        help: 'Swipe direction for element-based mode: left, right, up, down.',
+        allowed: ['left', 'right', 'up', 'down'],
+      )
+      ..addOption(
+        'distance',
+        help: 'Swipe distance in pixels for element-based mode.',
+        defaultsTo: '200',
+      )
+      ..addOption('start-x', help: 'Start X coordinate for coordinate-based swipe.')
+      ..addOption('start-y', help: 'Start Y coordinate for coordinate-based swipe.')
+      ..addOption('end-x', help: 'End X coordinate for coordinate-based swipe.')
+      ..addOption('end-y', help: 'End Y coordinate for coordinate-based swipe.');
+  }
+
+  final InstanceRegistry _registry;
+
+  @override
+  InstanceRegistry get registry => _registry;
+
+  @override
+  String get name => 'swipe';
+
+  @override
+  String get description =>
+      'Swipe/drag on an element (key, text, or type) in a direction, '
+      'or between coordinates. Useful for PageView, Dismissible, Drawer, '
+      'and Slider widgets.';
+
+  @override
+  Future<int> execute(VmServiceConnector connector) async {
+    final startX = argResults?['start-x'] as String?;
+    final startY = argResults?['start-y'] as String?;
+    final endX = argResults?['end-x'] as String?;
+    final endY = argResults?['end-y'] as String?;
+
+    final anyCoordinate =
+        startX != null || startY != null || endX != null || endY != null;
+
+    final swipeArgs = <String, dynamic>{};
+
+    if (anyCoordinate) {
+      if (startX == null || startY == null || endX == null || endY == null) {
+        usageException(
+          'Coordinate-based swipe requires all of: '
+          '--start-x, --start-y, --end-x, --end-y.',
+        );
+      }
+      _ensureNumber('--start-x', startX);
+      _ensureNumber('--start-y', startY);
+      _ensureNumber('--end-x', endX);
+      _ensureNumber('--end-y', endY);
+      swipeArgs['startX'] = startX;
+      swipeArgs['startY'] = startY;
+      swipeArgs['endX'] = endX;
+      swipeArgs['endY'] = endY;
+    } else {
+      final matcher = buildMatcherFromArgs(
+        key: argResults?['key'] as String?,
+        text: argResults?['text'] as String?,
+        type: argResults?['type'] as String?,
+      );
+      if (matcher.isEmpty) {
+        usageException(
+          'Element-based swipe requires a matcher: --key, --text, or --type. '
+          'Alternatively provide --start-x/--start-y/--end-x/--end-y for '
+          'coordinate-based swipe.',
+        );
+      }
+
+      final direction = argResults?['direction'] as String?;
+      if (direction == null) {
+        usageException(
+          'Element-based swipe requires --direction '
+          '(left, right, up, or down).',
+        );
+      }
+
+      final distance = argResults?['distance'] as String;
+      _ensureNumber('--distance', distance);
+
+      swipeArgs
+        ..addAll(matcher)
+        ..['direction'] = direction
+        ..['distance'] = distance;
+    }
+
+    final response = await connector.swipe(swipeArgs);
+    final message = response['message'] as String? ?? 'Successfully swiped';
+    stdout.writeln(message);
+    return 0;
+  }
+
+  void _ensureNumber(String flag, String value) {
+    if (double.tryParse(value) == null) {
+      usageException('$flag must be a number, got "$value".');
+    }
+  }
+}

--- a/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
@@ -54,6 +54,20 @@ class SwipeCommand extends InstanceCommand {
     final anyCoordinate =
         startX != null || startY != null || endX != null || endY != null;
 
+    final anyElement = argResults?['key'] != null ||
+        argResults?['text'] != null ||
+        argResults?['type'] != null ||
+        argResults?['direction'] != null ||
+        (argResults?.wasParsed('distance') ?? false);
+
+    if (anyCoordinate && anyElement) {
+      usageException(
+        'Cannot mix coordinate-based options '
+        '(--start-x/--start-y/--end-x/--end-y) with element-based options '
+        '(--key/--text/--type/--direction/--distance). Use one mode.',
+      );
+    }
+
     final swipeArgs = <String, dynamic>{};
 
     if (anyCoordinate) {

--- a/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
+++ b/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
@@ -18,6 +18,7 @@ import 'package:marionette_cli/src/cli/commands/press_back_button_command.dart';
 import 'package:marionette_cli/src/cli/commands/register_command.dart';
 import 'package:marionette_cli/src/cli/commands/scroll_to_command.dart';
 import 'package:marionette_cli/src/cli/commands/secondary_tap_command.dart';
+import 'package:marionette_cli/src/cli/commands/swipe_command.dart';
 import 'package:marionette_cli/src/cli/commands/take_screenshots_command.dart';
 import 'package:marionette_cli/src/cli/commands/tap_command.dart';
 import 'package:marionette_cli/src/cli/commands/unregister_command.dart';
@@ -56,6 +57,7 @@ class MarionetteCommandRunner extends CommandRunner<int> {
     addCommand(DoubleTapCommand(_registry));
     addCommand(LongPressCommand(_registry));
     addCommand(PinchZoomCommand(_registry));
+    addCommand(SwipeCommand(_registry));
     addCommand(EnterTextCommand(_registry));
     addCommand(PressBackButtonCommand(_registry));
     addCommand(ScrollToCommand(_registry));

--- a/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
+++ b/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
@@ -32,6 +32,7 @@ void main() {
         'double-tap',
         'long-press',
         'pinch-zoom',
+        'swipe',
         'enter-text',
         'press-back-button',
         'scroll-to',


### PR DESCRIPTION
## What

Adds a `swipe` command to the `marionette` CLI, bringing it on par with the MCP server.

## Why

The swipe/drag gesture was exposed via the MCP server (commit `022ff9a`) but never wired up in the CLI — even though every other gesture has a paired CLI command:

| Gesture | MCP tool | CLI command |
|---|---|---|
| tap | ✅ | ✅ |
| double-tap | ✅ | ✅ |
| secondary-tap | ✅ | ✅ |
| long-press | ✅ | ✅ |
| pinch-zoom | ✅ | ✅ |
| scroll-to | ✅ | ✅ |
| press-back-button | ✅ | ✅ |
| **swipe** | ✅ | ❌ → ✅ |

The underlying `connector.swipe(...)` and the Flutter `marionette.swipe` extension already existed — only the thin CLI command wrapper and its registration were missing. This was an oversight, not a deliberate design choice.

## Changes

- **New** `SwipeCommand`, following the `PinchZoomCommand` pattern, supporting both modes of the MCP tool:
  - **Element-based:** `--key`/`--text`/`--type` + `--direction` (left/right/up/down) + optional `--distance` (default 200)
  - **Coordinate-based:** `--start-x`/`--start-y`/`--end-x`/`--end-y` (all required together)
  - Mode-mixing and numeric validation produce usage errors consistent with existing commands.
- Registered the command in `marionette_command_runner.dart`.
- Documented `swipe` in the `help-ai` machine-readable reference and the README usage examples.

## Usage

```bash
marionette -i my-app swipe --type PageView --direction left
marionette -i my-app swipe --key carousel --direction right --distance 300
marionette -i my-app swipe --start-x 300 --start-y 400 --end-x 50 --end-y 400
```

## Testing

- `dart analyze` on all touched files: no issues.
- `marionette swipe --help` and `marionette --help` render the command correctly.
- No dedicated test added: among gesture commands only `record-video` has tests today, so adding one solely for swipe would diverge from the existing convention. Happy to start that convention if preferred.

## Notes

The `help-ai` doc and README examples were also missing `double-tap`, `long-press`, and `pinch-zoom` (which do exist as commands). Left untouched to keep this PR focused on swipe — can backfill separately if wanted.