### PR TITLE
fix(marionette_flutter): fail loud, not silently, on double binding init

### DIFF
--- a/docs/flutter-setup.md
+++ b/docs/flutter-setup.md
@@ -56,11 +56,13 @@ Keep `MarionetteBinding` in your production `main()` (`lib/main.dart`) and creat
 
 ### Watch out for plugins that install their own binding
 
-The same rule bites in production, not just under `flutter test` — and it's much harder to spot there, because it doesn't always look like a crash.
+The same rule bites in production, not just under `flutter test`. Some plugins install their own `WidgetsBinding` subclass as part of their own initialization, before your app code runs. Sentry is one example.
 
-Some plugins install their own `WidgetsBinding` subclass as part of their own `init()`, before your `appRunner` code runs. **Sentry is the known case**: `SentryFlutter.init()` always registers a `WidgetsFlutterBindingIntegration` that calls `WidgetsBinding.ensureInitialized()` before invoking `appRunner` — so if `MarionetteBinding.ensureInitialized()` is the first line of your `appRunner`, the "real" binding has already been claimed by Sentry by the time it runs.
+#### Sentry
 
-Normally this would throw immediately and you'd notice right away. With Sentry specifically, it doesn't: the app just hangs on the native splash screen forever, with **no exception, no crash, and no log output**. That's because `appRunner` executes inside Sentry's own error-capturing zone, which intercepts the binding error as if it were a reportable crash instead of letting it surface to your console — so nothing after the `ensureInitialized()` call ever runs, including `runApp()`. See [#96](https://github.com/leancodepl/marionette_mcp/issues/96) for a full repro.
+`SentryFlutter.init()` always registers a `WidgetsFlutterBindingIntegration` that calls `WidgetsBinding.ensureInitialized()` before invoking `appRunner` — so if `MarionetteBinding.ensureInitialized()` is the first line of your `appRunner`, the "real" binding has already been claimed by Sentry by the time it runs.
+
+Normally this would throw immediately and you'd notice right away. With Sentry it doesn't: the app just hangs on the native splash screen forever, with **no exception, no crash, and no log output**. That's because `appRunner` executes inside Sentry's own error-capturing zone, which intercepts the binding error as if it were a reportable crash instead of letting it surface to your console — so nothing after the `ensureInitialized()` call ever runs, including `runApp()`. See [#96](https://github.com/leancodepl/marionette_mcp/issues/96) for a full repro.
 
 The fix is to initialize `MarionetteBinding` **before** `SentryFlutter.init()`, not inside its `appRunner`:
 

--- a/docs/flutter-setup.md
+++ b/docs/flutter-setup.md
@@ -33,7 +33,7 @@ The zero-config setup above recognizes the **standard Flutter widgets**: buttons
 
 ## Single-binding rule
 
-Flutter allows only **one** `WidgetsBinding` per process. `MarionetteBinding` is a binding. If another binding (e.g. `AutomatedTestWidgetsFlutterBinding` from `flutter test`, or `IntegrationTestWidgetsFlutterBinding`) is already initialized, calling `MarionetteBinding.ensureInitialized()` throws a binding assertion error.
+Flutter allows only **one** `WidgetsBinding` per process. `MarionetteBinding` is a binding. If another binding (e.g. `AutomatedTestWidgetsFlutterBinding` from `flutter test`, or `IntegrationTestWidgetsFlutterBinding`) is already initialized, calling `MarionetteBinding.ensureInitialized()` throws a clear error telling you which binding got there first.
 
 This commonly bites when your test calls `main()` and `kDebugMode` is `true` during tests. Two ways to avoid it:
 
@@ -53,6 +53,33 @@ if (kDebugMode && !isFlutterTest) {
 ### Option B — Use a separate test entrypoint
 
 Keep `MarionetteBinding` in your production `main()` (`lib/main.dart`) and create a different entrypoint for tests (e.g. `lib/main_test.dart`) that does **not** initialize `MarionetteBinding`.
+
+### Watch out for plugins that install their own binding
+
+The same rule bites in production, not just under `flutter test` — and it's much harder to spot there, because it doesn't always look like a crash.
+
+Some plugins install their own `WidgetsBinding` subclass as part of their own `init()`, before your `appRunner` code runs. **Sentry is the known case**: `SentryFlutter.init()` always registers a `WidgetsFlutterBindingIntegration` that calls `WidgetsBinding.ensureInitialized()` before invoking `appRunner` — so if `MarionetteBinding.ensureInitialized()` is the first line of your `appRunner`, the "real" binding has already been claimed by Sentry by the time it runs.
+
+Normally this would throw immediately and you'd notice right away. With Sentry specifically, it doesn't: the app just hangs on the native splash screen forever, with **no exception, no crash, and no log output**. That's because `appRunner` executes inside Sentry's own error-capturing zone, which intercepts the binding error as if it were a reportable crash instead of letting it surface to your console — so nothing after the `ensureInitialized()` call ever runs, including `runApp()`. See [#96](https://github.com/leancodepl/marionette_mcp/issues/96) for a full repro.
+
+The fix is to initialize `MarionetteBinding` **before** `SentryFlutter.init()`, not inside its `appRunner`:
+
+```dart
+void main() {
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized();
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
+
+  SentryFlutter.init(
+    (options) => options.dsn = _sentryDsn,
+    appRunner: () => runApp(const MyApp()),
+  );
+}
+```
+
+Sentry's own binding setup checks for an existing `WidgetsBinding` first and reuses it rather than replacing it, so initializing Marionette first avoids the conflict entirely. The same fix applies to any other plugin whose `init()` touches `WidgetsBinding` ahead of your `appRunner`.
 
 ## Next steps
 

--- a/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
@@ -40,9 +40,11 @@ class MarionetteBinding extends WidgetsFlutterBinding {
   /// screen with no exception, crash, or log output. See
   /// https://github.com/leancodepl/marionette_mcp/issues/96.
   ///
-  /// To avoid this, call [ensureInitialized] as the very first statement in
-  /// `main()`/`appRunner`, before any other plugin initialization
-  /// (including `SentryFlutter.init()`).
+  /// To avoid this, call [ensureInitialized] early in `main()`, before any
+  /// other plugin initialization that might touch `WidgetsBinding`. When a
+  /// plugin installs the binding from inside a callback it runs for you (as
+  /// `SentryFlutter.init()` does with its `appRunner`), call
+  /// [ensureInitialized] before that plugin — not inside the callback.
   static MarionetteBinding ensureInitialized([
     MarionetteConfiguration configuration = const MarionetteConfiguration(),
   ]) {
@@ -57,16 +59,17 @@ class MarionetteBinding extends WidgetsFlutterBinding {
           ),
           ErrorDescription(
             'Flutter only supports a single WidgetsBinding instance per '
-            'app. This usually happens when another plugin (for example, '
-            'Sentry via SentryFlutter.init(), which installs its own '
-            'binding as part of its default integrations before your '
-            'appRunner callback runs) initializes the binding first.',
+            'app. This usually happens when another plugin initializes the '
+            'binding first — for example, a plugin that installs its own '
+            'binding from within a callback that runs before your app code.',
           ),
           ErrorHint(
-            'Call MarionetteBinding.ensureInitialized() as the very first '
-            'statement in your main()/appRunner, before any other plugin '
-            'initialization that might touch WidgetsBinding — including '
-            'SentryFlutter.init().',
+            'Call MarionetteBinding.ensureInitialized() early in main(), '
+            'before any other plugin initialization that might touch '
+            'WidgetsBinding. If a plugin initializes the binding from '
+            'inside a callback it invokes for you (such as an appRunner), '
+            'call MarionetteBinding.ensureInitialized() before that plugin '
+            'rather than inside the callback.',
           ),
         ]);
       }

--- a/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
@@ -26,13 +26,63 @@ class MarionetteBinding extends WidgetsFlutterBinding {
   /// Creates and initializes the binding with the given configuration.
   ///
   /// Returns the singleton instance of [MarionetteBinding].
+  ///
+  /// Flutter only allows a single [WidgetsBinding] instance per app, so this
+  /// must be called before any other plugin has a chance to install its own
+  /// binding subclass. A common way to trip over this without realizing it
+  /// is calling `SentryFlutter.init()` first: it installs a
+  /// `WidgetsFlutterBindingIntegration` that initializes `WidgetsBinding`
+  /// itself before running `appRunner`, so by the time this method runs
+  /// inside `appRunner`, the "real" binding is already spoken for. Flutter's
+  /// binding constructor then fails an internal assertion, and — because
+  /// that happens inside Sentry's error-capturing zone — the failure is
+  /// swallowed rather than surfaced, leaving the app hung on the splash
+  /// screen with no exception, crash, or log output. See
+  /// https://github.com/leancodepl/marionette_mcp/issues/96.
+  ///
+  /// To avoid this, call [ensureInitialized] as the very first statement in
+  /// `main()`/`appRunner`, before any other plugin initialization
+  /// (including `SentryFlutter.init()`).
   static MarionetteBinding ensureInitialized([
     MarionetteConfiguration configuration = const MarionetteConfiguration(),
   ]) {
     if (_instance == null) {
+      final existing = _existingWidgetsBinding();
+      if (existing != null) {
+        throw FlutterError.fromParts([
+          ErrorSummary(
+            'MarionetteBinding.ensureInitialized() was called after a '
+            '${existing.runtimeType} was already installed as the '
+            'WidgetsBinding.',
+          ),
+          ErrorDescription(
+            'Flutter only supports a single WidgetsBinding instance per '
+            'app. This usually happens when another plugin (for example, '
+            'Sentry via SentryFlutter.init(), which installs its own '
+            'binding as part of its default integrations before your '
+            'appRunner callback runs) initializes the binding first.',
+          ),
+          ErrorHint(
+            'Call MarionetteBinding.ensureInitialized() as the very first '
+            'statement in your main()/appRunner, before any other plugin '
+            'initialization that might touch WidgetsBinding — including '
+            'SentryFlutter.init().',
+          ),
+        ]);
+      }
       MarionetteBinding._(configuration);
     }
     return instance;
+  }
+
+  /// Returns the currently installed [WidgetsBinding], if any, without
+  /// throwing when none has been initialized yet.
+  static WidgetsBinding? _existingWidgetsBinding() {
+    try {
+      return WidgetsBinding.instance;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// The singleton instance of [MarionetteBinding].

--- a/packages/marionette_flutter/test/marionette_binding_test.dart
+++ b/packages/marionette_flutter/test/marionette_binding_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/src/binding/marionette_binding.dart';
+
+void main() {
+  test(
+    'ensureInitialized throws a clear FlutterError when another '
+    'WidgetsBinding is already installed',
+    () {
+      // Simulates a plugin (e.g. Sentry's WidgetsFlutterBindingIntegration)
+      // installing its own binding before MarionetteBinding gets a chance
+      // to. See https://github.com/leancodepl/marionette_mcp/issues/96 —
+      // previously this scenario made MarionetteBinding.ensureInitialized()
+      // fail an internal Flutter assertion deep inside the binding
+      // constructor instead of a clear, catchable error.
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+      expect(
+        MarionetteBinding.ensureInitialized,
+        throwsA(
+          isA<FlutterError>().having(
+            (e) => e.toString(),
+            'message',
+            allOf(
+              contains('already installed'),
+              contains('MarionetteBinding.ensureInitialized()'),
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}


### PR DESCRIPTION
Fixes #96.

## Root cause

`MarionetteBinding.ensureInitialized()` assumes it's the first thing to construct a `WidgetsBinding`. That's not true when another plugin's `init()` installs its own binding before your `appRunner` runs — which is exactly what `SentryFlutter.init()` does: it always registers a `WidgetsFlutterBindingIntegration` that calls `WidgetsBinding.ensureInitialized()` (via `sentry_flutter`'s `BindingWrapper`/`SentryWidgetsFlutterBinding`) before invoking `appRunner` (confirmed by reading `sentry_flutter`'s source — `_createDefaultIntegrations` adds `WidgetsFlutterBindingIntegration()`, which runs as part of `Sentry.init()`, ahead of `appRunner`).

So by the time `MarionetteBinding.ensureInitialized()` runs inside `appRunner`, `WidgetsBinding.instance` is already a `SentryWidgetsFlutterBinding`. `MarionetteBinding`'s own singleton check (`_instance == null`) still passes, so it proceeds to construct a second `WidgetsFlutterBinding` subclass — which trips Flutter's internal assertion in `BindingBase()`'s constructor (`assert(_debugInitializedType == null, 'Binding is already initialized to $_debugInitializedType')`).

Normally an assertion failure here would be visible immediately. Under Sentry specifically, it isn't: `appRunner` executes inside Sentry's own error-capturing zone, which intercepts the assertion as a reportable error instead of letting it propagate to the console — so nothing after the `ensureInitialized()` call in `appRunner` ever runs, including `runApp()`. The result matches the report exactly: the app hangs on the native splash screen indefinitely, with no exception, no crash, and no log output.

I reproduced the mechanism locally against `sentry_flutter` 8.14.2 by tracing the actual call chain (`sentry_flutter.dart` → `_createDefaultIntegrations` → `WidgetsFlutterBindingIntegration.call` → `BindingWrapper.ensureInitialized` → `SentryWidgetsFlutterBinding.ensureInitialized`) and cross-checking against the Flutter SDK's `BindingBase` constructor assertion.

## Fix

- `MarionetteBinding.ensureInitialized()` now checks for an existing `WidgetsBinding` *before* attempting construction, and throws a clear, actionable `FlutterError` naming the conflicting binding type instead of letting Flutter's opaque internal assertion fire deep inside the constructor.
- `docs/flutter-setup.md`'s "Single-binding rule" section gets a new subsection documenting this specific production gotcha (distinct from the existing `flutter test` binding-conflict case) and the concrete fix: initialize `MarionetteBinding` **before** `SentryFlutter.init()`, not inside its `appRunner`. Sentry's own binding setup (`SentryWidgetsFlutterBinding.ensureInitialized()`) checks for an existing `WidgetsBinding` first and reuses it rather than replacing it, so ordering Marionette first avoids the conflict entirely — no Sentry-side change needed.
- Added `marionette_binding_test.dart`, which simulates a pre-existing binding via `TestWidgetsFlutterBinding.ensureInitialized()` and asserts the new clear-error behavior.

## Testing

From `packages/marionette_flutter`:
- `flutter analyze` — no issues found
- `flutter test` — 144 tests passed (including the new binding test)

## Note

This doesn't change Sentry's behavior or make Marionette and Sentry's bindings coexist simultaneously — Flutter only supports one `WidgetsBinding` per process, so that's not possible. What it does is turn a silent, undebuggable hang into a clear, fail-fast error for any case where the failure *does* surface, and — more importantly — gives Sentry users the actual, documented fix (initialization order) so they don't hit the silent-hang path at all.