### PR TITLE
feat: match and discover widgets by Semantics identifier

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,11 +83,11 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | --- | --- |
 | `get-interactive-elements` | List interactive UI elements. |
 | `tap` | Tap an element (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`). |
-| `secondary-tap` | Right-click a matching element (desktop only). |
-| `double-tap` | Double tap (matchers + `--delay`). |
-| `long-press` | Long press (matchers + `--duration`). |
-| `pinch-zoom` | Pinch zoom (matchers + `--scale`, `--start-distance`). |
-| `swipe` | Swipe/drag (matchers + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
+| `secondary-tap` | Right-click a matching element (desktop only) (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`). |
+| `double-tap` | Double tap (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--delay`). |
+| `long-press` | Long press (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--duration`). |
+| `pinch-zoom` | Pinch zoom (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--scale`, `--start-distance`). |
+| `swipe` | Swipe/drag (`--key`/`--identifier`/`--text` + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
 | `enter-text` | Enter text (`--key`, `--identifier`, `--text`, or `--focused`, plus `--input`). |
 | `press-key` | Press a key on the focused element (`--key`, optional `--modifiers`). Real key event: enter to submit, tab to move focus, escape, arrows/backspace to edit, or `--modifiers control` for shortcuts. |
 | `scroll-to` | Scroll to an element (`--key`, `--identifier`, or `--text`). |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,9 +88,9 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | `long-press` | Long press (matchers + `--duration`). |
 | `pinch-zoom` | Pinch zoom (matchers + `--scale`, `--start-distance`). |
 | `swipe` | Swipe/drag (matchers + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
-| `enter-text` | Enter text (`--key`, `--identifier`, or `--focused`, plus `--input`). |
+| `enter-text` | Enter text (`--key`, `--identifier`, `--text`, or `--focused`, plus `--input`). |
 | `press-key` | Press a key on the focused element (`--key`, optional `--modifiers`). Real key event: enter to submit, tab to move focus, escape, arrows/backspace to edit, or `--modifiers control` for shortcuts. |
-| `scroll-to` | Scroll to an element (`--key` or `--text`). |
+| `scroll-to` | Scroll to an element (`--key`, `--identifier`, or `--text`). |
 | `press-back-button` | Simulate the system back button. |
 | `take-screenshots` | Capture a screenshot (`-o/--output`, `--open`). |
 | `record-video` | Record video (`-o/--output`, `-d/--duration`, `--width`, `--height`, `--ffmpeg-path`, `--open`, …). |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,7 @@ marionette register other-app ws://127.0.0.1:9090/ws
 # Interact with a specific instance
 marionette -i my-app get-interactive-elements
 marionette -i my-app tap --key submit_button
+marionette -i my-app tap --identifier submit_button
 marionette -i my-app tap --text "Submit"
 marionette -i my-app enter-text --key email_field --input "test@example.com"
 marionette -i my-app scroll-to --text "Bottom Item"
@@ -81,13 +82,13 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | Command | Purpose |
 | --- | --- |
 | `get-interactive-elements` | List interactive UI elements. |
-| `tap` | Tap an element (`--key`, `--text`, `--type`, or `--x`/`--y`). |
+| `tap` | Tap an element (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`). |
 | `secondary-tap` | Right-click a matching element (desktop only). |
 | `double-tap` | Double tap (matchers + `--delay`). |
 | `long-press` | Long press (matchers + `--duration`). |
 | `pinch-zoom` | Pinch zoom (matchers + `--scale`, `--start-distance`). |
 | `swipe` | Swipe/drag (matchers + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
-| `enter-text` | Enter text (`--key` or `--focused`, plus `--input`). |
+| `enter-text` | Enter text (`--key`, `--identifier`, or `--focused`, plus `--input`). |
 | `press-key` | Press a key on the focused element (`--key`, optional `--modifiers`). Real key event: enter to submit, tab to move focus, escape, arrows/backspace to edit, or `--modifiers control` for shortcuts. |
 | `scroll-to` | Scroll to an element (`--key` or `--text`). |
 | `press-back-button` | Simulate the system back button. |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -15,7 +15,7 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 
 | Tool | Description |
 | --- | --- |
-| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, and identifying properties. The agent's primary way to "see" the screen. |
+| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, identifier (Semantics identifier), and other identifying properties. The agent's primary way to "see" the screen. |
 | `take_screenshots` | Capture screenshots of all active views, returned as base64 PNGs. |
 | `get_logs` | Retrieve app logs collected since start or the last hot reload. Requires a [`LogCollector`](./logging.md). |
 
@@ -24,11 +24,11 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 | Tool | Description |
 | --- | --- |
 | `tap` | Tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. Prefer `key`; `identifier` (Semantics identifier) is the next-best stable selector. Tapping a text field focuses it. |
-| `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. |
-| `double_tap` | Double tap an element (optional `delay` between taps, default 100 ms). |
-| `long_press` | Long press an element (optional `duration`, default 600 ms) — context menus, reorderable lists. |
+| `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. Match by `key`, `identifier`, `text`, `type`, or `coordinates`. |
+| `double_tap` | Double tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `delay` between taps, default 100 ms). |
+| `long_press` | Long press an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `duration`, default 600 ms) — context menus, reorderable lists. |
 | `swipe` | Swipe/drag. Element-based (`key`/`identifier`/`text` + `direction` + optional `distance`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
-| `pinch_zoom` | Pinch to zoom an element. `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
+| `pinch_zoom` | Pinch to zoom an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
 | `press_back_button` | Simulate the system back button (Android back / iOS swipe-back). Works with Navigator, GoRouter, etc. |
 | `scroll_to` | Scroll until an element matching `key`, `identifier`, or `text` becomes visible. |
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -23,20 +23,20 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 
 | Tool | Description |
 | --- | --- |
-| `tap` | Tap an element matched by `key`, `text`, `type`, or `coordinates`. Prefer `key`. Tapping a text field focuses it. |
+| `tap` | Tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. Prefer `key`; `identifier` (Semantics identifier) is the next-best stable selector. Tapping a text field focuses it. |
 | `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. |
 | `double_tap` | Double tap an element (optional `delay` between taps, default 100 ms). |
 | `long_press` | Long press an element (optional `duration`, default 600 ms) — context menus, reorderable lists. |
-| `swipe` | Swipe/drag. Element-based (`key`/`text` + `direction` + optional `distance`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
+| `swipe` | Swipe/drag. Element-based (`key`/`identifier`/`text` + `direction` + optional `distance`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
 | `pinch_zoom` | Pinch to zoom an element. `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
 | `press_back_button` | Simulate the system back button (Android back / iOS swipe-back). Works with Navigator, GoRouter, etc. |
-| `scroll_to` | Scroll until an element matching `key` or `text` becomes visible. |
+| `scroll_to` | Scroll until an element matching `key`, `identifier`, or `text` becomes visible. |
 
 ### Text input
 
 | Tool | Description |
 | --- | --- |
-| `enter_text` | Enter text into a field. Target by `key`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required. |
+| `enter_text` | Enter text into a field. Target by `key`, by `identifier`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required. |
 | `press_key` | Press a key on the focused element, producing a real key event (unlike `enter_text`). `key` is a named key (`enter`, `tab`, `escape`, `backspace`, `delete`, `space`, `arrowUp`/`arrowDown`/`arrowLeft`/`arrowRight`, `home`, `end`, `pageUp`, `pageDown`) or a single character `a`-`z`/`0`-`9`. Optional `modifiers` (comma-separated: `control`, `shift`, `alt`, `meta`) for shortcuts like `control,a`. Focus a target first via `tap`. |
 
 > **Platform note for `press_key`:** key events reach `Focus`, `Shortcuts`/`Actions`, and focus traversal on every platform — so app shortcuts, submit (`enter`), dismiss (`escape`), and button activation work everywhere. In-field text editing with `backspace`/arrows/characters relies on Flutter's hardware-key text-editing actions, which are wired on **desktop and web**; on **mobile (iOS/Android)** `TextField` editing is owned by the platform keyboard, so use `enter_text` to change a field's value there.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -23,11 +23,31 @@ When both `label` and `value` are set, Marionette joins them as `'label: value'`
 
 This works without any `extractText` configuration. The same technique works for tables, lists, charts, badges, and any custom-rendered content where you want to give an agent a single authoritative summary instead of asking it to reconstruct meaning from a flat list of cells.
 
-## Discovery-only contract
+## Discovery-only contract for `label` / `value`
 
-`Semantics` annotations are surfaced as a **discovery-only** fallback in `get_interactive_elements` — they are **not** consulted by the matcher path used by `tap`, `scroll_to`, and `enter_text`. So wrapping a control in `Semantics(label: ...)` will **not** cause gestures to be redirected to the wrapper instead of the inner widget.
+`Semantics` **`label` and `value`** annotations are surfaced as a **discovery-only** fallback in `get_interactive_elements` — they are **not** consulted by the matcher path used by `tap`, `scroll_to`, and `enter_text`. So wrapping a control in `Semantics(label: ...)` will **not** cause gestures to be redirected to the wrapper instead of the inner widget.
+
+This is deliberate: a `label` like `"Submit"` would otherwise collide with the rendered `Text("Submit")`, leaving the matcher unable to tell the `Semantics` wrapper apart from the real control. Keeping `label`/`value` out of matching avoids that ambiguity.
 
 `Semantics` widgets without an explicit `label` or `value` (framework-generated annotations with no user-visible content) are **not** reported, so the output stays quiet by default.
+
+## Matching by `identifier`
+
+The `Semantics` **`identifier`** is different. Unlike `label`/`value` it is an explicit, unique, machine-readable handle that you set on purpose — and it lives only on the `Semantics` widget, never on the inner control — so there is no ambiguity about which element it refers to. Marionette therefore **does** consult `identifier` in the matcher path: `tap`, `double_tap`, `secondary_tap`, `long_press`, `swipe`, `pinch_zoom`, `scroll_to`, and `enter_text` all accept an `identifier` selector (in the CLI: `--identifier`).
+
+```dart
+// No ValueKey, but a stable Semantics identifier the agent can target.
+Semantics(
+  identifier: 'submit_button',
+  child: ElevatedButton(onPressed: _submit, child: const Text('Submit')),
+)
+```
+
+Because the `Semantics` wrapper shares the bounds of (and is hittable through) its child, a tap matched by `identifier` lands on the real control underneath. This makes `identifier` an equally stable alternative to a `ValueKey` for elements you cannot — or would rather not — assign a key to. The `identifier` is also surfaced in `get_interactive_elements` (for hittable elements, like every other discovery entry) so agents can discover it.
+
+Convenience parameters that forward to a generated `Semantics` wrapper are covered by the same mechanism — no special handling required. For example `Text('Submit', semanticsIdentifier: 'submit_btn')` builds a `Semantics(identifier: 'submit_btn')` internally, so `identifier: 'submit_btn'` matches it just like an explicit wrapper.
+
+One thing it does **not** cover: per-span identifiers set via `TextSpan.semanticsIdentifier` / `InlineSpan.semanticsIdentifier`. Those are applied at the `SemanticsNode` level inside `RenderParagraph`, not as a widget in the tree, so there is no element for the matcher to match. If you need to target a specific run of rich text, wrap it in an explicit `Semantics(identifier: ...)` (or split it into its own `Text`) instead.
 
 ## Accessibility trade-off: keep `label` human-friendly
 
@@ -35,5 +55,6 @@ Whatever you put in `Semantics.label` is announced verbatim by VoiceOver and Tal
 
 - **Pattern A — clean label, render via `Text.rich`.** Keep `label` as the human-friendly string and let `Text.rich.toPlainText()` cover the rendered version. Both the agent and the screen reader get clean text; the agent simply sees two complementary entries (`Type: Semantics` + `Type: Text`).
 - **Pattern B — structural label + dynamic value.** Use `label` for what the control *is* and `value` for its current state. Marionette emits the combined `'label: value'` for agents; screen readers announce the pair the same way they announce a native slider.
+- **Pattern C — machine-readable selector via `identifier`.** When all you want is a stable handle for the agent to *target* (not read aloud), put it in `Semantics.identifier`, not `label`. The `identifier` is never announced by VoiceOver/TalkBack, so a value like `submit_button` stays invisible to screen-reader users while remaining a first-class matcher for `tap`, `enter_text`, and the other gesture tools. This is the recommended home for machine-readable selectors and avoids polluting `label` with non-human-friendly strings.
 
 If your `label` is genuinely not human-readable (e.g. you really do want the agent to see raw markup), prefer a custom widget with [`extractText`](./configuration.md#extracttext) so the markup never reaches the accessibility tree.

--- a/packages/marionette_cli/lib/src/cli/commands/double_tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/double_tap_command.dart
@@ -9,6 +9,7 @@ class DoubleTapCommand extends InstanceCommand {
   DoubleTapCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., ListTile).')
       ..addOption('x', help: 'X coordinate for positional double tap.')
@@ -30,12 +31,13 @@ class DoubleTapCommand extends InstanceCommand {
 
   @override
   String get description =>
-      'Double tap an element by key, text, type, or coordinates.';
+      'Double tap an element by key, identifier, text, type, or coordinates.';
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
@@ -50,7 +52,8 @@ class DoubleTapCommand extends InstanceCommand {
 
     if (matcher.isEmpty) {
       usageException(
-        'At least one matcher required: --key, --text, --type, or --x/--y.',
+        'At least one matcher required: --key, --identifier, --text, --type, '
+        'or --x/--y.',
       );
     }
 

--- a/packages/marionette_cli/lib/src/cli/commands/enter_text_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/enter_text_command.dart
@@ -9,6 +9,7 @@ class EnterTextCommand extends InstanceCommand {
   EnterTextCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the text field.')
       ..addOption('text', help: 'Visible text of the text field.')
       ..addFlag(
         'focused',
@@ -39,13 +40,15 @@ class EnterTextCommand extends InstanceCommand {
     final focused = argResults!['focused'] as bool;
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       focused: focused,
     );
 
     if (matcher.isEmpty) {
       usageException(
-        'At least one matcher required: --key, --text, or --focused.',
+        'At least one matcher required: --key, --identifier, --text, '
+        'or --focused.',
       );
     }
 

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -126,8 +126,9 @@ List interactive UI elements in the app's widget tree.
     Type: TextField, Key: "email_field"
     Type: IconButton, Text: ""
 
-  Each element may have: type, key, text, and additional properties.
-  Use the key or text values as matchers for tap, enter-text, scroll-to.
+  Each element may have: type, key, text, identifier, and additional
+  properties. Use the key, identifier, or text values as matchers for tap,
+  enter-text, scroll-to.
 
 ---
 
@@ -138,14 +139,16 @@ Tap an element. Provide exactly one matching strategy.
   Requires: -i <instance> or --uri <ws-uri>
 
   Options:
-    --key <string>    Match by ValueKey<String> (most reliable)
-    --text <string>   Match by visible text content
-    --type <string>   Match by widget type name (e.g., ElevatedButton)
-    --x <number>      X screen coordinate (use with --y)
-    --y <number>      Y screen coordinate (use with --x)
+    --key <string>        Match by ValueKey<String> (most reliable)
+    --identifier <string> Match by Semantics identifier (stable alternative)
+    --text <string>       Match by visible text content
+    --type <string>       Match by widget type name (e.g., ElevatedButton)
+    --x <number>          X screen coordinate (use with --y)
+    --y <number>          Y screen coordinate (use with --x)
 
   Examples:
     marionette -i my-app tap --key submit_button
+    marionette -i my-app tap --identifier submit_button
     marionette -i my-app tap --text "Submit"
     marionette --uri ws://127.0.0.1:8181/ws tap --key submit_button
     marionette -i my-app tap --x 100 --y 200
@@ -164,14 +167,16 @@ strategy.
   Requires: -i <instance> or --uri <ws-uri>
 
   Options:
-    --key <string>    Match by ValueKey<String> (most reliable)
-    --text <string>   Match by visible text content
-    --type <string>   Match by widget type name (e.g., ElevatedButton)
-    --x <number>      X screen coordinate (use with --y)
-    --y <number>      Y screen coordinate (use with --x)
+    --key <string>        Match by ValueKey<String> (most reliable)
+    --identifier <string> Match by Semantics identifier (stable alternative)
+    --text <string>       Match by visible text content
+    --type <string>       Match by widget type name (e.g., ElevatedButton)
+    --x <number>          X screen coordinate (use with --y)
+    --y <number>          Y screen coordinate (use with --x)
 
   Examples:
     marionette -i my-app secondary-tap --key file_item
+    marionette -i my-app secondary-tap --identifier file_item
     marionette -i my-app secondary-tap --text "Document"
     marionette -i my-app secondary-tap --x 100 --y 200
 
@@ -186,13 +191,16 @@ Enter text into a text field.
 
   Requires: -i <instance> or --uri <ws-uri>
 
-  Options (all required):
-    --key <string>      Match text field by key (or use --text)
-    --text <string>     Match text field by visible text
-    --input <string>    Text to enter (mandatory)
+  Options:
+    --key <string>        Match text field by key
+    --identifier <string> Match text field by Semantics identifier
+    --text <string>       Match text field by visible text
+    --focused             Target the currently focused text field
+    --input <string>      Text to enter (mandatory)
 
   Example:
     marionette -i my-app enter-text --key email_field --input "user@example.com"
+    marionette -i my-app enter-text --identifier email_field --input "user@example.com"
 
   Output (stdout):
     Entered text into element matching {key: email_field}
@@ -265,6 +273,7 @@ Use either element-based mode (matcher + direction) or coordinate-based mode.
 
   Element-based options:
     --key <string>        Match by ValueKey<String> (most reliable)
+    --identifier <string> Match by Semantics identifier (stable alternative)
     --text <string>       Match by visible text content
     --type <string>       Match by widget type name (e.g., PageView)
     --direction <dir>     left, right, up, or down (required for this mode)
@@ -294,8 +303,9 @@ Scroll until an element becomes visible.
   Requires: -i <instance> or --uri <ws-uri>
 
   Options:
-    --key <string>    Match by ValueKey<String>
-    --text <string>   Match by visible text content
+    --key <string>        Match by ValueKey<String>
+    --identifier <string> Match by Semantics identifier
+    --text <string>       Match by visible text content
 
   Example:
     marionette -i my-app scroll-to --text "Bottom Item"
@@ -483,6 +493,8 @@ If a command fails with a connection error, the app may have stopped.
 - Prefer --uri for one-off interactions (no setup/cleanup overhead)
 - Prefer --instance for repeated interactions with the same app (shorter commands)
 - Prefer --key over --text for matching elements (keys are stable, text may change)
+- --identifier (Semantics identifier) is an equally stable alternative to --key
+  when a widget has no ValueKey but does set an accessibility identifier
 - Run `get-interactive-elements` first to discover what's on screen before interacting
 - Instance names are alphanumeric with hyphens/underscores: [a-zA-Z0-9_-]+
 - Commands are stateless — each opens a fresh connection, so no session management needed

--- a/packages/marionette_cli/lib/src/cli/commands/long_press_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/long_press_command.dart
@@ -9,6 +9,7 @@ class LongPressCommand extends InstanceCommand {
   LongPressCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., ListTile).')
       ..addOption('x', help: 'X coordinate for positional long press.')
@@ -30,12 +31,13 @@ class LongPressCommand extends InstanceCommand {
 
   @override
   String get description =>
-      'Long press an element by key, text, type, or coordinates.';
+      'Long press an element by key, identifier, text, type, or coordinates.';
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
@@ -44,7 +46,8 @@ class LongPressCommand extends InstanceCommand {
 
     if (matcher.isEmpty) {
       usageException(
-        'At least one matcher required: --key, --text, --type, or --x/--y.',
+        'At least one matcher required: --key, --identifier, --text, --type, '
+        'or --x/--y.',
       );
     }
 

--- a/packages/marionette_cli/lib/src/cli/commands/pinch_zoom_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/pinch_zoom_command.dart
@@ -9,6 +9,7 @@ class PinchZoomCommand extends InstanceCommand {
   PinchZoomCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., InteractiveViewer).')
       ..addOption('x', help: 'X coordinate for pinch center.')
@@ -35,12 +36,14 @@ class PinchZoomCommand extends InstanceCommand {
 
   @override
   String get description =>
-      'Pinch zoom on an element by key, text, type, or coordinates.';
+      'Pinch zoom on an element by key, identifier, text, type, or '
+      'coordinates.';
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
@@ -55,7 +58,8 @@ class PinchZoomCommand extends InstanceCommand {
 
     if (matcher.isEmpty) {
       usageException(
-        'At least one matcher required: --key, --text, --type, or --x/--y.',
+        'At least one matcher required: --key, --identifier, --text, --type, '
+        'or --x/--y.',
       );
     }
 

--- a/packages/marionette_cli/lib/src/cli/commands/scroll_to_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/scroll_to_command.dart
@@ -9,6 +9,7 @@ class ScrollToCommand extends InstanceCommand {
   ScrollToCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text of the element to scroll to.');
   }
 
@@ -28,11 +29,14 @@ class ScrollToCommand extends InstanceCommand {
   Future<int> execute(VmServiceConnector connector) async {
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
     );
 
     if (matcher.isEmpty) {
-      usageException('At least one matcher required: --key or --text.');
+      usageException(
+        'At least one matcher required: --key, --identifier, or --text.',
+      );
     }
 
     final response = await connector.scrollToElement(matcher);

--- a/packages/marionette_cli/lib/src/cli/commands/secondary_tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/secondary_tap_command.dart
@@ -9,6 +9,7 @@ class SecondaryTapCommand extends InstanceCommand {
   SecondaryTapCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
       ..addOption('x', help: 'X coordinate for positional secondary tap.')
@@ -25,13 +26,14 @@ class SecondaryTapCommand extends InstanceCommand {
 
   @override
   String get description =>
-      'Secondary (right mouse button) tap an element by key, text, type, '
-      'or coordinates. Desktop only; triggers onSecondaryTap.';
+      'Secondary (right mouse button) tap an element by key, identifier, '
+      'text, type, or coordinates. Desktop only; triggers onSecondaryTap.';
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
@@ -40,7 +42,8 @@ class SecondaryTapCommand extends InstanceCommand {
 
     if (matcher.isEmpty) {
       usageException(
-        'At least one matcher required: --key, --text, --type, or --x/--y.',
+        'At least one matcher required: --key, --identifier, --text, --type, '
+        'or --x/--y.',
       );
     }
 

--- a/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
@@ -9,6 +9,7 @@ class SwipeCommand extends InstanceCommand {
   SwipeCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., PageView).')
       ..addOption(
@@ -40,9 +41,9 @@ class SwipeCommand extends InstanceCommand {
 
   @override
   String get description =>
-      'Swipe/drag on an element (key, text, or type) in a direction, '
-      'or between coordinates. Useful for PageView, Dismissible, Drawer, '
-      'and Slider widgets.';
+      'Swipe/drag on an element (key, identifier, text, or type) in a '
+      'direction, or between coordinates. Useful for PageView, Dismissible, '
+      'Drawer, and Slider widgets.';
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
@@ -55,6 +56,7 @@ class SwipeCommand extends InstanceCommand {
         startX != null || startY != null || endX != null || endY != null;
 
     final anyElement = argResults?['key'] != null ||
+        argResults?['identifier'] != null ||
         argResults?['text'] != null ||
         argResults?['type'] != null ||
         argResults?['direction'] != null ||
@@ -64,7 +66,8 @@ class SwipeCommand extends InstanceCommand {
       usageException(
         'Cannot mix coordinate-based options '
         '(--start-x/--start-y/--end-x/--end-y) with element-based options '
-        '(--key/--text/--type/--direction/--distance). Use one mode.',
+        '(--key/--identifier/--text/--type/--direction/--distance). '
+        'Use one mode.',
       );
     }
 
@@ -88,14 +91,15 @@ class SwipeCommand extends InstanceCommand {
     } else {
       final matcher = buildMatcherFromArgs(
         key: argResults?['key'] as String?,
+        identifier: argResults?['identifier'] as String?,
         text: argResults?['text'] as String?,
         type: argResults?['type'] as String?,
       );
       if (matcher.isEmpty) {
         usageException(
-          'Element-based swipe requires a matcher: --key, --text, or --type. '
-          'Alternatively provide --start-x/--start-y/--end-x/--end-y for '
-          'coordinate-based swipe.',
+          'Element-based swipe requires a matcher: --key, --identifier, '
+          '--text, or --type. Alternatively provide '
+          '--start-x/--start-y/--end-x/--end-y for coordinate-based swipe.',
         );
       }
 

--- a/packages/marionette_cli/lib/src/cli/commands/tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/tap_command.dart
@@ -9,6 +9,7 @@ class TapCommand extends InstanceCommand {
   TapCommand(this._registry) {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
+      ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
       ..addOption('x', help: 'X coordinate for positional tap.')
@@ -25,12 +26,13 @@ class TapCommand extends InstanceCommand {
 
   @override
   String get description =>
-      'Tap an element by key, text, type, or coordinates.';
+      'Tap an element by key, identifier, text, type, or coordinates.';
 
   @override
   Future<int> execute(VmServiceConnector connector) async {
     final matcher = buildMatcherFromArgs(
       key: argResults?['key'] as String?,
+      identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
@@ -39,7 +41,8 @@ class TapCommand extends InstanceCommand {
 
     if (matcher.isEmpty) {
       usageException(
-        'At least one matcher required: --key, --text, --type, or --x/--y.',
+        'At least one matcher required: --key, --identifier, --text, --type, '
+        'or --x/--y.',
       );
     }
 

--- a/packages/marionette_cli/lib/src/cli/matcher_builder.dart
+++ b/packages/marionette_cli/lib/src/cli/matcher_builder.dart
@@ -1,9 +1,10 @@
 /// Builds a widget matcher map from CLI arguments.
 ///
-/// Accepts named args like --key, --text, --type, --x, --y and
+/// Accepts named args like --key, --identifier, --text, --type, --x, --y and
 /// constructs the matcher map expected by [VmServiceConnector].
 Map<String, dynamic> buildMatcherFromArgs({
   String? key,
+  String? identifier,
   String? text,
   String? type,
   num? x,
@@ -12,6 +13,7 @@ Map<String, dynamic> buildMatcherFromArgs({
 }) {
   final matcher = <String, dynamic>{};
   if (key != null) matcher['key'] = key;
+  if (identifier != null) matcher['identifier'] = identifier;
   if (text != null) matcher['text'] = text;
   if (type != null) matcher['type'] = type;
   if (x != null) matcher['x'] = x;

--- a/packages/marionette_cli/test/matcher_builder_test.dart
+++ b/packages/marionette_cli/test/matcher_builder_test.dart
@@ -11,6 +11,13 @@ void main() {
       expect(buildMatcherFromArgs(key: 'btn'), equals({'key': 'btn'}));
     });
 
+    test('single identifier arg', () {
+      expect(
+        buildMatcherFromArgs(identifier: 'submit_button'),
+        equals({'identifier': 'submit_button'}),
+      );
+    });
+
     test('single text arg', () {
       expect(buildMatcherFromArgs(text: 'Submit'), equals({'text': 'Submit'}));
     });

--- a/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
@@ -59,8 +59,12 @@ class ElementTreeFinder {
     // shadow the inner button.
     final discoverableText = text ?? _extractSemanticsText(widget);
     final keyValue = _extractKeyValue(widget.key);
+    final identifierValue = _extractIdentifier(widget);
 
-    if (!isInteractive && discoverableText == null && keyValue == null) {
+    if (!isInteractive &&
+        discoverableText == null &&
+        keyValue == null &&
+        identifierValue == null) {
       return null;
     }
 
@@ -86,6 +90,10 @@ class ElementTreeFinder {
 
     if (keyValue != null) {
       data['key'] = keyValue;
+    }
+
+    if (identifierValue != null) {
+      data['identifier'] = identifierValue;
     }
 
     if (discoverableText != null) {
@@ -119,6 +127,21 @@ class ElementTreeFinder {
       return key.value;
     }
     return null;
+  }
+
+  /// Extracts the accessibility `identifier` from a `Semantics` widget.
+  ///
+  /// Unlike `label`/`value` (see [_extractSemanticsText]), the `identifier` is
+  /// a unique, machine-readable handle that lives only on the `Semantics`
+  /// widget, so it is both surfaced for discovery here and consulted by the
+  /// matcher path (see `IdentifierMatcher`). Returns null when the widget is
+  /// not a `Semantics` or carries no identifier, keeping the output quiet by
+  /// default.
+  static String? _extractIdentifier(Widget widget) {
+    if (widget is! Semantics) return null;
+    final identifier = widget.properties.identifier;
+    if (identifier == null || identifier.isEmpty) return null;
+    return identifier;
   }
 
   /// Discovery-only fallback: extracts the accessibility annotation from a

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -10,7 +10,7 @@ sealed class WidgetMatcher {
 
   /// Creates a matcher from a JSON map.
   /// If multiple fields are present, precedence is:
-  /// 'focused' > coordinates (x & y) > 'key' > 'text' > 'type'.
+  /// 'focused' > coordinates (x & y) > 'key' > 'identifier' > 'text' > 'type'.
   static WidgetMatcher fromJson(Map<String, dynamic> json) {
     // Focused matcher has highest precedence because it bypasses tree search.
     if (json.containsKey('focused')) {
@@ -19,13 +19,16 @@ sealed class WidgetMatcher {
       return CoordinatesMatcher.fromJson(json);
     } else if (json.containsKey('key')) {
       return KeyMatcher.fromJson(json);
+    } else if (json.containsKey('identifier')) {
+      return IdentifierMatcher.fromJson(json);
     } else if (json.containsKey('text')) {
       return TextMatcher.fromJson(json);
     } else if (json.containsKey('type')) {
       return TypeStringMatcher.fromJson(json);
     } else {
       throw ArgumentError(
-        'Matcher JSON must contain "focused", "x" & "y", "key", "text", or "type" field',
+        'Matcher JSON must contain "focused", "x" & "y", "key", '
+        '"identifier", "text", or "type" field',
       );
     }
   }
@@ -110,6 +113,46 @@ class KeyMatcher extends WidgetMatcher {
   @override
   Map<String, dynamic> toJson() {
     return <String, dynamic>{'key': keyValue};
+  }
+}
+
+/// Matches widgets by their `Semantics` identifier.
+///
+/// Unlike [TextMatcher], which is deliberately kept away from `Semantics`
+/// annotations (see the rationale on `MarionetteConfiguration`), the
+/// accessibility `identifier` is an explicit, unique, machine-readable handle
+/// set intentionally by the developer. It only ever lives on a [Semantics]
+/// widget — never on the inner control — so there is no ambiguity about which
+/// element to match. The matched `Semantics` wrapper shares the bounds of (and
+/// is hittable through) its child, so gestures land on the real control.
+///
+/// Convenience identifier parameters that other widgets forward to a generated
+/// `Semantics` are covered by the same mechanism: e.g. `Text(semanticsIdentifier:
+/// ...)` builds a `Semantics(identifier: ...)` wrapper, which this matcher then
+/// matches like any other. Per-span identifiers (`TextSpan.semanticsIdentifier`
+/// / `InlineSpan.semanticsIdentifier`) are applied at the `SemanticsNode` level
+/// inside `RenderParagraph`, not as widgets, so they are not matchable here.
+class IdentifierMatcher extends WidgetMatcher {
+  const IdentifierMatcher(this.identifierValue);
+
+  factory IdentifierMatcher.fromJson(Map<String, dynamic> json) {
+    return IdentifierMatcher(json['identifier'] as String);
+  }
+
+  final String identifierValue;
+
+  @override
+  bool matches(Element element, MarionetteConfiguration configuration) {
+    final widget = element.widget;
+    if (widget is Semantics) {
+      return widget.properties.identifier == identifierValue;
+    }
+    return false;
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'identifier': identifierValue};
   }
 }
 

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -143,9 +143,12 @@ class IdentifierMatcher extends WidgetMatcher {
 
   @override
   bool matches(Element element, MarionetteConfiguration configuration) {
-    final widget = element.widget;
-    if (widget is Semantics) {
-      return widget.properties.identifier == identifierValue;
+   if (identifierValue.isEmpty) {
+      return false;
+   }
+
+    if (element.widget case Semantics(:final properties)) {
+      return properties.identifier == identifierValue;
     }
     return false;
   }

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -143,9 +143,9 @@ class IdentifierMatcher extends WidgetMatcher {
 
   @override
   bool matches(Element element, MarionetteConfiguration configuration) {
-   if (identifierValue.isEmpty) {
+    if (identifierValue.isEmpty) {
       return false;
-   }
+    }
 
     if (element.widget case Semantics(:final properties)) {
       return properties.identifier == identifierValue;

--- a/packages/marionette_flutter/test/element_tree_finder_test.dart
+++ b/packages/marionette_flutter/test/element_tree_finder_test.dart
@@ -145,4 +145,62 @@ void main() {
       );
     });
   });
+
+  group('ElementTreeFinder identifier extraction', () {
+    testWidgets(
+        'Semantics with only an identifier (no label/value, no key) is '
+        'surfaced with its identifier so agents can discover it',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Semantics(
+                identifier: 'submit_button',
+                child: ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Submit'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final elements = _finder.findInteractiveElements();
+      expect(
+        elements.any(
+          (e) =>
+              e['type'] == 'Semantics' && e['identifier'] == 'submit_button',
+        ),
+        isTrue,
+        reason: 'An identifier-only Semantics wrapper must appear in '
+            'get_interactive_elements — mirroring how a keyed wrapper is '
+            'surfaced — otherwise agents cannot discover the identifier they '
+            'are told to match on',
+      );
+    });
+
+    testWidgets('Semantics with an empty identifier is not reported',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Semantics(
+              identifier: '',
+              child: Container(width: 100, height: 100, color: Colors.green),
+            ),
+          ),
+        ),
+      );
+
+      final elements = _finder.findInteractiveElements();
+      expect(
+        elements.any((e) => e['type'] == 'Semantics'),
+        isFalse,
+        reason: 'An empty identifier carries no content and should stay quiet, '
+            'consistent with the label/value discovery contract',
+      );
+    });
+  });
 }

