### PR TITLE
feat: add keyboard input support (press_key)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,6 +88,7 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | `pinch-zoom` | Pinch zoom (matchers + `--scale`, `--start-distance`). |
 | `swipe` | Swipe/drag (matchers + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
 | `enter-text` | Enter text (`--key` or `--focused`, plus `--input`). |
+| `press-key` | Press a key on the focused element (`--key`, optional `--modifiers`). Real key event: enter to submit, tab to move focus, escape, arrows/backspace to edit, or `--modifiers control` for shortcuts. |
 | `scroll-to` | Scroll to an element (`--key` or `--text`). |
 | `press-back-button` | Simulate the system back button. |
 | `take-screenshots` | Capture a screenshot (`-o/--output`, `--open`). |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -37,6 +37,9 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 | Tool | Description |
 | --- | --- |
 | `enter_text` | Enter text into a field. Target by `key`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required. |
+| `press_key` | Press a key on the focused element, producing a real key event (unlike `enter_text`). `key` is a named key (`enter`, `tab`, `escape`, `backspace`, `delete`, `space`, `arrowUp`/`arrowDown`/`arrowLeft`/`arrowRight`, `home`, `end`, `pageUp`, `pageDown`) or a single character `a`-`z`/`0`-`9`. Optional `modifiers` (comma-separated: `control`, `shift`, `alt`, `meta`) for shortcuts like `control,a`. Focus a target first via `tap`. |
+
+> **Platform note for `press_key`:** key events reach `Focus`, `Shortcuts`/`Actions`, and focus traversal on every platform — so app shortcuts, submit (`enter`), dismiss (`escape`), and button activation work everywhere. In-field text editing with `backspace`/arrows/characters relies on Flutter's hardware-key text-editing actions, which are wired on **desktop and web**; on **mobile (iOS/Android)** `TextField` editing is owned by the platform keyboard, so use `enter_text` to change a field's value there.
 
 ### Custom extensions
 

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -199,6 +199,40 @@ Enter text into a text field.
 
 ---
 
+### press-key
+
+Press a keyboard key on the currently focused element. Unlike enter-text
+(which rewrites a field's value), this sends a real key event through the focus
+system, so onSubmitted, Shortcuts/Actions, and focus traversal all respond.
+The key goes to whatever has focus — focus a target first (e.g. with tap).
+
+  Requires: -i <instance> or --uri <ws-uri>
+
+  Options:
+    --key <string>        Key to press (mandatory). Named keys: enter, tab,
+                          escape, backspace, delete, space, arrowUp, arrowDown,
+                          arrowLeft, arrowRight, home, end, pageUp, pageDown.
+                          Also a single character a-z or 0-9.
+    --modifiers <list>    Comma-separated modifiers to hold: control, shift,
+                          alt, meta. On macOS use meta for the Command key.
+
+  Examples:
+    marionette -i my-app press-key --key enter
+    marionette -i my-app press-key --key tab
+    marionette -i my-app press-key --key a --modifiers control
+    marionette --uri ws://127.0.0.1:8181/ws press-key --key arrowDown
+
+  Output (stdout):
+    Pressed key: enter
+    Pressed key: control+a
+
+  Notes:
+    - A character is only typed for an unmodified (or shift-only) printable
+      key; control+a activates select-all rather than typing "a".
+    - Modifier combos match Flutter Shortcuts/SingleActivator.
+
+---
+
 ### press-back-button
 
 Simulate a system back button press (Android back / iOS swipe-back).

--- a/packages/marionette_cli/lib/src/cli/commands/press_key_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/press_key_command.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:marionette_cli/src/cli/instance_command.dart';
+import 'package:marionette_cli/src/instance_registry.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+
+class PressKeyCommand extends InstanceCommand {
+  PressKeyCommand(this._registry) {
+    argParser
+      ..addOption(
+        'key',
+        help: 'Key to press: a named key (enter, tab, escape, backspace, '
+            'delete, space, arrowUp/arrowDown/arrowLeft/arrowRight, home, end, '
+            'pageUp, pageDown) or a single character a-z / 0-9.',
+        mandatory: true,
+      )
+      ..addOption(
+        'modifiers',
+        help: 'Comma-separated modifiers to hold: control, shift, alt, meta '
+            '(e.g. "control" or "control,shift"). On macOS use meta for Command.',
+      );
+  }
+
+  final InstanceRegistry _registry;
+
+  @override
+  InstanceRegistry get registry => _registry;
+
+  @override
+  String get name => 'press-key';
+
+  @override
+  String get description =>
+      'Press a keyboard key on the focused element. Produces a real key event '
+      '(unlike enter-text): submit with enter, move focus with tab, dismiss '
+      'with escape, edit with backspace/arrows, or trigger shortcuts with '
+      'modifiers (e.g. --key a --modifiers control).';
+
+  @override
+  Future<int> execute(VmServiceConnector connector) async {
+    final key = argResults!['key'] as String;
+    final modifiers = argResults?['modifiers'] as String?;
+
+    final response = await connector.pressKey(key, modifiers: modifiers);
+    final message =
+        response['message'] as String? ?? 'Successfully pressed key';
+    stdout.writeln(message);
+    return 0;
+  }
+}

--- a/packages/marionette_cli/lib/src/cli/commands/press_key_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/press_key_command.dart
@@ -37,6 +37,18 @@ class PressKeyCommand extends InstanceCommand {
       'modifiers (e.g. --key a --modifiers control).';
 
   @override
+  Future<int> run() {
+    // Validate before InstanceCommand.run() connects, so a bad modifier is a
+    // usage error (exit 64) that doesn't require a running app.
+    final modifierError =
+        invalidModifiersError(argResults?['modifiers'] as String?);
+    if (modifierError != null) {
+      usageException(modifierError);
+    }
+    return super.run();
+  }
+
+  @override
   Future<int> execute(VmServiceConnector connector) async {
     final key = argResults!['key'] as String;
     final modifiers = argResults?['modifiers'] as String?;

--- a/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
+++ b/packages/marionette_cli/lib/src/cli/marionette_command_runner.dart
@@ -16,6 +16,7 @@ import 'package:marionette_cli/src/cli/commands/mcp_command.dart';
 import 'package:marionette_cli/src/cli/commands/pinch_zoom_command.dart';
 import 'package:marionette_cli/src/cli/commands/record_video_command.dart';
 import 'package:marionette_cli/src/cli/commands/press_back_button_command.dart';
+import 'package:marionette_cli/src/cli/commands/press_key_command.dart';
 import 'package:marionette_cli/src/cli/commands/register_command.dart';
 import 'package:marionette_cli/src/cli/commands/scroll_to_command.dart';
 import 'package:marionette_cli/src/cli/commands/secondary_tap_command.dart';
@@ -60,6 +61,7 @@ class MarionetteCommandRunner extends CommandRunner<int> {
     addCommand(PinchZoomCommand(_registry));
     addCommand(SwipeCommand(_registry));
     addCommand(EnterTextCommand(_registry));
+    addCommand(PressKeyCommand(_registry));
     addCommand(PressBackButtonCommand(_registry));
     addCommand(ScrollToCommand(_registry));
     addCommand(ScreenshotCommand(_registry));

--- a/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
+++ b/packages/marionette_cli/test/cli/marionette_command_runner_test.dart
@@ -34,6 +34,7 @@ void main() {
         'pinch-zoom',
         'swipe',
         'enter-text',
+        'press-key',
         'press-back-button',
         'scroll-to',
         'take-screenshots',

--- a/packages/marionette_flutter/example/lib/main.dart
+++ b/packages/marionette_flutter/example/lib/main.dart
@@ -18,27 +18,11 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
@@ -48,15 +32,6 @@ class MyApp extends StatelessWidget {
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
 
   final String title;
 
@@ -72,31 +47,15 @@ class _MyHomePageState extends State<MyHomePage> {
   void _incrementCounter() {
     _logger.info('Incrementing counter, from $_counter');
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
       _counter++;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
         title: Text(widget.title),
       ),
       // The arrowUp shortcut demonstrates press_key: an autofocused
@@ -113,22 +72,7 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Focus(
           autofocus: true,
           child: Center(
-            // Center is a layout widget. It takes a single child and positions
-            // it in the middle of the parent.
             child: Column(
-              // Column is also a layout widget. It takes a list of children and
-              // arranges them vertically. By default, it sizes itself to fit its
-              // children horizontally, and tries to be as tall as its parent.
-              //
-              // Column has various properties to control how it sizes itself and
-              // how it positions its children. Here we use mainAxisAlignment to
-              // center the children vertically; the main axis here is the vertical
-              // axis because Columns are vertical (the cross axis would be
-              // horizontal).
-              //
-              // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-              // action in the IDE, or press "p" in the console), to see the
-              // wireframe for each widget.
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 const Text('You have pushed the button this many times:'),

--- a/packages/marionette_flutter/example/lib/main.dart
+++ b/packages/marionette_flutter/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 
@@ -98,31 +99,59 @@ class _MyHomePageState extends State<MyHomePage> {
         // the App.build method, and use it to set our appbar title.
         title: Text(widget.title),
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+      // The arrowUp shortcut demonstrates press_key: an autofocused
+      // CallbackShortcuts increments the counter whenever the Up arrow is
+      // pressed, so `marionette press-key --key arrowUp` works end-to-end.
+      body: CallbackShortcuts(
+        bindings: {
+          const SingleActivator(LogicalKeyboardKey.arrowUp): _incrementCounter,
+          // Modifier-gated: only control+arrowDown fires (plain arrowDown does
+          // nothing), so press_key modifiers can be verified end-to-end.
+          const SingleActivator(LogicalKeyboardKey.arrowDown, control: true):
+              () => setState(() => _counter += 10),
+        },
+        child: Focus(
+          autofocus: true,
+          child: Center(
+            // Center is a layout widget. It takes a single child and positions
+            // it in the middle of the parent.
+            child: Column(
+              // Column is also a layout widget. It takes a list of children and
+              // arranges them vertically. By default, it sizes itself to fit its
+              // children horizontally, and tries to be as tall as its parent.
+              //
+              // Column has various properties to control how it sizes itself and
+              // how it positions its children. Here we use mainAxisAlignment to
+              // center the children vertically; the main axis here is the vertical
+              // axis because Columns are vertical (the cross axis would be
+              // horizontal).
+              //
+              // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
+              // action in the IDE, or press "p" in the console), to see the
+              // wireframe for each widget.
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Text('You have pushed the button this many times:'),
+                Text(
+                  '$_counter',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 32,
+                    vertical: 24,
+                  ),
+                  child: TextField(
+                    key: const ValueKey('demo_field'),
+                    decoration: const InputDecoration(
+                      labelText: 'Type something',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
       floatingActionButton: FloatingActionButton(

--- a/packages/marionette_flutter/lib/src/binding/extensions/keyboard_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/keyboard_extensions.dart
@@ -1,0 +1,45 @@
+import 'package:marionette_flutter/src/binding/marionette_extension_result.dart';
+import 'package:marionette_flutter/src/binding/register_extension_internal.dart';
+import 'package:marionette_flutter/src/services/keyboard_simulator.dart';
+
+/// Registers keyboard `marionette.*` extensions: pressKey.
+void registerKeyboardExtensions({
+  required KeyboardSimulator keyboardSimulator,
+}) {
+  registerInternalMarionetteExtension(
+    name: 'marionette.pressKey',
+    callback: (params) async {
+      final key = params['key'];
+      if (key == null || key.isEmpty) {
+        return MarionetteExtensionResult.invalidParams(
+          'Missing required parameter: key',
+        );
+      }
+
+      final modifiers = _parseModifiers(params['modifiers']);
+
+      // KeyboardSimulator throws ArgumentError for an unknown key or modifier,
+      // which register_extension_internal maps to an invalidParams response.
+      await keyboardSimulator.pressKey(key, modifiers: modifiers);
+
+      final description =
+          modifiers.isEmpty ? key : '${modifiers.join('+')}+$key';
+      return MarionetteExtensionResult.success({
+        'message': 'Pressed key: $description',
+      });
+    },
+  );
+}
+
+/// Parses the comma-separated `modifiers` parameter into a set of lower-case
+/// modifier names, ignoring blank entries.
+Set<String> _parseModifiers(String? raw) {
+  if (raw == null || raw.trim().isEmpty) {
+    return const {};
+  }
+  return raw
+      .split(',')
+      .map((modifier) => modifier.trim().toLowerCase())
+      .where((modifier) => modifier.isNotEmpty)
+      .toSet();
+}

--- a/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/extensions/gesture_extensions.dart';
 import 'package:marionette_flutter/src/binding/extensions/info_extensions.dart';
+import 'package:marionette_flutter/src/binding/extensions/keyboard_extensions.dart';
 import 'package:marionette_flutter/src/binding/extensions/media_extensions.dart';
 import 'package:marionette_flutter/src/binding/extensions/text_extensions.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
@@ -10,6 +11,7 @@ import 'package:marionette_flutter/src/binding/register_extension_internal.dart'
 import 'package:marionette_flutter/src/services/create_screencast_server.dart';
 import 'package:marionette_flutter/src/services/element_tree_finder.dart';
 import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
+import 'package:marionette_flutter/src/services/keyboard_simulator.dart';
 import 'package:marionette_flutter/src/services/log_store.dart';
 import 'package:marionette_flutter/src/services/screencast_server.dart';
 import 'package:marionette_flutter/src/services/screencast_service.dart';
@@ -45,6 +47,7 @@ class MarionetteBinding extends WidgetsFlutterBinding {
   // Service instances
   late final ElementTreeFinder _elementTreeFinder;
   late final GestureDispatcher _gestureDispatcher;
+  late final KeyboardSimulator _keyboardSimulator;
   LogStore? _logStore;
   late final ScreenshotService _screenshotService;
   late final ScrollSimulator _scrollSimulator;
@@ -73,6 +76,7 @@ class MarionetteBinding extends WidgetsFlutterBinding {
     );
     _scrollSimulator = ScrollSimulator(_gestureDispatcher, _widgetFinder);
     _textInputSimulator = TextInputSimulator(_widgetFinder);
+    _keyboardSimulator = KeyboardSimulator();
 
     if (configuration.logCollector != null) {
       _logStore = LogStore();
@@ -97,6 +101,9 @@ class MarionetteBinding extends WidgetsFlutterBinding {
     registerTextExtensions(
       textInputSimulator: _textInputSimulator,
       configuration: configuration,
+    );
+    registerKeyboardExtensions(
+      keyboardSimulator: _keyboardSimulator,
     );
     registerMediaExtensions(
       screenshotService: _screenshotService,

--- a/packages/marionette_flutter/lib/src/services/keyboard_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/keyboard_simulator.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// A resolved key: the physical/logical pair plus the base character it
+/// produces (lower-case, or `null` for non-printable keys like Enter/Tab).
+typedef _KeyDef = ({
+  PhysicalKeyboardKey physical,
+  LogicalKeyboardKey logical,
+  String? character,
+});
+
+/// Simulates hardware key presses against the currently focused element.
+///
+/// Unlike [TextInputSimulator], which rewrites a field's value directly, this
+/// produces real [KeyEvent]s that flow through [HardwareKeyboard] and the
+/// focus system. That lets `Focus.onKeyEvent`, `Shortcuts`/`Actions`, focus
+/// traversal (Tab), and editing intents (arrows, Backspace, Enter) all respond
+/// exactly as they would to a physical keyboard.
+class KeyboardSimulator {
+  KeyboardSimulator();
+
+  // KeyData/KeyEvent timestamps must be monotonically increasing. Real
+  // timestamps don't matter for dispatch, so a simple counter suffices.
+  int _timeStampMicros = 0;
+
+  /// Presses [keyName] once (down then up), optionally with [modifiers] held
+  /// for the duration of the press.
+  ///
+  /// [keyName] is matched case-insensitively against [supportedKeyNames] (and
+  /// single characters `a`-`z` / `0`-`9`). [modifiers] is any subset of
+  /// `control`, `shift`, `alt`, `meta`.
+  ///
+  /// Throws [ArgumentError] for an unknown key or modifier; the extension layer
+  /// turns that into an `invalidParams` response.
+  Future<void> pressKey(
+    String keyName, {
+    Set<String> modifiers = const {},
+  }) async {
+    final keyDef = _resolveKey(keyName);
+    if (keyDef == null) {
+      throw ArgumentError(
+        'Unknown key "$keyName". Supported keys: '
+        '${supportedKeyNames.join(', ')}, plus single characters a-z and 0-9.',
+      );
+    }
+
+    final modifierDefs = <_KeyDef>[];
+    var hasShift = false;
+    var hasNonShiftModifier = false;
+    for (final modifier in modifiers) {
+      final normalized = modifier.toLowerCase();
+      final def = _modifierKeys[normalized];
+      if (def == null) {
+        throw ArgumentError(
+          'Unknown modifier "$modifier". Supported modifiers: '
+          '${_modifierKeys.keys.join(', ')}.',
+        );
+      }
+      modifierDefs.add(def);
+      if (normalized == 'shift') {
+        hasShift = true;
+      } else {
+        hasNonShiftModifier = true;
+      }
+    }
+
+    // A character is only delivered for an unmodified (or shift-only) printable
+    // key — Ctrl+A must not also type "a".
+    String? character;
+    if (!hasNonShiftModifier && keyDef.character != null) {
+      character =
+          hasShift ? keyDef.character!.toUpperCase() : keyDef.character;
+    }
+
+    // Press modifiers, then the key down/up, then release modifiers in reverse
+    // so the keyboard never ends a press with a key still logically held.
+    for (final modifier in modifierDefs) {
+      _dispatch(_downEvent(modifier, character: null));
+    }
+    _dispatch(_downEvent(keyDef, character: character));
+    _dispatch(_upEvent(keyDef));
+    for (final modifier in modifierDefs.reversed) {
+      _dispatch(_upEvent(modifier));
+    }
+
+    WidgetsBinding.instance.scheduleFrame();
+  }
+
+  KeyEvent _downEvent(_KeyDef def, {required String? character}) => KeyDownEvent(
+        physicalKey: def.physical,
+        logicalKey: def.logical,
+        character: character,
+        timeStamp: Duration(microseconds: _timeStampMicros++),
+      );
+
+  KeyEvent _upEvent(_KeyDef def) => KeyUpEvent(
+        physicalKey: def.physical,
+        logicalKey: def.logical,
+        timeStamp: Duration(microseconds: _timeStampMicros++),
+      );
+
+  void _dispatch(KeyEvent event) {
+    // Updates the pressed-key state and notifies HardwareKeyboard handlers.
+    HardwareKeyboard.instance.handleKeyEvent(event);
+    // FocusManager routes key events to Focus/Shortcuts via keyMessageHandler;
+    // there is no non-deprecated injection path for this yet.
+    // ignore: deprecated_member_use
+    ServicesBinding.instance.keyEventManager.keyMessageHandler
+        // ignore: deprecated_member_use
+        ?.call(KeyMessage(<KeyEvent>[event], null));
+  }
+
+  _KeyDef? _resolveKey(String name) {
+    final lower = name.toLowerCase();
+
+    final named = _namedKeys[lower];
+    if (named != null) {
+      return named;
+    }
+
+    if (lower.length == 1) {
+      final code = lower.codeUnitAt(0);
+      // Logical key ids for letters and digits are their lower-case ASCII
+      // code points (e.g. 'a' == 0x61, '0' == 0x30).
+      if (code >= 0x61 && code <= 0x7a) {
+        return (
+          physical: _letterPhysicalKeys[lower]!,
+          logical: LogicalKeyboardKey(code),
+          character: lower,
+        );
+      }
+      if (code >= 0x30 && code <= 0x39) {
+        return (
+          physical: _digitPhysicalKeys[lower]!,
+          logical: LogicalKeyboardKey(code),
+          character: lower,
+        );
+      }
+    }
+
+    return null;
+  }
+
+  /// All explicitly named keys this simulator understands (in addition to
+  /// single characters `a`-`z` and `0`-`9`).
+  static List<String> get supportedKeyNames =>
+      _namedKeys.keys.toList(growable: false);
+}
+
+const Map<String, _KeyDef> _namedKeys = {
+  'enter': (
+    physical: PhysicalKeyboardKey.enter,
+    logical: LogicalKeyboardKey.enter,
+    character: null,
+  ),
+  'tab': (
+    physical: PhysicalKeyboardKey.tab,
+    logical: LogicalKeyboardKey.tab,
+    character: null,
+  ),
+  'escape': (
+    physical: PhysicalKeyboardKey.escape,
+    logical: LogicalKeyboardKey.escape,
+    character: null,
+  ),
+  'backspace': (
+    physical: PhysicalKeyboardKey.backspace,
+    logical: LogicalKeyboardKey.backspace,
+    character: null,
+  ),
+  'delete': (
+    physical: PhysicalKeyboardKey.delete,
+    logical: LogicalKeyboardKey.delete,
+    character: null,
+  ),
+  'space': (
+    physical: PhysicalKeyboardKey.space,
+    logical: LogicalKeyboardKey.space,
+    character: ' ',
+  ),
+  'arrowup': (
+    physical: PhysicalKeyboardKey.arrowUp,
+    logical: LogicalKeyboardKey.arrowUp,
+    character: null,
+  ),
+  'arrowdown': (
+    physical: PhysicalKeyboardKey.arrowDown,
+    logical: LogicalKeyboardKey.arrowDown,
+    character: null,
+  ),
+  'arrowleft': (
+    physical: PhysicalKeyboardKey.arrowLeft,
+    logical: LogicalKeyboardKey.arrowLeft,
+    character: null,
+  ),
+  'arrowright': (
+    physical: PhysicalKeyboardKey.arrowRight,
+    logical: LogicalKeyboardKey.arrowRight,
+    character: null,
+  ),
+  'home': (
+    physical: PhysicalKeyboardKey.home,
+    logical: LogicalKeyboardKey.home,
+    character: null,
+  ),
+  'end': (
+    physical: PhysicalKeyboardKey.end,
+    logical: LogicalKeyboardKey.end,
+    character: null,
+  ),
+  'pageup': (
+    physical: PhysicalKeyboardKey.pageUp,
+    logical: LogicalKeyboardKey.pageUp,
+    character: null,
+  ),
+  'pagedown': (
+    physical: PhysicalKeyboardKey.pageDown,
+    logical: LogicalKeyboardKey.pageDown,
+    character: null,
+  ),
+};
+
+/// Modifier name → the left-hand physical/logical key used to hold it.
+/// `HardwareKeyboard.isControlPressed` (etc.) treats the left key as the
+/// modifier being down, which is what `Shortcuts`/`SingleActivator` check.
+const Map<String, _KeyDef> _modifierKeys = {
+  'control': (
+    physical: PhysicalKeyboardKey.controlLeft,
+    logical: LogicalKeyboardKey.controlLeft,
+    character: null,
+  ),
+  'shift': (
+    physical: PhysicalKeyboardKey.shiftLeft,
+    logical: LogicalKeyboardKey.shiftLeft,
+    character: null,
+  ),
+  'alt': (
+    physical: PhysicalKeyboardKey.altLeft,
+    logical: LogicalKeyboardKey.altLeft,
+    character: null,
+  ),
+  'meta': (
+    physical: PhysicalKeyboardKey.metaLeft,
+    logical: LogicalKeyboardKey.metaLeft,
+    character: null,
+  ),
+};
+
+const Map<String, PhysicalKeyboardKey> _letterPhysicalKeys = {
+  'a': PhysicalKeyboardKey.keyA,
+  'b': PhysicalKeyboardKey.keyB,
+  'c': PhysicalKeyboardKey.keyC,
+  'd': PhysicalKeyboardKey.keyD,
+  'e': PhysicalKeyboardKey.keyE,
+  'f': PhysicalKeyboardKey.keyF,
+  'g': PhysicalKeyboardKey.keyG,
+  'h': PhysicalKeyboardKey.keyH,
+  'i': PhysicalKeyboardKey.keyI,
+  'j': PhysicalKeyboardKey.keyJ,
+  'k': PhysicalKeyboardKey.keyK,
+  'l': PhysicalKeyboardKey.keyL,
+  'm': PhysicalKeyboardKey.keyM,
+  'n': PhysicalKeyboardKey.keyN,
+  'o': PhysicalKeyboardKey.keyO,
+  'p': PhysicalKeyboardKey.keyP,
+  'q': PhysicalKeyboardKey.keyQ,
+  'r': PhysicalKeyboardKey.keyR,
+  's': PhysicalKeyboardKey.keyS,
+  't': PhysicalKeyboardKey.keyT,
+  'u': PhysicalKeyboardKey.keyU,
+  'v': PhysicalKeyboardKey.keyV,
+  'w': PhysicalKeyboardKey.keyW,
+  'x': PhysicalKeyboardKey.keyX,
+  'y': PhysicalKeyboardKey.keyY,
+  'z': PhysicalKeyboardKey.keyZ,
+};
+
+const Map<String, PhysicalKeyboardKey> _digitPhysicalKeys = {
+  '0': PhysicalKeyboardKey.digit0,
+  '1': PhysicalKeyboardKey.digit1,
+  '2': PhysicalKeyboardKey.digit2,
+  '3': PhysicalKeyboardKey.digit3,
+  '4': PhysicalKeyboardKey.digit4,
+  '5': PhysicalKeyboardKey.digit5,
+  '6': PhysicalKeyboardKey.digit6,
+  '7': PhysicalKeyboardKey.digit7,
+  '8': PhysicalKeyboardKey.digit8,
+  '9': PhysicalKeyboardKey.digit9,
+};

--- a/packages/marionette_flutter/lib/src/services/keyboard_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/keyboard_simulator.dart
@@ -68,8 +68,7 @@ class KeyboardSimulator {
     // key — Ctrl+A must not also type "a".
     String? character;
     if (!hasNonShiftModifier && keyDef.character != null) {
-      character =
-          hasShift ? keyDef.character!.toUpperCase() : keyDef.character;
+      character = hasShift ? keyDef.character!.toUpperCase() : keyDef.character;
     }
 
     // Press modifiers, then the key down/up, then release modifiers in reverse
@@ -86,7 +85,8 @@ class KeyboardSimulator {
     WidgetsBinding.instance.scheduleFrame();
   }
 
-  KeyEvent _downEvent(_KeyDef def, {required String? character}) => KeyDownEvent(
+  KeyEvent _downEvent(_KeyDef def, {required String? character}) =>
+      KeyDownEvent(
         physicalKey: def.physical,
         logicalKey: def.logical,
         character: character,

--- a/packages/marionette_flutter/test/keyboard_simulator_test.dart
+++ b/packages/marionette_flutter/test/keyboard_simulator_test.dart
@@ -96,10 +96,8 @@ void main() {
         expect(selectAllCount, 1, reason: 'control+a should fire the shortcut');
 
         // Control wraps the letter: control down, a down, a up, control up.
-        final logicalDownOrder = events
-            .whereType<KeyDownEvent>()
-            .map((e) => e.logicalKey)
-            .toList();
+        final logicalDownOrder =
+            events.whereType<KeyDownEvent>().map((e) => e.logicalKey).toList();
         expect(logicalDownOrder, [
           LogicalKeyboardKey.controlLeft,
           LogicalKeyboardKey.keyA,

--- a/packages/marionette_flutter/test/keyboard_simulator_test.dart
+++ b/packages/marionette_flutter/test/keyboard_simulator_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/src/services/keyboard_simulator.dart';
+
+const _timeout = Timeout(Duration(seconds: 10));
+
+void main() {
+  group('KeyboardSimulator.pressKey', () {
+    testWidgets(
+      'dispatches a matched down/up pair for a named key to the focused widget',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final events = <KeyEvent>[];
+        await tester.pumpWidget(_focusHarness(events.add));
+        await tester.pump();
+
+        await KeyboardSimulator().pressKey('enter');
+        await tester.pump();
+
+        final down = events.whereType<KeyDownEvent>().toList();
+        final up = events.whereType<KeyUpEvent>().toList();
+        expect(down, hasLength(1));
+        expect(up, hasLength(1));
+        expect(down.single.logicalKey, LogicalKeyboardKey.enter);
+        expect(up.single.logicalKey, LogicalKeyboardKey.enter);
+        // Enter is non-printable: no character delivered.
+        expect(down.single.character, isNull);
+      },
+    );
+
+    testWidgets(
+      'delivers a character for an unmodified printable key',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final events = <KeyEvent>[];
+        await tester.pumpWidget(_focusHarness(events.add));
+        await tester.pump();
+
+        await KeyboardSimulator().pressKey('a');
+        await tester.pump();
+
+        final down = events.whereType<KeyDownEvent>().single;
+        expect(down.logicalKey, LogicalKeyboardKey.keyA);
+        expect(down.character, 'a');
+      },
+    );
+
+    testWidgets(
+      'uppercases the character when shift is held',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final events = <KeyEvent>[];
+        await tester.pumpWidget(_focusHarness(events.add));
+        await tester.pump();
+
+        await KeyboardSimulator().pressKey('a', modifiers: {'shift'});
+        await tester.pump();
+
+        final letterDown = events
+            .whereType<KeyDownEvent>()
+            .firstWhere((e) => e.logicalKey == LogicalKeyboardKey.keyA);
+        expect(letterDown.character, 'A');
+      },
+    );
+
+    testWidgets(
+      'holds modifiers so Shortcuts activate, and suppresses the character',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final events = <KeyEvent>[];
+        var selectAllCount = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: CallbackShortcuts(
+              bindings: {
+                const SingleActivator(LogicalKeyboardKey.keyA, control: true):
+                    () => selectAllCount++,
+              },
+              child: Focus(
+                autofocus: true,
+                onKeyEvent: (node, event) {
+                  events.add(event);
+                  return KeyEventResult.ignored;
+                },
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await KeyboardSimulator().pressKey('a', modifiers: {'control'});
+        await tester.pump();
+
+        expect(selectAllCount, 1, reason: 'control+a should fire the shortcut');
+
+        // Control wraps the letter: control down, a down, a up, control up.
+        final logicalDownOrder = events
+            .whereType<KeyDownEvent>()
+            .map((e) => e.logicalKey)
+            .toList();
+        expect(logicalDownOrder, [
+          LogicalKeyboardKey.controlLeft,
+          LogicalKeyboardKey.keyA,
+        ]);
+        // The control modifier suppresses the typed character.
+        final letterDown = events
+            .whereType<KeyDownEvent>()
+            .firstWhere((e) => e.logicalKey == LogicalKeyboardKey.keyA);
+        expect(letterDown.character, isNull);
+
+        // The keyboard must not be left with any key held.
+        expect(HardwareKeyboard.instance.logicalKeysPressed, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'throws ArgumentError for an unknown key',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_focusHarness((_) {}));
+        await tester.pump();
+
+        expect(
+          () => KeyboardSimulator().pressKey('nope'),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    testWidgets(
+      'throws ArgumentError for an unknown modifier',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_focusHarness((_) {}));
+        await tester.pump();
+
+        expect(
+          () => KeyboardSimulator().pressKey('a', modifiers: {'hyper'}),
+          throwsArgumentError,
+        );
+      },
+    );
+  });
+}
+
+/// A minimal app with an autofocused [Focus] that reports every [KeyEvent] it
+/// receives to [onKeyEvent].
+Widget _focusHarness(void Function(KeyEvent) onKeyEvent) {
+  return MaterialApp(
+    home: Focus(
+      autofocus: true,
+      onKeyEvent: (node, event) {
+        onKeyEvent(event);
+        return KeyEventResult.ignored;
+      },
+      child: const SizedBox.expand(),
+    ),
+  );
+}

--- a/packages/marionette_mcp/lib/src/vm_service/tools/keyboard_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/keyboard_tools.dart
@@ -1,0 +1,59 @@
+import 'package:logging/logging.dart' as logging;
+import 'package:marionette_mcp/src/vm_service/tools/tool_runner.dart';
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+
+/// Registers keyboard MCP tools: `press_key`.
+void registerKeyboardTools(
+  McpServer server,
+  VmServiceConnector connector,
+  logging.Logger logger,
+) {
+  server.registerTool(
+    'press_key',
+    description:
+        'Presses a keyboard key in the Flutter app, producing a real key event '
+        'that flows through the focus system — unlike enter_text, which only '
+        'replaces a field\'s value. Use it to submit a form (enter), move focus '
+        '(tab), dismiss a dialog (escape), edit within a field (backspace, '
+        'delete, arrowLeft/arrowRight/arrowUp/arrowDown, home, end), or trigger '
+        'app shortcuts via modifiers (for example control+a to select all). '
+        'The key is sent to whatever currently has focus, exactly like a real '
+        'keyboard, so focus a target first if needed (for example with tap). '
+        'Requires an active connection established via connect.',
+    annotations: const ToolAnnotations(title: 'Press Key'),
+    inputSchema: ToolInputSchema(
+      properties: {
+        'key': JsonSchema.string(
+          description:
+              'The key to press. Named keys: enter, tab, escape, backspace, '
+              'delete, space, arrowUp, arrowDown, arrowLeft, arrowRight, home, '
+              'end, pageUp, pageDown. Also accepts a single character a-z or '
+              '0-9 (case-insensitive).',
+        ),
+        'modifiers': JsonSchema.string(
+          description:
+              'Optional comma-separated modifier keys to hold during the '
+              'press: any of control, shift, alt, meta (e.g. "control" or '
+              '"control,shift"). On macOS use meta for the Command key.',
+        ),
+      },
+      required: ['key'],
+    ),
+    callback: (args, extra) async {
+      final key = args['key'] as String;
+      final modifiers = args['modifiers'] as String?;
+
+      logger.info('Pressing key: $key (modifiers: ${modifiers ?? 'none'})');
+      return runTool(logger, 'press key', () async {
+        final response = await connector.pressKey(key, modifiers: modifiers);
+        final message = response['message'] as String?;
+        return CallToolResult(
+          content: [
+            TextContent(text: message ?? 'Successfully pressed key'),
+          ],
+        );
+      });
+    },
+  );
+}

--- a/packages/marionette_mcp/lib/src/vm_service/tools/keyboard_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/keyboard_tools.dart
@@ -44,6 +44,14 @@ void registerKeyboardTools(
       final key = args['key'] as String;
       final modifiers = args['modifiers'] as String?;
 
+      final modifierError = invalidModifiersError(modifiers);
+      if (modifierError != null) {
+        return CallToolResult(
+          isError: true,
+          content: [TextContent(text: modifierError)],
+        );
+      }
+
       logger.info('Pressing key: $key (modifiers: ${modifiers ?? 'none'})');
       return runTool(logger, 'press key', () async {
         final response = await connector.pressKey(key, modifiers: modifiers);

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -40,6 +40,33 @@ class VmServiceExtensionException implements Exception {
   }
 }
 
+/// Modifier keys accepted by [VmServiceConnector.pressKey].
+///
+/// Must stay in sync with the modifiers the `marionette_flutter`
+/// `KeyboardSimulator` understands; this mirror lets the CLI and MCP server
+/// (which can't import the Flutter package) reject bad input before it reaches
+/// the device.
+const supportedKeyModifiers = {'control', 'shift', 'alt', 'meta'};
+
+/// Validates a comma-separated [modifiers] string against
+/// [supportedKeyModifiers] (case-insensitive).
+///
+/// Returns a human-readable error message listing the offending entries, or
+/// `null` when [modifiers] is null/empty or every entry is supported.
+String? invalidModifiersError(String? modifiers) {
+  if (modifiers == null || modifiers.trim().isEmpty) return null;
+  final invalid = modifiers
+      .split(',')
+      .map((modifier) => modifier.trim())
+      .where((modifier) => modifier.isNotEmpty)
+      .where((modifier) => !supportedKeyModifiers.contains(modifier.toLowerCase()))
+      .toList();
+  if (invalid.isEmpty) return null;
+  final plural = invalid.length > 1 ? 's' : '';
+  return 'Unsupported modifier$plural: ${invalid.join(', ')}. '
+      'Supported modifiers: ${supportedKeyModifiers.join(', ')}.';
+}
+
 /// Manages connection to a Flutter app's VM service and provides
 /// wrapper methods for custom marionette.* extensions.
 class VmServiceConnector {
@@ -342,6 +369,10 @@ class VmServiceConnector {
     String key, {
     String? modifiers,
   }) {
+    final error = invalidModifiersError(modifiers);
+    if (error != null) {
+      throw ArgumentError(error);
+    }
     final args = <String, dynamic>{'key': key};
     if (modifiers != null && modifiers.isNotEmpty) {
       args['modifiers'] = modifiers;

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -59,7 +59,8 @@ String? invalidModifiersError(String? modifiers) {
       .split(',')
       .map((modifier) => modifier.trim())
       .where((modifier) => modifier.isNotEmpty)
-      .where((modifier) => !supportedKeyModifiers.contains(modifier.toLowerCase()))
+      .where(
+          (modifier) => !supportedKeyModifiers.contains(modifier.toLowerCase()))
       .toList();
   if (invalid.isEmpty) return null;
   final plural = invalid.length > 1 ? 's' : '';
@@ -374,7 +375,10 @@ class VmServiceConnector {
       throw ArgumentError(error);
     }
     final args = <String, dynamic>{'key': key};
-    if (modifiers != null && modifiers.isNotEmpty) {
+    // Only forward modifiers when there is real content; a blank/whitespace
+    // string means "no modifiers" (matching invalidModifiersError) and should
+    // not be sent over the wire.
+    if (modifiers != null && modifiers.trim().isNotEmpty) {
       args['modifiers'] = modifiers;
     }
     return _callExtension('marionette.pressKey', args);

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -330,6 +330,25 @@ class VmServiceConnector {
     return _callExtension('marionette.enterText', args);
   }
 
+  /// Presses a keyboard key against the currently focused element.
+  ///
+  /// [key] is a named key (e.g. 'enter', 'tab', 'escape', 'backspace',
+  /// 'arrowDown') or a single character ('a'-'z', '0'-'9').
+  /// [modifiers] is an optional comma-separated list of modifiers to hold
+  /// during the press: any of 'control', 'shift', 'alt', 'meta'.
+  ///
+  /// Throws [NotConnectedException] if not connected.
+  Future<Map<String, dynamic>> pressKey(
+    String key, {
+    String? modifiers,
+  }) {
+    final args = <String, dynamic>{'key': key};
+    if (modifiers != null && modifiers.isNotEmpty) {
+      args['modifiers'] = modifiers;
+    }
+    return _callExtension('marionette.pressKey', args);
+  }
+
   /// Simulates a swipe gesture.
   ///
   /// Supports two modes:

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_context.dart
@@ -4,6 +4,7 @@ import 'package:marionette_mcp/src/vm_service/dynamic_extension_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/extension_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/gesture_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/inspection_tools.dart';
+import 'package:marionette_mcp/src/vm_service/tools/keyboard_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/system_tools.dart';
 import 'package:marionette_mcp/src/vm_service/tools/text_tools.dart';
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
@@ -39,6 +40,7 @@ final class VmServiceContext {
     registerInspectionTools(server, connector, _logger);
     registerGestureTools(server, connector, _logger);
     registerTextTools(server, connector, _logger);
+    registerKeyboardTools(server, connector, _logger);
     registerExtensionTools(server, connector, _logger);
     registerSystemTools(server, connector, _logger);
   }

--- a/packages/marionette_mcp/test/vm_service/press_key_modifiers_test.dart
+++ b/packages/marionette_mcp/test/vm_service/press_key_modifiers_test.dart
@@ -1,0 +1,39 @@
+import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('invalidModifiersError', () {
+    test('returns null for null or empty input', () {
+      expect(invalidModifiersError(null), isNull);
+      expect(invalidModifiersError(''), isNull);
+      expect(invalidModifiersError('   '), isNull);
+    });
+
+    test('accepts every supported modifier, case-insensitively', () {
+      expect(invalidModifiersError('control'), isNull);
+      expect(invalidModifiersError('shift,alt,meta'), isNull);
+      expect(invalidModifiersError('Control, SHIFT'), isNull);
+    });
+
+    test('reports a single unsupported modifier', () {
+      final error = invalidModifiersError('hyper');
+      expect(error, contains('Unsupported modifier: hyper'));
+      expect(error, contains('control, shift, alt, meta'));
+    });
+
+    test('reports multiple unsupported modifiers and pluralizes', () {
+      final error = invalidModifiersError('control,hyper,fn');
+      expect(error, contains('Unsupported modifiers: hyper, fn'));
+    });
+  });
+
+  group('VmServiceConnector.pressKey', () {
+    test('throws ArgumentError before connecting when a modifier is invalid',
+        () {
+      expect(
+        () => VmServiceConnector().pressKey('a', modifiers: 'bogus'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a **`press_key`** action that dispatches *real* hardware key events to the focused element — filling the gap that `enter_text` leaves (it only rewrites a field's value and never produces key events).

Supports named keys (`enter`, `tab`, `escape`, `backspace`, `delete`, `space`, arrows, `home`/`end`, `pageUp`/`pageDown`) and single characters `a`-`z`/`0`-`9`, with optional modifiers (`control`, `shift`, `alt`, `meta`). Targets whatever currently has focus, like a real keyboard — so form submission (`enter`), focus traversal (`tab`), dismiss (`escape`), in-field editing, and app `Shortcuts`/`Actions` (e.g. `control,a`) all work.

## How

Flutter side injects events via `HardwareKeyboard.instance.handleKeyEvent` **plus** the `FocusManager` `keyMessageHandler`, reaching `Focus`, `Shortcuts`/`Actions`, and focus traversal — the same path a physical keyboard takes. Wired through the new `marionette.pressKey` VM service extension, the connector, the `press_key` MCP tool, and the `press-key` CLI command.

Implemented across all four layers, mirroring the existing per-action pattern:
- **Flutter:** `KeyboardSimulator` service + `marionette.pressKey` extension, wired into `MarionetteBinding`
- **MCP:** `press_key` tool + `connector.pressKey` + registration
- **CLI:** `press-key` command + runner + `help-ai` reference
- **Docs:** `cli.md`, `mcp-tools.md` (incl. a platform note)

### Modifier validation
`modifiers` is validated at every boundary via a shared `supportedKeyModifiers` set + `invalidModifiersError` helper in `marionette_mcp`:
- CLI validates in `run()` **before connecting** → usage error (exit 64), no running app needed
- MCP tool returns an error result up front
- `VmServiceConnector.pressKey` throws `ArgumentError` as a guard
- Flutter side validates on-device as the final guard

## Testing

- **Unit:** 6 `KeyboardSimulator` tests + 5 modifier-validation tests (event dispatch, character/shift/modifier-suppression, real `SingleActivator` activation, clean down/up pairing, error handling). Full suites pass; analyze clean across all three packages.
- **Live e2e (iOS simulator):** `press-key arrowUp` drove an autofocused `CallbackShortcuts` (counter incremented); `control+arrowDown` confirmed modifiers are held during the press and released cleanly afterward; verified through both the **CLI** and the **MCP JSON-RPC server**.

## Platform note

App-level shortcuts, submit/dismiss, button activation, and focus traversal work everywhere. In-field `TextField` editing with hardware `backspace`/arrows is wired on **desktop/web**; on **mobile (iOS/Android)** editing is owned by the platform IME, so use `enter_text` to change a field's value there. (Documented in `docs/mcp-tools.md`.)

The example app gains a `TextField` and two shortcut bindings as a keyboard demo.