### PR TITLE
fix: declare meta as a direct dependency of marionette_flutter

### DIFF
--- a/packages/marionette_flutter/pubspec.yaml
+++ b/packages/marionette_flutter/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  meta: ^1.15.0
   web: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
## Problem
The 0.6.0 publish failed at the `marionette_flutter` step:

```
line 1, column 1 of lib/src/binding/extension_schema.dart:
This package does not have meta in the `dependencies` section of `pubspec.yaml`.
```

`extension_schema.dart` (added with the typed-schema DSL in #78) imports `package:meta`, but `marionette_flutter` only received `meta` transitively through the Flutter SDK. `dart analyze`/`flutter analyze` therefore passed in CI, while the stricter `pub publish` validation rejects an undeclared direct dependency — so the failure only surfaced at publish time.

Nothing was uploaded to pub.dev (validation runs before upload), so 0.6.0 is still free.

## Fix
Declare `meta: ^1.15.0` as a direct dependency. The lower bound keeps the minimum supported Flutter (3.27.0) resolvable; `pub publish --dry-run` now passes with no errors.

After merge, the `v0.6.0` tag will be re-pointed to the fixed commit to re-trigger publishing.