--- a/packages/marionette_flutter/test/element_tree_finder_test.dart
+++ b/packages/marionette_flutter/test/element_tree_finder_test.dart
@@ -170,8 +170,7 @@ void main() {
       final elements = _finder.findInteractiveElements();
       expect(
         elements.any(
-          (e) =>
-              e['type'] == 'Semantics' && e['identifier'] == 'submit_button',
+          (e) => e['type'] == 'Semantics' && e['identifier'] == 'submit_button',
         ),
         isTrue,
         reason: 'An identifier-only Semantics wrapper must appear in '

--- a/packages/marionette_flutter/test/widget_matcher_semantics_test.dart
+++ b/packages/marionette_flutter/test/widget_matcher_semantics_test.dart
@@ -103,4 +103,127 @@ void main() {
       );
     });
   });
+
+  group('IdentifierMatcher with Semantics wrappers', () {
+    testWidgets(
+        'matches the Semantics wrapper and is hittable through its child',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Semantics(
+                identifier: 'submit_button',
+                child: ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Submit'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final element = WidgetFinder().findHittableElement(
+        const IdentifierMatcher('submit_button'),
+        _configuration,
+      );
+
+      expect(
+        element,
+        isNotNull,
+        reason: 'A Semantics identifier is an explicit, unique selector and '
+            'must be matchable — and hittable, since the wrapper shares the '
+            "child's bounds so the tap lands on the inner control",
+      );
+      expect(element!.widget, isA<Semantics>());
+      expect(
+        (element.widget as Semantics).properties.identifier,
+        'submit_button',
+      );
+
+      // The matched Semantics wrapper shares the bounds of its child, so a
+      // tap at its center reaches the underlying ElevatedButton.
+      final semanticsBox = element.renderObject! as RenderBox;
+      final buttonBox = tester.renderObject<RenderBox>(
+        find.byType(ElevatedButton),
+      );
+      expect(semanticsBox.size, buttonBox.size);
+      expect(
+        semanticsBox.localToGlobal(Offset.zero),
+        buttonBox.localToGlobal(Offset.zero),
+      );
+    });
+
+    testWidgets('does not match a Semantics widget without an identifier',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Semantics(
+                label: 'submit_button',
+                child: ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Submit'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final element = WidgetFinder().findElement(
+        const IdentifierMatcher('submit_button'),
+        _configuration,
+      );
+
+      expect(
+        element,
+        isNull,
+        reason: 'IdentifierMatcher must match the Semantics identifier, not '
+            'the label — a label that happens to equal the identifier value '
+            'must not produce a false match',
+      );
+    });
+
+    testWidgets(
+        'matches Text.semanticsIdentifier, which desugars to a Semantics '
+        'wrapper, and is hittable inside an interactive ancestor',
+        (tester) async {
+      // Text(semanticsIdentifier: ...) builds a Semantics(identifier: ...)
+      // wrapper internally, so the same matcher mechanism covers it — no
+      // per-widget special case needed.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () {},
+                child: const Text('Submit', semanticsIdentifier: 'submit_btn'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final element = WidgetFinder().findHittableElement(
+        const IdentifierMatcher('submit_btn'),
+        _configuration,
+      );
+
+      expect(
+        element,
+        isNotNull,
+        reason: 'Text.semanticsIdentifier forwards to a generated Semantics '
+            'wrapper, so identifier matching must find it; inside a button it '
+            'is hittable so tap/enter_text reach the control',
+      );
+      expect(element!.widget, isA<Semantics>());
+      expect(
+        (element.widget as Semantics).properties.identifier,
+        'submit_btn',
+      );
+    });
+  });
 }

