### PR TITLE
Add Dockerfile for Docker MCP Registry submission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# The Dockerfile installs marionette_mcp from pub.dev and copies nothing from the
+# build context, so exclude everything to keep the context empty and the build fast.
+*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM dart:stable
+
+# Version of marionette_mcp to install from pub.dev.
+# Bump this (or override with --build-arg) to track releases; pinning keeps the
+# image reproducible for a given Docker MCP Registry commit.
+ARG MARIONETTE_VERSION=0.5.0
+
+RUN dart pub global activate marionette_mcp ${MARIONETTE_VERSION}
+ENV PATH="${PATH}:/root/.pub-cache/bin"
+
+LABEL org.opencontainers.image.title="marionette_mcp" \
+      org.opencontainers.image.description="MCP server that lets AI agents inspect and interact with running Flutter apps." \
+      org.opencontainers.image.source="https://github.com/leancodepl/marionette_mcp" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Default stdio transport — the form the Docker MCP gateway launches.
+ENTRYPOINT ["marionette_mcp"]


### PR DESCRIPTION
## What

Adds a `Dockerfile` and `.dockerignore` so `marionette_mcp` can be built as a container image and submitted to the [Docker MCP Registry](https://github.com/docker/mcp-registry) (Docker Desktop's MCP Toolkit + hub.docker.com/mcp).

Closes #66.

## How it works

- Based on `dart:stable` (there is no `dart:stable-slim` tag — the original request assumed one).
- Installs the published `marionette_mcp` package from pub.dev via `dart pub global activate`. The version is pinned through an overridable build arg (`--build-arg MARIONETTE_VERSION=x.y.z`, default `0.5.0`) so the image is reproducible for a given registry commit.
- `ENTRYPOINT` runs the server over **stdio** — the form the Docker MCP gateway uses to launch local servers (`docker run -i ...`).

## Verification

Built and smoke-tested locally:

- `docker build -t marionette-mcp .` → succeeds, `Activated marionette_mcp 0.5.0`
- `docker run --rm -i marionette-mcp --version` → `marionette_mcp version: 0.5.0`
- `docker run --rm -i marionette-mcp --help` → full usage
- Piped an MCP `initialize` request over stdin → got a valid JSON-RPC result with `serverInfo: {name: "marionette-mcp", version: "0.5.0"}`

## ⚠️ Networking caveat (not addressed here)

Inside the container, `127.0.0.1` is the container's own loopback, **not** the host. The `connect` tool is normally given the `ws://127.0.0.1:<port>/ws` URI that `flutter run` prints, which will not resolve from inside the container. Users must instead point `connect` at `host.docker.internal:<port>` (Docker Desktop; plus `--add-host=host.docker.internal:host-gateway` on Linux) or run with `--network host` on Linux.

This needs documenting (e.g. a `docs/docker.md` and/or the registry `server.yaml` description) before the image is widely promoted. Left out of this PR to keep scope minimal.

## Follow-up (separate, not in this repo)

The actual registry listing is a PR to `docker/mcp-registry` (`task wizard` against this Dockerfile → generates `servers/marionette_mcp/server.yaml` → PR for Docker team review).
