### PR TITLE
fix: exit stdio server on stdin EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add the `secondary_tap` tool (plus the `secondary-tap` CLI command) for right mouse button clicks on desktop. It dispatches a mouse pointer with the secondary button pressed, triggering Flutter's `onSecondaryTap` (e.g. context menus). Touch `tap` is unchanged.
 - Surface `Semantics(label:)` and `Semantics(value:)` in `get_interactive_elements`. Widgets that render via inline-span trees (`Text.rich`, custom-painted text, etc.) where `toPlainText()` loses structure can now be made fully readable by agents through an explicit accessibility annotation, without altering the rendered widget.
+- Exit the stdio server when its stdin reaches EOF. Previously the process only stopped on `SIGINT`/`SIGTERM`, so when an MCP host closed the connection without sending a signal (e.g. the host was killed and the server reparented to init), the process lingered idle indefinitely and such orphans accumulated over time.
 
 # 0.5.0
 

--- a/packages/marionette_mcp/lib/src/compat/copilot_stdio_server_transport.dart
+++ b/packages/marionette_mcp/lib/src/compat/copilot_stdio_server_transport.dart
@@ -16,17 +16,24 @@ import 'package:mcp_dart/mcp_dart.dart';
 /// This transport rewrites those fields to `true` before handing the message to
 /// `JsonRpcMessage.fromJson`, keeping behavior backward compatible.
 final class CopilotCompatStdioServerTransport implements Transport {
-  CopilotCompatStdioServerTransport({io.Stdin? stdin, io.IOSink? stdout})
+  CopilotCompatStdioServerTransport(
+      {Stream<List<int>>? stdin, io.IOSink? stdout})
       : _stdin = stdin ?? io.stdin,
         _stdout = stdout ?? io.stdout,
         _logger = logging.Logger('CopilotCompatStdioServerTransport');
 
-  final io.Stdin _stdin;
+  final Stream<List<int>> _stdin;
   final io.IOSink _stdout;
   final logging.Logger _logger;
 
   bool _started = false;
   StreamSubscription<String>? _linesSubscription;
+  final Completer<void> _closed = Completer<void>();
+
+  /// Completes when the transport closes — either via [close] or because the
+  /// client disconnected (stdin reached EOF). Lets the server shut down when
+  /// the host closes the connection without sending a POSIX signal.
+  Future<void> get done => _closed.future;
 
   @override
   void Function()? onclose;
@@ -147,6 +154,10 @@ final class CopilotCompatStdioServerTransport implements Transport {
 
   @override
   Future<void> close() async {
+    // Complete [done] on the first close, even if start() was never called, so
+    // callers awaiting it are always released.
+    if (!_closed.isCompleted) _closed.complete();
+
     if (!_started) return;
 
     await _linesSubscription?.cancel();

--- a/packages/marionette_mcp/lib/src/mcp_server_runner.dart
+++ b/packages/marionette_mcp/lib/src/mcp_server_runner.dart
@@ -103,8 +103,19 @@ Future<int> _runStdioServer(McpServer server) async {
     return 1;
   }
 
-  final signal = await ExitSignal().wait;
-  logger.info('Received ${signal.name}, stopping');
+  // Stop on either an OS signal (SIGINT/SIGTERM) or the client closing the
+  // connection (stdin EOF). MCP hosts shut a stdio server down by closing its
+  // stdin; honoring that is required so the process exits when the host goes
+  // away without sending a signal (e.g. the host is killed and this process is
+  // reparented to init), instead of lingering idle forever.
+  // See https://github.com/leancodepl/marionette_mcp/issues/84.
+  final exitSignal = ExitSignal();
+  final reason = await Future.any([
+    exitSignal.wait.then((signal) => 'Received ${signal.name}'),
+    transport.done.then((_) => 'stdin closed'),
+  ]);
+  exitSignal.dispose();
+  logger.info('$reason, stopping');
 
   await server.close();
   await transport.close();
@@ -159,6 +170,11 @@ class ExitSignal {
   late final StreamSubscription<ProcessSignal> _sigintSubscription;
 
   Future<ProcessSignal> get wait => _completer.future;
+
+  /// Cancels the signal subscriptions. Must be called when shutting down for a
+  /// reason other than a caught signal (e.g. stdin EOF); otherwise the watch
+  /// subscriptions keep the Dart event loop alive and the process never exits.
+  void dispose() => _cleanup();
 
   void _handleSignal(ProcessSignal signal) {
     if (!_completer.isCompleted) {

--- a/packages/marionette_mcp/test/compat/copilot_stdio_server_transport_test.dart
+++ b/packages/marionette_mcp/test/compat/copilot_stdio_server_transport_test.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:marionette_mcp/src/compat/copilot_stdio_server_transport.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CopilotCompatStdioServerTransport', () {
+    test('done completes (and onclose fires) when stdin reaches EOF', () async {
+      final stdin = StreamController<List<int>>();
+      final transport = CopilotCompatStdioServerTransport(stdin: stdin.stream);
+
+      final onCloseFired = Completer<void>();
+      transport.onclose = onCloseFired.complete;
+
+      var done = false;
+      unawaited(transport.done.then((_) => done = true));
+
+      await transport.start();
+      expect(done, isFalse);
+
+      // The MCP host closing the connection surfaces as stdin EOF.
+      await stdin.close();
+      await transport.done.timeout(const Duration(seconds: 5));
+      await onCloseFired.future.timeout(const Duration(seconds: 5));
+
+      expect(done, isTrue);
+    });
+
+    test('done completes when close() is called after start()', () async {
+      final stdin = StreamController<List<int>>();
+      final transport = CopilotCompatStdioServerTransport(stdin: stdin.stream);
+
+      await transport.start();
+      await transport.close();
+
+      await transport.done.timeout(const Duration(seconds: 5));
+    });
+
+    test('done completes even when close() is called before start()', () async {
+      final transport = CopilotCompatStdioServerTransport(
+        stdin: StreamController<List<int>>().stream,
+      );
+
+      await transport.close();
+
+      await transport.done.timeout(const Duration(seconds: 5));
+    });
+  });
+}

--- a/packages/marionette_mcp/test/compat/stdio_eof_exit_integration_test.dart
+++ b/packages/marionette_mcp/test/compat/stdio_eof_exit_integration_test.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('stdio server process exits when stdin reaches EOF', () async {
+    final process = await Process.start(
+      Platform.resolvedExecutable,
+      ['run', 'bin/marionette_mcp.dart'],
+    );
+    unawaited(process.stdout.drain<void>());
+    unawaited(process.stderr.drain<void>());
+
+    // Closing the child's stdin is how an MCP host signals shutdown.
+    await process.stdin.close();
+
+    final exitCode = await process.exitCode.timeout(
+      const Duration(seconds: 30),
+      onTimeout: () {
+        process.kill(ProcessSignal.sigkill);
+        fail('Server did not exit within 30s of stdin closing');
+      },
+    );
+
+    expect(exitCode, 0);
+  });
+}


### PR DESCRIPTION
## Problem

The stdio MCP server does not exit when its **stdin reaches EOF**. When the MCP host goes away without sending `SIGTERM` — the host is `SIGKILL`ed, the IDE/terminal closes the connection, or the host crashes — the `marionette_mcp` process is reparented to `init`/`launchd` (`ppid 1`) and keeps running idle **forever**. These orphans accumulate; in one case **282 orphaned `marionette_mcp` processes** had piled up over ~7 weeks of normal use (Claude Code as the host on macOS).

Fixes #84.

## Root cause

`_runStdioServer` blocks on a signal-only future:

```dart
final signal = await ExitSignal().wait;   // completes ONLY on SIGINT / SIGTERM
```

`CopilotCompatStdioServerTransport` already detects stdin EOF (`_onStdinDone → close()`), but nothing reacts to it, and `ExitSignal` keeps `ProcessSignal.sigterm/sigint.watch()` subscriptions alive — which keep the Dart event loop alive. So on stdin EOF the transport closes but the process never exits.

Per the stdio MCP lifecycle, a server should shut down when the client closes the connection (stdin EOF), not only on POSIX signals.

## Change

- Expose a `done` future on `CopilotCompatStdioServerTransport` that completes when the transport closes (via `close()` or stdin EOF).
- In `_runStdioServer`, stop on whichever happens first — an OS signal **or** transport close — then `dispose()` the `ExitSignal` subscriptions so the event loop can drain and the process exits.
- The transport's injectable stdin is now typed `Stream<List<int>>` (was `io.Stdin`) purely so the EOF path is unit-testable; the runtime default is still `io.stdin`.

No public MCP API or tool behavior changes. SIGINT/SIGTERM shutdown is unchanged.

## Verification

- `dart analyze` — no issues (whole package).
- New unit tests in `test/compat/copilot_stdio_server_transport_test.dart` cover `done` completing on stdin EOF (and `onclose` firing), and on explicit `close()` before/after `start()`.
- Manual, compiled server:
  - stdin EOF (`</dev/null`): exits `0` in ~1s — logs `Server started → stdin closed, stopping → Stopped`. (Before this change it hangs indefinitely.)
  - `SIGTERM`: still exits `0` — logs `Received SIGTERM, stopping → Stopped`.