--- a/packages/marionette_flutter/test/widget_matcher_semantics_test.dart
+++ b/packages/marionette_flutter/test/widget_matcher_semantics_test.dart
@@ -186,44 +186,5 @@ void main() {
             'must not produce a false match',
       );
     });
-
-    testWidgets(
-        'matches Text.semanticsIdentifier, which desugars to a Semantics '
-        'wrapper, and is hittable inside an interactive ancestor',
-        (tester) async {
-      // Text(semanticsIdentifier: ...) builds a Semantics(identifier: ...)
-      // wrapper internally, so the same matcher mechanism covers it — no
-      // per-widget special case needed.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: ElevatedButton(
-                onPressed: () {},
-                child: const Text('Submit', semanticsIdentifier: 'submit_btn'),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final element = WidgetFinder().findHittableElement(
-        const IdentifierMatcher('submit_btn'),
-        _configuration,
-      );
-
-      expect(
-        element,
-        isNotNull,
-        reason: 'Text.semanticsIdentifier forwards to a generated Semantics '
-            'wrapper, so identifier matching must find it; inside a button it '
-            'is hittable so tap/enter_text reach the control',
-      );
-      expect(element!.widget, isA<Semantics>());
-      expect(
-        (element.widget as Semantics).properties.identifier,
-        'submit_btn',
-      );
-    });
   });
 }

