### PR TITLE
feat: add compact mode to get_interactive_elements

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,7 +80,7 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 
 | Command | Purpose |
 | --- | --- |
-| `get-interactive-elements` | List interactive UI elements. |
+| `get-interactive-elements` | List interactive UI elements (`--compact` to omit verbose widget properties). |
 | `tap` | Tap an element (`--key`, `--text`, `--type`, or `--x`/`--y`). |
 | `secondary-tap` | Right-click a matching element (desktop only). |
 | `double-tap` | Double tap (matchers + `--delay`). |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -15,7 +15,7 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 
 | Tool | Description |
 | --- | --- |
-| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, and identifying properties. The agent's primary way to "see" the screen. |
+| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, and identifying properties. The agent's primary way to "see" the screen. Pass `compact: true` to omit verbose widget properties (style/decoration/color blobs) and return only identifying fields plus primitive state flags (e.g. `enabled`, `value`, `obscureText`) — much more token-efficient for agent loops; a text field's label/hint is preserved. |
 | `take_screenshots` | Capture screenshots of all active views, returned as base64 PNGs. |
 | `get_logs` | Retrieve app logs collected since start or the last hot reload. Requires a [`LogCollector`](./logging.md). |
 

--- a/packages/marionette_cli/lib/src/cli/commands/get_interactive_elements_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/get_interactive_elements_command.dart
@@ -6,7 +6,14 @@ import 'package:marionette_mcp/src/formatting.dart';
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 
 class ElementsCommand extends InstanceCommand {
-  ElementsCommand(this._registry);
+  ElementsCommand(this._registry) {
+    argParser.addFlag(
+      'compact',
+      help: 'Omit verbose widget properties (style/decoration/color blobs); '
+          'show only identifying fields and primitive state flags.',
+      defaultsTo: false,
+    );
+  }
 
   final InstanceRegistry _registry;
 
@@ -22,7 +29,8 @@ class ElementsCommand extends InstanceCommand {
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
-    final response = await connector.getInteractiveElements();
+    final compact = argResults?['compact'] as bool? ?? false;
+    final response = await connector.getInteractiveElements(compact: compact);
     final elements = response['elements'] as List<dynamic>;
 
     stdout.writeln('Found ${elements.length} interactive element(s):\n');

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -115,8 +115,14 @@ List interactive UI elements in the app's widget tree.
 
   Requires: -i <instance> or --uri <ws-uri>
 
+  Options:
+    --compact   Omit verbose widget properties (style/decoration/color blobs);
+                show only identifying fields and primitive state flags. Much
+                more token-efficient; a text field's label/hint is preserved.
+
   Examples:
     marionette -i my-app get-interactive-elements
+    marionette -i my-app get-interactive-elements --compact
     marionette --uri ws://127.0.0.1:8181/ws get-interactive-elements
 
   Output (stdout), one line per element:

--- a/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
@@ -53,7 +53,11 @@ void registerInfoExtensions({
   registerInternalMarionetteExtension(
     name: 'marionette.interactiveElements',
     callback: (params) async {
-      final elements = elementTreeFinder.findInteractiveElements();
+      // VM service delivers params as strings; absent defaults to false.
+      final compact = params['compact'] == 'true';
+      final elements = elementTreeFinder.findInteractiveElements(
+        compact: compact,
+      );
       return MarionetteExtensionResult.success({'elements': elements});
     },
   );

--- a/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
@@ -10,20 +10,29 @@ class ElementTreeFinder {
   final MarionetteConfiguration configuration;
 
   /// Returns a list of interactive elements from the current widget tree.
-  List<Map<String, dynamic>> findInteractiveElements() {
+  ///
+  /// When [compact] is true, the per-element property dump is reduced to
+  /// primitive-valued properties only (see [_extractElementData]), dropping the
+  /// large `ButtonStyle`/`TextStyle`/`InputDecoration` blobs that otherwise
+  /// dominate the output.
+  List<Map<String, dynamic>> findInteractiveElements({bool compact = false}) {
     final elements = <Map<String, dynamic>>[];
     final rootElement = WidgetsBinding.instance.rootElement;
 
     if (rootElement != null) {
-      _visitElement(rootElement, elements);
+      _visitElement(rootElement, elements, compact: compact);
     }
 
     return elements;
   }
 
-  void _visitElement(Element element, List<Map<String, dynamic>> result) {
+  void _visitElement(
+    Element element,
+    List<Map<String, dynamic>> result, {
+    required bool compact,
+  }) {
     final widget = element.widget;
-    final elementData = _extractElementData(element, widget);
+    final elementData = _extractElementData(element, widget, compact: compact);
 
     if (elementData != null) {
       result.add(elementData);
@@ -34,11 +43,15 @@ class ElementTreeFinder {
     }
 
     element.visitChildren((child) {
-      _visitElement(child, result);
+      _visitElement(child, result, compact: compact);
     });
   }
 
-  Map<String, dynamic>? _extractElementData(Element element, Widget widget) {
+  Map<String, dynamic>? _extractElementData(
+    Element element,
+    Widget widget, {
+    required bool compact,
+  }) {
     // Only process elements with render objects
     final renderObject = element.renderObject;
     if (renderObject == null) {
@@ -71,12 +84,20 @@ class ElementTreeFinder {
 
     final properties = DiagnosticPropertiesBuilder();
     widget.debugFillProperties(properties);
+    // In compact mode keep only primitive-valued properties (bool/num/String/
+    // Enum) and drop object blobs (ButtonStyle, TextStyle, InputDecoration,
+    // Color, controllers, FocusNode) and callbacks/closures. Filtering by value
+    // type — rather than by DiagnosticsNode subtype — is necessary because
+    // widgets are inconsistent: e.g. TextField declares `enabled`/`obscureText`
+    // as generic DiagnosticsProperty<bool> while ElevatedButton uses
+    // FlagProperty. Exact retained fields therefore vary per widget.
     final data = Map<String, Object>.fromEntries(
       properties.properties
           .where((p) =>
               p.runtimeType != DiagnosticsProperty &&
               p.name != null &&
-              p.value != null)
+              p.value != null &&
+              (!compact || _isPrimitive(p.value)))
           .map(
             (p) => MapEntry(p.name!, p.value.toString()),
           ),
@@ -90,6 +111,18 @@ class ElementTreeFinder {
 
     if (discoverableText != null) {
       data['text'] = discoverableText;
+    }
+
+    // The InputDecoration blob is dropped in compact mode, but it carries a
+    // keyless text field's only human-readable handle (its `text` holds the
+    // entered value, empty for a blank field). Surface the label/hint so such
+    // fields stay identifiable. TextFormField has no public `decoration`, so
+    // this only applies to TextField.
+    if (compact && widget is TextField) {
+      final label = widget.decoration?.labelText ?? widget.decoration?.hintText;
+      if (label != null && label.isNotEmpty) {
+        data['label'] = label;
+      }
     }
 
     // Get position and size if available
@@ -113,6 +146,10 @@ class ElementTreeFinder {
 
     return data;
   }
+
+  /// Whether [value] is a primitive worth keeping in compact mode.
+  static bool _isPrimitive(Object? value) =>
+      value is bool || value is num || value is String || value is Enum;
 
   String? _extractKeyValue(Key? key) {
     if (key is ValueKey<String>) {

--- a/packages/marionette_flutter/test/element_tree_finder_test.dart
+++ b/packages/marionette_flutter/test/element_tree_finder_test.dart
@@ -145,4 +145,74 @@ void main() {
       );
     });
   });
+
+  group('ElementTreeFinder compact mode', () {
+    testWidgets('drops style/object blobs but keeps primitive state and bounds',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.purple,
+                ),
+                onPressed: () {},
+                child: const Text('Submit'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final verbose = _finder.findInteractiveElements();
+      final verboseButton =
+          verbose.firstWhere((e) => e['type'] == 'ElevatedButton');
+      expect(verboseButton.containsKey('style'), isTrue,
+          reason: 'verbose mode (default) still dumps the ButtonStyle blob');
+
+      final compact = _finder.findInteractiveElements(compact: true);
+      final compactButton =
+          compact.firstWhere((e) => e['type'] == 'ElevatedButton');
+      expect(compactButton.containsKey('style'), isFalse,
+          reason: 'compact drops the ButtonStyle object blob');
+      expect(compactButton.containsKey('focusNode'), isFalse,
+          reason: 'compact drops the FocusNode object blob');
+      expect(compactButton['enabled'], isNotNull,
+          reason: 'compact keeps the primitive enabled flag');
+      expect(compactButton.containsKey('bounds'), isTrue);
+      expect(compactButton['visible'], isTrue);
+    });
+
+    testWidgets(
+        'keeps generic DiagnosticsProperty<bool> state and preserves '
+        'TextField label', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TextField(
+              controller: TextEditingController(),
+              enabled: true,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+          ),
+        ),
+      );
+
+      final compact = _finder.findInteractiveElements(compact: true);
+      final field = compact.firstWhere((e) => e['type'] == 'TextField');
+
+      // These are declared as DiagnosticsProperty<bool> by TextField, so a
+      // node-type filter would wrongly drop them — value-type keeps them.
+      expect(field['obscureText'], 'true');
+      expect(field['enabled'], isNotNull);
+      // Object blobs are dropped.
+      expect(field.containsKey('decoration'), isFalse);
+      expect(field.containsKey('controller'), isFalse);
+      expect(field.containsKey('style'), isFalse);
+      // Label is preserved from the dropped InputDecoration.
+      expect(field['label'], 'Email');
+    });
+  });
 }

--- a/packages/marionette_mcp/lib/src/vm_service/tools/inspection_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/inspection_tools.dart
@@ -15,17 +15,26 @@ void registerInspectionTools(
     ..registerTool(
       'get_interactive_elements',
       description:
-          'Returns a list of all interactive elements currently visible in the Flutter app UI tree. Each element includes its type, text content (if any), key (if any), and other identifying properties. This is useful for understanding what can be interacted with in the app. Requires an active connection established via connect.',
+          'Returns a list of all interactive elements currently visible in the Flutter app UI tree. Each element includes its type, text content (if any), key (if any), and other identifying properties. This is useful for understanding what can be interacted with in the app. Set compact to true to omit verbose widget properties (e.g. ButtonStyle, TextStyle, InputDecoration, colors) and return only the type, key, text, bounds, visibility, and primitive state flags (e.g. enabled, value, obscureText) — this is much more token-efficient for agent loops, and a text field\'s label/hint is preserved. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(
         title: 'Get Interactive Elements',
         readOnlyHint: true,
         idempotentHint: true,
       ),
-      inputSchema: const ToolInputSchema(properties: {}),
+      inputSchema: ToolInputSchema(
+        properties: {
+          'compact': JsonSchema.boolean(
+            description:
+                'When true, omit verbose widget properties (style/decoration/color blobs) and return only identifying fields plus primitive state flags. Defaults to false (full properties).',
+          ),
+        },
+      ),
       callback: (args, extra) async {
-        logger.info('Getting interactive elements');
+        final compact = args['compact'] == true;
+        logger.info('Getting interactive elements (compact: $compact)');
         return runTool(logger, 'get interactive elements', () async {
-          final response = await connector.getInteractiveElements();
+          final response =
+              await connector.getInteractiveElements(compact: compact);
           final elements = response['elements'] as List<dynamic>;
 
           final buffer = StringBuffer()

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -247,9 +247,16 @@ class VmServiceConnector {
 
   /// Gets the list of interactive elements in the widget tree.
   ///
+  /// When [compact] is true, each element's property dump is reduced to
+  /// primitive-valued properties only, dropping the large style/decoration
+  /// blobs (see `get_interactive_elements`).
+  ///
   /// Throws [NotConnectedException] if not connected.
-  Future<Map<String, dynamic>> getInteractiveElements() {
-    return _callExtension('marionette.interactiveElements', {});
+  Future<Map<String, dynamic>> getInteractiveElements({bool compact = false}) {
+    return _callExtension(
+      'marionette.interactiveElements',
+      {if (compact) 'compact': true},
+    );
   }
 
   /// Taps an element matching the given criteria.


### PR DESCRIPTION
## What

Adds an opt-in **compact** mode to `get_interactive_elements`:

- MCP tool: new `compact` boolean parameter (default `false`).
- CLI: new `--compact` flag on `get-interactive-elements`.

When enabled, the per-element property dump omits verbose widget objects (`ButtonStyle`, `TextStyle`, `InputDecoration`, colors, `FocusNode`, controllers, callbacks) and returns only the identifying fields (`type`/`key`/`text`/`bounds`/`visible`) plus **primitive state flags** (`enabled`, `value`, `obscureText`, `maxLines`, enums, …). Default output is **unchanged** — fully non-breaking.

## Why

`get_interactive_elements` stringifies *every* `debugFillProperties` entry. The heavy ones — typed `DiagnosticsProperty<ButtonStyle>` / `<TextStyle>` / `<InputDecoration>` — slip past the existing base-type filter and dominate the output: a typical screen burns 3000+ tokens on a handful of useful widgets. None of these style properties are consumed by any interaction tool (`tap`/`enter_text`/`scroll_to`/`swipe` match only on key/text/type/coordinates), so they're pure agent-context cost. Compact mode lets agent loops scale dramatically while keeping the state flags useful for verifying outcomes.

## Design notes for reviewers

- **Filter by value type, not node type.** Inspecting the actual Flutter SDK (3.41.7) `debugFillProperties` for every Marionette-supported widget showed node-type filtering is unreliable: `TextField` declares `enabled`/`obscureText` as generic `DiagnosticsProperty<bool>`, while `ElevatedButton` uses `FlagProperty`. So compact keeps a property iff its value is `bool`/`num`/`String`/`Enum` and drops object/callback blobs — consistent across widgets.
- **Filtering runs Dart-side** in `ElementTreeFinder` (not in `formatElement`), because the `DiagnosticsNode` value type is only available before stringification. This also avoids serializing the large blobs on the app side.
- **TextField label preserved.** Dropping `InputDecoration` would remove a keyless empty field's only human-readable handle (`text` holds the entered value), so compact surfaces `decoration.labelText ?? hintText` as `label`. `TextFormField` has no public `decoration` (it's captured in its builder), so this applies to `TextField` only — a pre-existing limitation, noted in code.
- Widgets with no `debugFillProperties` override (Checkbox, Radio, Dropdown, PopupMenuButton, the `*ListTile` variants) already cost ~0 extra, so compact is a no-op for them.

## Tests & verification

- New `ElementTreeFinder` compact tests: button drops `style`/`focusNode` blobs but keeps `enabled` + bounds; `TextField` keeps `obscureText`/`enabled` (proving value-type beats node-type), drops `decoration`/`controller`/`style`, and preserves `label`.
- `dart analyze` clean across all three packages.
- All suites pass: marionette_flutter 130, marionette_mcp 137, marionette_cli 88.

## Docs

Updated `docs/mcp-tools.md`, `docs/cli.md`, and the CLI `help-ai` output.