### PR TITLE
fix(marionette_flutter): prefer the largest scrollable when the target isn't built yet

### DIFF
--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -79,20 +79,29 @@ class ScrollSimulator {
       return null;
     }
 
+    // The target isn't built yet (e.g. it's off-screen in a lazily built
+    // list), so it can't be found directly. Fall back to scanning the tree
+    // for candidate Scrollables. A screen can have more than one — a
+    // horizontal chip row or tab strip alongside the main vertical list, for
+    // example — so instead of taking the first scrollable-with-range found
+    // in traversal order (which can latch onto a small auxiliary
+    // scrollable and then scroll the wrong axis entirely), collect every
+    // candidate and prefer the one covering the most screen area: the main
+    // scroll body is almost always larger than an auxiliary strip/carousel.
     Element? fallbackScrollable;
-    Element? scrollableWithRange;
+    Element? bestScrollableWithRange;
+    var bestArea = -1.0;
 
     void visit(Element element) {
-      if (scrollableWithRange != null) {
-        return;
-      }
-
       if (element.widget is Scrollable) {
         fallbackScrollable ??= element;
         final position = _tryResolveScrollPosition(element);
         if (position != null && _hasScrollableRange(position)) {
-          scrollableWithRange = element;
-          return;
+          final area = _elementArea(element);
+          if (area > bestArea) {
+            bestArea = area;
+            bestScrollableWithRange = element;
+          }
         }
       }
 
@@ -100,7 +109,16 @@ class ScrollSimulator {
     }
 
     visit(root);
-    return scrollableWithRange ?? fallbackScrollable;
+    return bestScrollableWithRange ?? fallbackScrollable;
+  }
+
+  double _elementArea(Element element) {
+    final renderObject = element.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return 0;
+    }
+    final size = renderObject.size;
+    return size.width * size.height;
   }
 
   Element? _findScrollableAncestor(Element element) {

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -115,6 +115,70 @@ void main() {
         expect(dispatcher.dragCount, 200);
       },
     );
+
+    testWidgets(
+      'picks the main list over a smaller auxiliary scrollable that '
+      'appears first in the tree',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // Regression test for #76: a screen with a small horizontal chip
+        // row above the main vertical list used to make the fallback
+        // scrollable search latch onto the chip row (first
+        // scrollable-with-range found in traversal order) instead of the
+        // list actually containing the target, so scrollUntilVisible
+        // dragged the wrong axis and never reached below-the-fold targets.
+        final listController = ScrollController();
+        addTearDown(listController.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  SizedBox(
+                    height: 40,
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: 30,
+                      itemBuilder: (context, index) => SizedBox(
+                        width: 60,
+                        child: Center(child: Text('Chip $index')),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: ListView.builder(
+                      controller: listController,
+                      physics: const ClampingScrollPhysics(),
+                      itemCount: 60,
+                      itemBuilder: (context, index) => ListTile(
+                        key: ValueKey('item_$index'),
+                        minTileHeight: 80,
+                        title: Text('Item $index'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _LocationBasedGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const KeyMatcher('item_40'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_40')), findsOneWidget);
+        expect(listController.offset, greaterThan(0));
+      },
+    );
   });
 }
 
@@ -141,6 +205,23 @@ Widget _buildItemsApp({
       ),
     ),
   );
+}
+
+/// Mirrors the real [GestureDispatcher.drag]: dispatches the gesture at the
+/// given screen coordinates and lets Flutter's hit-testing route it,
+/// instead of targeting a fixed [Finder]. Needed to catch bugs where the
+/// wrong Scrollable is selected, since a Finder-based double would always
+/// drag the pre-selected widget regardless of what the simulator picked.
+class _LocationBasedGestureDispatcher extends GestureDispatcher {
+  _LocationBasedGestureDispatcher(this._tester);
+
+  final WidgetTester _tester;
+
+  @override
+  Future<void> drag(Offset from, Offset to) async {
+    await _tester.dragFrom(from, to - from);
+    await _tester.pump();
+  }
 }
 
 class _WidgetTesterGestureDispatcher extends GestureDispatcher {


### PR DESCRIPTION
Speculative fix for #76 ("marionette scroll-to failing on certain screens, limited reaching below-the-fold buttons"). **I don't have a repro** — the original report is one line and the reporter never followed up with details — so I want to be upfront that this is a best-guess based on reading the fallback scrollable-selection logic, not a confirmed root cause. Happy to close this if it turns out to be the wrong lead once/if a repro shows up.

## The bug I found

`ScrollSimulator._findScrollableElement` has two paths:
1. If the target widget is already built, walk up its ancestors to the nearest `Scrollable`. This is correct — nearest enclosing scrollable is unambiguous.
2. If the target *isn't* built yet (e.g. it's off-screen in a lazily built `ListView.builder`, so it doesn't exist in the tree until scrolled into range), fall back to scanning the whole tree for a `Scrollable`.

Path 2 is where this breaks: the old code returned the **first** `Scrollable` it found in traversal order that had a nonzero scroll range (`scrollableWithRange`), short-circuiting as soon as it found one. On a screen with more than one scrollable — a horizontal chip row, a tab strip, a small carousel placed before the main vertical list in the widget tree — the fallback can latch onto that smaller auxiliary scrollable instead of the list that actually contains the target.

Once the wrong scrollable is selected, everything downstream is wrong too: `direction` comes from `scrollableWidget.axisDirection` of the *wrong* element (e.g. horizontal instead of vertical), and the real gesture dispatcher computes the drag's screen coordinates from that wrong element's `renderObject.localToGlobal(center)` — so the actual synthetic drag happens at the auxiliary scrollable's on-screen location, scrolling it back and forth, while the main list (and the below-the-fold target inside it) never moves. That matches the report: scrolling silently does nothing useful, and buttons below the fold stay unreachable.

## The fix

Instead of stopping at the first scrollable-with-range found, collect all of them and pick the one covering the most screen area (`RenderBox.size.width * height`). Heuristic reasoning: the main content scroll body is almost always the largest scrollable on screen; auxiliary strips/carousels/tab bars are usually much smaller in at least one dimension.

## Test

Added a regression test in `scroll_simulator_test.dart`: a `Column` with a small horizontal chip-row `ListView` on top and the real target list (with a lazily-built target 40 items in) below. It uses a new location-based gesture-dispatcher test double (`dragFrom`-based, matching how the real `GestureDispatcher` dispatches at literal screen coordinates) instead of the existing Finder-based double, since a Finder-based double can't actually catch "wrong scrollable selected" bugs — it always drags whatever Finder it's given regardless of what the simulator picked.

Verified the test is a real regression test, not a false positive: it **fails** against the pre-fix selection logic (confirmed by temporarily reverting just the source change and re-running) and **passes** with the fix.

## Testing

From `packages/marionette_flutter`:
- `flutter analyze` — no issues found
- `flutter test` — 145 tests passed (including the new regression test)