--- a/packages/marionette_flutter/test/widget_matcher_test.dart
+++ b/packages/marionette_flutter/test/widget_matcher_test.dart
@@ -17,6 +17,31 @@ void main() {
 
       expect(matcher, isA<FocusedElementMatcher>());
     });
+
+    test('returns IdentifierMatcher for identifier matcher', () {
+      final matcher = WidgetMatcher.fromJson({'identifier': 'submit_button'});
+
+      expect(matcher, isA<IdentifierMatcher>());
+      expect((matcher as IdentifierMatcher).identifierValue, 'submit_button');
+    });
+
+    test('key takes precedence over identifier', () {
+      final matcher = WidgetMatcher.fromJson({
+        'key': 'submit_key',
+        'identifier': 'submit_id',
+      });
+
+      expect(matcher, isA<KeyMatcher>());
+    });
+
+    test('identifier takes precedence over text', () {
+      final matcher = WidgetMatcher.fromJson({
+        'identifier': 'submit_id',
+        'text': 'Submit',
+      });
+
+      expect(matcher, isA<IdentifierMatcher>());
+    });
   });
 
   group('FocusedElementMatcher', () {
@@ -24,6 +49,22 @@ void main() {
       const matcher = FocusedElementMatcher();
 
       expect(matcher.toJson(), {'focused': true});
+    });
+  });
+
+  group('IdentifierMatcher', () {
+    test('serializes to identifier json', () {
+      const matcher = IdentifierMatcher('submit_button');
+
+      expect(matcher.toJson(), {'identifier': 'submit_button'});
+    });
+
+    test('round-trips through fromJson/toJson', () {
+      const original = IdentifierMatcher('submit_button');
+      final restored = WidgetMatcher.fromJson(original.toJson());
+
+      expect(restored, isA<IdentifierMatcher>());
+      expect((restored as IdentifierMatcher).identifierValue, 'submit_button');
     });
   });
 }

--- a/packages/marionette_mcp/lib/src/formatting.dart
+++ b/packages/marionette_mcp/lib/src/formatting.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 /// Builds a widget matcher map from tool/CLI arguments.
 ///
-/// Supports matching by key, text, type, and coordinates.
+/// Supports matching by key, identifier, text, type, and coordinates.
 Map<String, dynamic> buildMatcher(Map<String, dynamic> args) {
   final matcher = <String, dynamic>{};
   if (args['focused_element'] == true) {
@@ -15,6 +15,9 @@ Map<String, dynamic> buildMatcher(Map<String, dynamic> args) {
   }
   if (args.containsKey('key')) {
     matcher['key'] = args['key'];
+  }
+  if (args.containsKey('identifier')) {
+    matcher['identifier'] = args['identifier'];
   }
   if (args.containsKey('text')) {
     matcher['text'] = args['text'];

--- a/packages/marionette_mcp/lib/src/mcp_server_runner.dart
+++ b/packages/marionette_mcp/lib/src/mcp_server_runner.dart
@@ -18,7 +18,7 @@ Usage:
 6. Use "hot_reload" after making code changes to reload the app without losing state.
 7. Use "hot_restart" to fully restart the app from main() and reset all state — needed for changes a hot reload cannot pick up (e.g. main()/bootstrap edits, global singletons, or state shape). Requires the app to be running via `flutter run`.
 
-Important: Elements are matched by their key (ValueKey<String>) or text content. Keys are more reliable. If you cannot locate a widget, you may need to add a ValueKey to it in the Flutter source code. For example: `ElevatedButton(key: ValueKey('submit_button'), ...)`.
+Important: Elements are matched by their key (ValueKey<String>), Semantics identifier, or text content. Keys are the most reliable; a Semantics identifier (set via `Semantics(identifier: ...)`) is an equally stable alternative when adding a key is not practical. If you cannot locate a widget, you may need to add a ValueKey to it in the Flutter source code. For example: `ElevatedButton(key: ValueKey('submit_button'), ...)`.
 ''';
 
 /// Runs the Marionette MCP server with the given configuration.

--- a/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
@@ -15,13 +15,20 @@ void registerGestureTools(
     ..registerTool(
       'tap',
       description:
-          'Simulates a tap gesture on an element in the Flutter app that matches the given criteria. You can match elements by their key (a ValueKey<String>), by their text content (but not accessibility!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, text, type, or coordinates. Prefer using the key if available, as it is more reliable. Limit yourself to elements from get_interactive_elements only if you can. Tapping a text field gives it focus, after which you can use enter_text with focused_element to type into it. Requires an active connection established via connect.',
+          'Simulates a tap gesture on an element in the Flutter app that matches the given criteria. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content (but not accessibility label!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, identifier, text, type, or coordinates. Prefer using the key if available, as it is more reliable; the Semantics identifier is the next-best stable selector. Limit yourself to elements from get_interactive_elements only if you can. Tapping a text field gives it focus, after which you can use enter_text with focused_element to type into it. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
           'key': JsonSchema.string(
             description:
                 'The key of the element to tap. You can get the key of an element by calling get_interactive_elements.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to tap. A stable, '
+                'unique, accessibility identifier set via Semantics(identifier: ...). '
+                'Useful when an element has no ValueKey but does set an identifier. '
+                'You can discover identifiers by calling get_interactive_elements.',
           ),
           'text': JsonSchema.string(
             description:
@@ -62,13 +69,19 @@ void registerGestureTools(
     ..registerTool(
       'secondary_tap',
       description:
-          'Simulates a secondary tap (right mouse button click) on an element in the Flutter app. Desktop only — dispatches a mouse pointer with the secondary button pressed, which is what Flutter recognises as onSecondaryTap (e.g. for opening context menus). You can match elements by their key (a ValueKey<String>), by their text content, by their widget type, or by screen coordinates. Only one matching method should be used. Prefer using the key if available, as it is more reliable. Requires an active connection established via connect.',
+          'Simulates a secondary tap (right mouse button click) on an element in the Flutter app. Desktop only — dispatches a mouse pointer with the secondary button pressed, which is what Flutter recognises as onSecondaryTap (e.g. for opening context menus). You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content, by their widget type, or by screen coordinates. Only one matching method should be used. Prefer using the key if available, as it is more reliable. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Secondary Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
           'key': JsonSchema.string(
             description:
                 'The key of the element to secondary tap. You can get the key of an element by calling get_interactive_elements.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to secondary tap. A '
+                'stable, unique accessibility identifier set via '
+                'Semantics(identifier: ...).',
           ),
           'text': JsonSchema.string(
             description:
@@ -110,13 +123,19 @@ void registerGestureTools(
     ..registerTool(
       'double_tap',
       description:
-          'Simulates a double tap gesture on an element in the Flutter app. This is useful for triggering text selection, zoom, or any widget that responds to double tap. You can match elements by their key, text, type, or coordinates. An optional delay parameter controls the time between the two taps (default: 100ms). Requires an active connection established via connect.',
+          'Simulates a double tap gesture on an element in the Flutter app. This is useful for triggering text selection, zoom, or any widget that responds to double tap. You can match elements by their key, identifier, text, type, or coordinates. An optional delay parameter controls the time between the two taps (default: 100ms). Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Double Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
           'key': JsonSchema.string(
             description:
                 'The key of the element to double tap. You can get the key of an element by calling get_interactive_elements.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to double tap. A '
+                'stable, unique accessibility identifier set via '
+                'Semantics(identifier: ...).',
           ),
           'text': JsonSchema.string(
             description:
@@ -173,13 +192,19 @@ void registerGestureTools(
     ..registerTool(
       'long_press',
       description:
-          'Simulates a long press gesture on an element in the Flutter app. This is useful for triggering context menus, reorderable lists, or any widget that responds to long press. You can match elements by their key, text, type, or coordinates. An optional duration parameter controls how long the press is held (default: 600ms). Requires an active connection established via connect.',
+          'Simulates a long press gesture on an element in the Flutter app. This is useful for triggering context menus, reorderable lists, or any widget that responds to long press. You can match elements by their key, identifier, text, type, or coordinates. An optional duration parameter controls how long the press is held (default: 600ms). Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Long Press Element'),
       inputSchema: ToolInputSchema(
         properties: {
           'key': JsonSchema.string(
             description:
                 'The key of the element to long press. You can get the key of an element by calling get_interactive_elements.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to long press. A '
+                'stable, unique accessibility identifier set via '
+                'Semantics(identifier: ...).',
           ),
           'text': JsonSchema.string(
             description:
@@ -230,7 +255,7 @@ void registerGestureTools(
       'swipe',
       description:
           'Simulates a swipe/drag gesture on the Flutter app. Supports two modes: '
-          '1. Element-based: provide key or text to identify the element, plus a direction (left, right, up, down) and optional distance in pixels (default 200). '
+          '1. Element-based: provide key, identifier, or text to identify the element, plus a direction (left, right, up, down) and optional distance in pixels (default 200). '
           '2. Coordinate-based: provide startX, startY, endX, endY for precise control. '
           'Useful for interacting with PageView, Dismissible, Drawer, Slider, and other swipe-based widgets. '
           'Requires an active connection established via connect.',
@@ -240,6 +265,12 @@ void registerGestureTools(
           'key': JsonSchema.string(
             description:
                 'The key of the element to swipe on. Use with direction.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to swipe on. Use with '
+                'direction. A stable, unique accessibility identifier set via '
+                'Semantics(identifier: ...).',
           ),
           'text': JsonSchema.string(
             description:
@@ -324,14 +355,20 @@ void registerGestureTools(
           'Simulates a pinch zoom gesture on an element in the Flutter app. '
           'Use scale > 1.0 to zoom in (fingers move apart) and scale < 1.0 '
           'to zoom out (fingers move together). You can target the element by '
-          'key, text, type, or coordinates. Useful for maps, images, PDFs, '
-          'and other zoomable content. '
+          'key, identifier, text, type, or coordinates. Useful for maps, '
+          'images, PDFs, and other zoomable content. '
           'Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Pinch Zoom'),
       inputSchema: ToolInputSchema(
         properties: {
           'key': JsonSchema.string(
             description: 'The key of the element to pinch zoom on.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to pinch zoom on. A '
+                'stable, unique accessibility identifier set via '
+                'Semantics(identifier: ...).',
           ),
           'text': JsonSchema.string(
             description:
@@ -445,13 +482,19 @@ void registerGestureTools(
     ..registerTool(
       'scroll_to',
       description:
-          'Scrolls the view until an element matching the given criteria becomes visible. You can match elements by their key (a ValueKey<String>) or by their visible text content. This is useful when you need to interact with elements that are not currently visible on screen. Requires an active connection established via connect.',
+          'Scrolls the view until an element matching the given criteria becomes visible. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, or by their visible text content. This is useful when you need to interact with elements that are not currently visible on screen. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Scroll to Element'),
       inputSchema: ToolInputSchema(
         properties: {
           'key': JsonSchema.string(
             description:
                 'The key of the element to scroll to. You can get the key of an element by calling get_interactive_elements.',
+          ),
+          'identifier': JsonSchema.string(
+            description:
+                'The Semantics identifier of the element to scroll to. A '
+                'stable, unique accessibility identifier set via '
+                'Semantics(identifier: ...).',
           ),
           'text': JsonSchema.string(
             description:

--- a/packages/marionette_mcp/lib/src/vm_service/tools/text_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/text_tools.dart
@@ -13,7 +13,7 @@ void registerTextTools(
   server.registerTool(
     'enter_text',
     description:
-        'Enters text into a text field in the Flutter app. You can target the field in two ways: 1. By key: provide the key parameter with the ValueKey<String> of the field. You can discover available keys by calling get_interactive_elements. 2. By focused element: first tap a text field to give it focus, then call enter_text with focused_element set to true. This is useful when the field does not have a ValueKey assigned. Important: a text field must be focused before calling this (for example by using the tap tool), otherwise it will fail with an error. Exactly one of key or focused_element must be provided. Requires an active connection established via connect.',
+        'Enters text into a text field in the Flutter app. You can target the field in three ways: 1. By key: provide the key parameter with the ValueKey<String> of the field. You can discover available keys by calling get_interactive_elements. 2. By Semantics identifier: provide the identifier parameter with the accessibility identifier of the field. Useful when the field has no ValueKey but does set a Semantics identifier. 3. By focused element: first tap a text field to give it focus, then call enter_text with focused_element set to true. Important: when targeting by focused element, a text field must be focused before calling this (for example by using the tap tool), otherwise it will fail with an error. Exactly one of key, identifier, or focused_element must be provided. Requires an active connection established via connect.',
     annotations: const ToolAnnotations(title: 'Enter Text'),
     inputSchema: ToolInputSchema(
       properties: {
@@ -23,6 +23,12 @@ void registerTextTools(
         'key': JsonSchema.string(
           description:
               'The key of the text field. You can get the key of an element by calling get_interactive_elements.',
+        ),
+        'identifier': JsonSchema.string(
+          description:
+              'The Semantics identifier of the text field. A stable, unique '
+              'accessibility identifier set via Semantics(identifier: ...). '
+              'You can discover identifiers by calling get_interactive_elements.',
         ),
         'focused_element': JsonSchema.boolean(
           description:
@@ -35,15 +41,18 @@ void registerTextTools(
     callback: (args, extra) async {
       final input = args['input'] as String;
       final hasKey = args['key'] != null;
+      final hasIdentifier = args['identifier'] != null;
       final hasFocusedElement = args['focused_element'] == true;
 
-      if (hasKey == hasFocusedElement) {
+      final selectorCount =
+          [hasKey, hasIdentifier, hasFocusedElement].where((e) => e).length;
+      if (selectorCount != 1) {
         return CallToolResult(
           isError: true,
           content: [
             const TextContent(
               text:
-                  'enter_text requires exactly one selector: provide either key or focused_element=true.',
+                  'enter_text requires exactly one selector: provide key, identifier, or focused_element=true.',
             ),
           ],
         );

--- a/packages/marionette_mcp/test/stdio_server_test.dart
+++ b/packages/marionette_mcp/test/stdio_server_test.dart
@@ -44,7 +44,10 @@ void main() {
           'params': {
             'protocolVersion': '2025-06-18',
             'capabilities': {
-              'tasks': {'list': <String, dynamic>{}, 'cancel': <String, dynamic>{}},
+              'tasks': {
+                'list': <String, dynamic>{},
+                'cancel': <String, dynamic>{}
+              },
             },
             'clientInfo': {'name': 'copilot', 'version': '1.0.0'},
           },


### PR DESCRIPTION
## Summary

Adds **`identifier`** as a first-class selector across Marionette, matching widgets by their `Semantics` identifier in addition to the existing `key`, `text`, `type`, and `coordinates`. Every gesture/text action — `tap`, `secondary_tap`, `double_tap`, `long_press`, `swipe`, `pinch_zoom`, `scroll_to`, and `enter_text` — accepts it (CLI: `--identifier`), and `get_interactive_elements` now surfaces the identifier so agents can discover it.

No public API changes. Fully backward compatible — existing `key`/`text`/`type`/`coordinates`/`focused` paths are unchanged.

## Why

Marionette already matched by `key` (a `ValueKey<String>`) and `text`, but both have gaps that the **Semantics identifier** is purpose-built to fill (see [Code With Andrea — Semantics Identifiers for UI Testing](https://codewithandrea.com/tips/semantics-identifiers-ui-testing/)):

- **Text-based matching is fragile.** A `TextMatcher('Submit')` breaks the moment the app is localized or the copy changes — the selector and the visible string are coupled. An identifier is language-independent and stable across copy changes.
- **`ValueKey` does not reach the semantics tree.** A `ValueKey` only exists in Flutter's widget tree. The tooling teams already use for UI testing — Maestro, Appium, and native integration tests — drives the app through the **accessibility / semantics tree**, which a `ValueKey` never reaches. `Semantics(identifier:)` is the one handle that lives in both places.
- **One identifier, reused everywhere.** Teams that already annotate widgets with `Semantics(identifier:)` for their existing UI-testing stack get Marionette matching for free, with no second set of `ValueKey`s to maintain.

Critically, `identifier` avoids the ambiguity that deliberately keeps `label`/`value` out of the matcher path (see #72). A `label` like `"Submit"` collides with the rendered `Text("Submit")`, so the matcher cannot tell the `Semantics` wrapper apart from the inner control. An `identifier` is a unique, machine-readable handle that only ever lives on the `Semantics` widget — never on the inner control — so there is no ambiguity, and matching it is safe.

## What changed

### Core matcher

Adds `IdentifierMatcher` (matches `Semantics.properties.identifier`), wired into `WidgetMatcher.fromJson` with precedence `focused > coordinates > key > identifier > text > type`. The matched `Semantics` wrapper shares the bounds of (and is hittable through) its child, so a tap matched by `identifier` lands on the real control underneath.

### MCP + CLI, kept in sync

`identifier` is threaded through **both** matcher builders — `formatting.buildMatcher` (MCP) and `matcher_builder.buildMatcherFromArgs` (CLI) — and exposed on every gesture/text tool and command, mirroring the existing per-action pattern.

### `enter_text` selector check relaxed

The selector requirement loosens from `key` **XOR** `focused_element` to **exactly one of** `key` / `identifier` / `focused_element`. This is a relaxation, so every previously valid call still succeeds.

### Discovery: surface the identifier

`ElementTreeFinder` now extracts `Semantics.identifier` the same way it already extracts `ValueKey` — added to the discovery gate and emitted as an `identifier` field. Without this, an identifier-only wrapper (the recommended pattern) was dropped from `get_interactive_elements`, leaving agents able to match on an identifier but unable to discover it.

### `Text.semanticsIdentifier` — covered, no special case

`Text('Submit', semanticsIdentifier: 'submit_btn')` builds a `Semantics(identifier: 'submit_btn')` wrapper internally, so the same matcher covers it with no per-widget handling. Per-span `TextSpan`/`InlineSpan.semanticsIdentifier` live on the `SemanticsNode` inside `RenderParagraph` (not a widget in the tree), so they are out of scope and documented as such.

## Behavior

| Selector | Matcher behavior | Discovery output |
|---|---|---|
| `Semantics(identifier: 'submit_btn', child: ElevatedButton(...))` | `IdentifierMatcher('submit_btn')` matches the wrapper; tap reaches the button | `Type: Semantics, identifier: 'submit_btn'` (hittable) |
| `Text('Submit', semanticsIdentifier: 'submit_btn')` | Matched via the generated `Semantics` wrapper | Surfaced when hittable, like any element |
| `Semantics(label: 'submit_btn', child: ...)` | **Not** matched by `IdentifierMatcher('submit_btn')` — label ≠ identifier | `Type: Semantics, text: 'submit_btn'` |
| `Semantics(identifier: '')` (empty) | Not matched | Not reported (quiet by default) |
| `TextSpan(text: 'x', semanticsIdentifier: 'y')` | Not matchable (semantics-node level, not a widget) | n/a |

## Documentation

- `docs/semantics.md`: reframes the discovery-only contract to apply to `label`/`value`, adds a **Matching by `identifier`** section, a **Pattern C** (machine-readable selectors belong in `identifier`, not `label`, so screen readers never announce them), and the `Text.semanticsIdentifier` coverage + span-level limitation.
- `docs/mcp-tools.md`, `docs/cli.md`: selector lists updated.
- MCP server `_instructions` and CLI `help-ai` reference updated.
- Dartdoc on `IdentifierMatcher` documenting why it is safe to match (unlike `label`/`text`) and what it does/doesn't cover.

## Test plan

All suites pass; `dart analyze` clean across all three packages.

**`marionette_flutter`** (138 pass; +10 net new):
- `widget_matcher_test.dart`: `IdentifierMatcher` from/to JSON, round-trip, and precedence (`key > identifier > text`).
- `widget_matcher_semantics_test.dart`: matches the wrapper and is hittable with bounds equal to the child; does **not** match a same-valued `label`; matches `Text.semanticsIdentifier` (hittable inside a button).
- `element_tree_finder_test.dart`: identifier-only `Semantics` is surfaced with its `identifier`; empty identifier stays quiet.

**`marionette_cli`** (89 pass; +1 net new):
- `matcher_builder_test.dart`: `--identifier` produces `{identifier: ...}`.

**`marionette_mcp`** (145 pass; unchanged).
