### PR TITLE
Add ancestor_keys to scope element matching to a subtree

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,15 +82,15 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | Command | Purpose |
 | --- | --- |
 | `get-interactive-elements` | List interactive UI elements. |
-| `tap` | Tap an element (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--within-key`). |
-| `secondary-tap` | Right-click a matching element (desktop only) (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--within-key`). |
-| `double-tap` | Double tap (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--delay`, `--within-key`). |
-| `long-press` | Long press (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--duration`, `--within-key`). |
-| `pinch-zoom` | Pinch zoom (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--scale`, `--start-distance`, `--within-key`). |
-| `swipe` | Swipe/drag (`--key`/`--identifier`/`--text` + `--direction`, `--distance`, `--within-key`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
-| `enter-text` | Enter text (`--key`, `--identifier`, `--text`, or `--focused`, plus `--input`, `--within-key`). |
+| `tap` | Tap an element (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--ancestor-key`). |
+| `secondary-tap` | Right-click a matching element (desktop only) (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--ancestor-key`). |
+| `double-tap` | Double tap (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--delay`, `--ancestor-key`). |
+| `long-press` | Long press (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--duration`, `--ancestor-key`). |
+| `pinch-zoom` | Pinch zoom (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--scale`, `--start-distance`, `--ancestor-key`). |
+| `swipe` | Swipe/drag (`--key`/`--identifier`/`--text` + `--direction`, `--distance`, `--ancestor-key`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
+| `enter-text` | Enter text (`--key`, `--identifier`, `--text`, or `--focused`, plus `--input`, `--ancestor-key`). |
 | `press-key` | Press a key on the focused element (`--key`, optional `--modifiers`). Real key event: enter to submit, tab to move focus, escape, arrows/backspace to edit, or `--modifiers control` for shortcuts. |
-| `scroll-to` | Scroll to an element (`--key`, `--identifier`, or `--text`, plus `--within-key`). |
+| `scroll-to` | Scroll to an element (`--key`, `--identifier`, or `--text`, plus `--ancestor-key`). |
 | `press-back-button` | Simulate the system back button. |
 | `take-screenshots` | Capture a screenshot (`-o/--output`, `--open`). |
 | `record-video` | Record video (`-o/--output`, `-d/--duration`, `--width`, `--height`, `--ffmpeg-path`, `--open`, …). |
@@ -104,10 +104,17 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | `help-ai` | Print the AI-oriented command reference. |
 | `mcp` | Run the MCP server (`-l/--log-level`, `--log-file`, `--sse-port`). |
 
-`--within-key <key>` is available on every matcher-based command. It limits the match to the subtree of the element with that `ValueKey<String>`, which is how you pick one instance when the same key repeats across identical subtrees:
+`--ancestor-key <key>` is available on every matcher-based command. It limits the match to the subtree of the element with that `ValueKey<String>`, which is how you pick one instance when the same key repeats across identical subtrees:
 
 ```bash
-marionette -i my-app tap --key cell.joinButton --within-key grid.cell_2
+marionette -i my-app tap --key cell.joinButton --ancestor-key grid.cell_2
 ```
 
-The command fails if no element has the scope key, rather than silently matching elsewhere.
+Repeat the option — outermost wrapper first — when the wrapper key itself repeats. Each key is looked up inside the previous one's subtree:
+
+```bash
+marionette -i my-app tap --key cell.joinButton \
+  --ancestor-key session_2 --ancestor-key grid.cell_3
+```
+
+The command fails if any key in the chain matches no element, rather than silently matching elsewhere.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,15 +82,15 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | Command | Purpose |
 | --- | --- |
 | `get-interactive-elements` | List interactive UI elements. |
-| `tap` | Tap an element (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`). |
-| `secondary-tap` | Right-click a matching element (desktop only) (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`). |
-| `double-tap` | Double tap (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--delay`). |
-| `long-press` | Long press (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--duration`). |
-| `pinch-zoom` | Pinch zoom (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--scale`, `--start-distance`). |
-| `swipe` | Swipe/drag (`--key`/`--identifier`/`--text` + `--direction`, `--distance`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
-| `enter-text` | Enter text (`--key`, `--identifier`, `--text`, or `--focused`, plus `--input`). |
+| `tap` | Tap an element (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--within-key`). |
+| `secondary-tap` | Right-click a matching element (desktop only) (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--within-key`). |
+| `double-tap` | Double tap (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--delay`, `--within-key`). |
+| `long-press` | Long press (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--duration`, `--within-key`). |
+| `pinch-zoom` | Pinch zoom (`--key`, `--identifier`, `--text`, `--type`, or `--x`/`--y`, plus `--scale`, `--start-distance`, `--within-key`). |
+| `swipe` | Swipe/drag (`--key`/`--identifier`/`--text` + `--direction`, `--distance`, `--within-key`, or `--start-x`/`--start-y`/`--end-x`/`--end-y`). |
+| `enter-text` | Enter text (`--key`, `--identifier`, `--text`, or `--focused`, plus `--input`, `--within-key`). |
 | `press-key` | Press a key on the focused element (`--key`, optional `--modifiers`). Real key event: enter to submit, tab to move focus, escape, arrows/backspace to edit, or `--modifiers control` for shortcuts. |
-| `scroll-to` | Scroll to an element (`--key`, `--identifier`, or `--text`). |
+| `scroll-to` | Scroll to an element (`--key`, `--identifier`, or `--text`, plus `--within-key`). |
 | `press-back-button` | Simulate the system back button. |
 | `take-screenshots` | Capture a screenshot (`-o/--output`, `--open`). |
 | `record-video` | Record video (`-o/--output`, `-d/--duration`, `--width`, `--height`, `--ffmpeg-path`, `--open`, …). |
@@ -103,3 +103,11 @@ Global options: `-i, --instance <name>`, `--uri <ws://...>`, `--timeout <seconds
 | `doctor` | Check connectivity of all instances. |
 | `help-ai` | Print the AI-oriented command reference. |
 | `mcp` | Run the MCP server (`-l/--log-level`, `--log-file`, `--sse-port`). |
+
+`--within-key <key>` is available on every matcher-based command. It limits the match to the subtree of the element with that `ValueKey<String>`, which is how you pick one instance when the same key repeats across identical subtrees:
+
+```bash
+marionette -i my-app tap --key cell.joinButton --within-key grid.cell_2
+```
+
+The command fails if no element has the scope key, rather than silently matching elsewhere.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -23,28 +23,34 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 
 | Tool | Description |
 | --- | --- |
-| `tap` | Tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. Prefer `key`; `identifier` (Semantics identifier) is the next-best stable selector. Tapping a text field focuses it. Optional `within_key` scopes the search. |
-| `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. Match by `key`, `identifier`, `text`, `type`, or `coordinates`. Optional `within_key` scopes the search. |
-| `double_tap` | Double tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `delay` between taps, default 100 ms, and `within_key`). |
-| `long_press` | Long press an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `duration`, default 600 ms, and `within_key`) — context menus, reorderable lists. |
-| `swipe` | Swipe/drag. Element-based (`key`/`identifier`/`text` + `direction` + optional `distance` and `within_key`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
-| `pinch_zoom` | Pinch to zoom an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `within_key`). `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
+| `tap` | Tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. Prefer `key`; `identifier` (Semantics identifier) is the next-best stable selector. Tapping a text field focuses it. Optional `ancestor_keys` scopes the search. |
+| `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. Match by `key`, `identifier`, `text`, `type`, or `coordinates`. Optional `ancestor_keys` scopes the search. |
+| `double_tap` | Double tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `delay` between taps, default 100 ms, and `ancestor_keys`). |
+| `long_press` | Long press an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `duration`, default 600 ms, and `ancestor_keys`) — context menus, reorderable lists. |
+| `swipe` | Swipe/drag. Element-based (`key`/`identifier`/`text` + `direction` + optional `distance` and `ancestor_keys`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
+| `pinch_zoom` | Pinch to zoom an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `ancestor_keys`). `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
 | `press_back_button` | Simulate the system back button (Android back / iOS swipe-back). Works with Navigator, GoRouter, etc. |
-| `scroll_to` | Scroll until an element matching `key`, `identifier`, or `text` becomes visible. Optional `within_key` scrolls inside one subtree. |
+| `scroll_to` | Scroll until an element matching `key`, `identifier`, or `text` becomes visible. Optional `ancestor_keys` scrolls inside one subtree. |
 
-> **Scoping a match with `within_key`:** every matcher-based tool takes an optional `within_key`. It names the `ValueKey<String>` of a wrapper element; the target is then searched for inside that element's subtree only, so a key repeated across identical subtrees (grid cells, repeated cards, embedded app instances) can be disambiguated without baking indices into leaf keys:
+> **Scoping a match with `ancestor_keys`:** every matcher-based tool takes an optional `ancestor_keys` — a list of wrapper `ValueKey<String>`s. The target is searched for inside that subtree only, so a key repeated across identical subtrees (grid cells, repeated cards, embedded app instances) can be disambiguated without baking indices into leaf keys:
 >
 > ```json
-> { "key": "cell.joinButton", "within_key": "grid.cell_2" }
+> { "key": "cell.joinButton", "ancestor_keys": ["grid.cell_2"] }
 > ```
 >
-> If no element has the scope key the call fails rather than falling back to a tree-wide search. It is ignored by `coordinates` and `focused_element`, which do not search the tree.
+> The keys nest, **outermost first**: each is looked up inside the previous one's subtree. That is what lets you reach a wrapper whose own key also repeats — if every session embeds the same grid, `grid.cell_3` alone would land in the first session:
+>
+> ```json
+> { "key": "cell.joinButton", "ancestor_keys": ["session_2", "grid.cell_3"] }
+> ```
+>
+> If any key in the chain matches no element the call fails — naming the link that broke — rather than falling back to a tree-wide search. It is ignored by `coordinates` and `focused_element`, which do not search the tree.
 
 ### Text input
 
 | Tool | Description |
 | --- | --- |
-| `enter_text` | Enter text into a field. Target by `key`, by `identifier`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required; optional `within_key` scopes the search. |
+| `enter_text` | Enter text into a field. Target by `key`, by `identifier`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required; optional `ancestor_keys` scopes the search. |
 | `press_key` | Press a key on the focused element, producing a real key event (unlike `enter_text`). `key` is a named key (`enter`, `tab`, `escape`, `backspace`, `delete`, `space`, `arrowUp`/`arrowDown`/`arrowLeft`/`arrowRight`, `home`, `end`, `pageUp`, `pageDown`) or a single character `a`-`z`/`0`-`9`. Optional `modifiers` (comma-separated: `control`, `shift`, `alt`, `meta`) for shortcuts like `control,a`. Focus a target first via `tap`. |
 
 > **Platform note for `press_key`:** key events reach `Focus`, `Shortcuts`/`Actions`, and focus traversal on every platform — so app shortcuts, submit (`enter`), dismiss (`escape`), and button activation work everywhere. In-field text editing with `backspace`/arrows/characters relies on Flutter's hardware-key text-editing actions, which are wired on **desktop and web**; on **mobile (iOS/Android)** `TextField` editing is owned by the platform keyboard, so use `enter_text` to change a field's value there.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -23,20 +23,28 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 
 | Tool | Description |
 | --- | --- |
-| `tap` | Tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. Prefer `key`; `identifier` (Semantics identifier) is the next-best stable selector. Tapping a text field focuses it. |
-| `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. Match by `key`, `identifier`, `text`, `type`, or `coordinates`. |
-| `double_tap` | Double tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `delay` between taps, default 100 ms). |
-| `long_press` | Long press an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `duration`, default 600 ms) — context menus, reorderable lists. |
-| `swipe` | Swipe/drag. Element-based (`key`/`identifier`/`text` + `direction` + optional `distance`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
-| `pinch_zoom` | Pinch to zoom an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
+| `tap` | Tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates`. Prefer `key`; `identifier` (Semantics identifier) is the next-best stable selector. Tapping a text field focuses it. Optional `within_key` scopes the search. |
+| `secondary_tap` | Right mouse button click on a matching element (**desktop only**); triggers `onSecondaryTap`, e.g. context menus. Match by `key`, `identifier`, `text`, `type`, or `coordinates`. Optional `within_key` scopes the search. |
+| `double_tap` | Double tap an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `delay` between taps, default 100 ms, and `within_key`). |
+| `long_press` | Long press an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `duration`, default 600 ms, and `within_key`) — context menus, reorderable lists. |
+| `swipe` | Swipe/drag. Element-based (`key`/`identifier`/`text` + `direction` + optional `distance` and `within_key`) or coordinate-based (`startX/Y`, `endX/Y`). For `PageView`, `Dismissible`, `Drawer`, sliders. |
+| `pinch_zoom` | Pinch to zoom an element matched by `key`, `identifier`, `text`, `type`, or `coordinates` (optional `within_key`). `scale > 1.0` zooms in, `< 1.0` zooms out. For maps, images, PDFs. |
 | `press_back_button` | Simulate the system back button (Android back / iOS swipe-back). Works with Navigator, GoRouter, etc. |
-| `scroll_to` | Scroll until an element matching `key`, `identifier`, or `text` becomes visible. |
+| `scroll_to` | Scroll until an element matching `key`, `identifier`, or `text` becomes visible. Optional `within_key` scrolls inside one subtree. |
+
+> **Scoping a match with `within_key`:** every matcher-based tool takes an optional `within_key`. It names the `ValueKey<String>` of a wrapper element; the target is then searched for inside that element's subtree only, so a key repeated across identical subtrees (grid cells, repeated cards, embedded app instances) can be disambiguated without baking indices into leaf keys:
+>
+> ```json
+> { "key": "cell.joinButton", "within_key": "grid.cell_2" }
+> ```
+>
+> If no element has the scope key the call fails rather than falling back to a tree-wide search. It is ignored by `coordinates` and `focused_element`, which do not search the tree.
 
 ### Text input
 
 | Tool | Description |
 | --- | --- |
-| `enter_text` | Enter text into a field. Target by `key`, by `identifier`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required. |
+| `enter_text` | Enter text into a field. Target by `key`, by `identifier`, or focus a field first (via `tap`) and pass `focused_element: true`. Exactly one selector required; optional `within_key` scopes the search. |
 | `press_key` | Press a key on the focused element, producing a real key event (unlike `enter_text`). `key` is a named key (`enter`, `tab`, `escape`, `backspace`, `delete`, `space`, `arrowUp`/`arrowDown`/`arrowLeft`/`arrowRight`, `home`, `end`, `pageUp`, `pageDown`) or a single character `a`-`z`/`0`-`9`. Optional `modifiers` (comma-separated: `control`, `shift`, `alt`, `meta`) for shortcuts like `control,a`. Focus a target first via `tap`. |
 
 > **Platform note for `press_key`:** key events reach `Focus`, `Shortcuts`/`Actions`, and focus traversal on every platform — so app shortcuts, submit (`enter`), dismiss (`escape`), and button activation work everywhere. In-field text editing with `backspace`/arrows/characters relies on Flutter's hardware-key text-editing actions, which are wired on **desktop and web**; on **mobile (iOS/Android)** `TextField` editing is owned by the platform keyboard, so use `enter_text` to change a field's value there.

--- a/packages/marionette_cli/lib/src/cli/commands/double_tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/double_tap_command.dart
@@ -14,7 +14,7 @@ class DoubleTapCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., ListTile).')
       ..addOption('x', help: 'X coordinate for positional double tap.')
       ..addOption('y', help: 'Y coordinate for positional double tap.')
-      ..addOption('within-key', help: withinKeyHelp)
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp)
       ..addOption(
         'delay',
         help: 'Delay between taps in milliseconds.',
@@ -43,7 +43,7 @@ class DoubleTapCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     final xStr = argResults?['x'] as String?;

--- a/packages/marionette_cli/lib/src/cli/commands/double_tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/double_tap_command.dart
@@ -14,6 +14,7 @@ class DoubleTapCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., ListTile).')
       ..addOption('x', help: 'X coordinate for positional double tap.')
       ..addOption('y', help: 'Y coordinate for positional double tap.')
+      ..addOption('within-key', help: withinKeyHelp)
       ..addOption(
         'delay',
         help: 'Delay between taps in milliseconds.',
@@ -42,6 +43,7 @@ class DoubleTapCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
+      withinKey: argResults?['within-key'] as String?,
     );
 
     final xStr = argResults?['x'] as String?;
@@ -50,7 +52,7 @@ class DoubleTapCommand extends InstanceCommand {
       usageException('--x and --y must be provided together.');
     }
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, --text, --type, '
         'or --x/--y.',

--- a/packages/marionette_cli/lib/src/cli/commands/enter_text_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/enter_text_command.dart
@@ -16,6 +16,7 @@ class EnterTextCommand extends InstanceCommand {
         help: 'Target the currently focused text field.',
         negatable: false,
       )
+      ..addOption('within-key', help: withinKeyHelp)
       ..addOption(
         'input',
         help: 'Text to enter into the field.',
@@ -43,9 +44,10 @@ class EnterTextCommand extends InstanceCommand {
       identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       focused: focused,
+      withinKey: argResults?['within-key'] as String?,
     );
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, --text, '
         'or --focused.',

--- a/packages/marionette_cli/lib/src/cli/commands/enter_text_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/enter_text_command.dart
@@ -16,7 +16,7 @@ class EnterTextCommand extends InstanceCommand {
         help: 'Target the currently focused text field.',
         negatable: false,
       )
-      ..addOption('within-key', help: withinKeyHelp)
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp)
       ..addOption(
         'input',
         help: 'Text to enter into the field.',
@@ -44,7 +44,7 @@ class EnterTextCommand extends InstanceCommand {
       identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
       focused: focused,
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     if (!hasSelector(matcher)) {

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -145,8 +145,9 @@ Tap an element. Provide exactly one matching strategy.
     --type <string>       Match by widget type name (e.g., ElevatedButton)
     --x <number>          X screen coordinate (use with --y)
     --y <number>          Y screen coordinate (use with --x)
-    --within-key <string> Limit the search to the subtree of the element with
-                          this key (repeated cards, grid cells, embedded apps)
+    --ancestor-key <str>  Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps).
+                          Repeat it, outermost first, to go deeper
 
   Examples:
     marionette -i my-app tap --key submit_button
@@ -154,7 +155,9 @@ Tap an element. Provide exactly one matching strategy.
     marionette -i my-app tap --text "Submit"
     marionette --uri ws://127.0.0.1:8181/ws tap --key submit_button
     marionette -i my-app tap --x 100 --y 200
-    marionette -i my-app tap --key cell.joinButton --within-key grid.cell_2
+    marionette -i my-app tap --key cell.joinButton --ancestor-key grid.cell_2
+    marionette -i my-app tap --key cell.joinButton \
+      --ancestor-key session_2 --ancestor-key grid.cell_3
 
   Output (stdout):
     Tapped element matching {key: submit_button}
@@ -176,8 +179,9 @@ strategy.
     --type <string>       Match by widget type name (e.g., ElevatedButton)
     --x <number>          X screen coordinate (use with --y)
     --y <number>          Y screen coordinate (use with --x)
-    --within-key <string> Limit the search to the subtree of the element with
-                          this key (repeated cards, grid cells, embedded apps)
+    --ancestor-key <str>  Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps).
+                          Repeat it, outermost first, to go deeper
 
   Examples:
     marionette -i my-app secondary-tap --key file_item
@@ -201,8 +205,9 @@ Enter text into a text field.
     --identifier <string> Match text field by Semantics identifier
     --text <string>       Match text field by visible text
     --focused             Target the currently focused text field
-    --within-key <string> Limit the search to the subtree of the element with
-                          this key (repeated cards, grid cells, embedded apps)
+    --ancestor-key <str>  Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps).
+                          Repeat it, outermost first, to go deeper
     --input <string>      Text to enter (mandatory)
 
   Example:
@@ -283,8 +288,9 @@ Use either element-based mode (matcher + direction) or coordinate-based mode.
     --identifier <string> Match by Semantics identifier (stable alternative)
     --text <string>       Match by visible text content
     --type <string>       Match by widget type name (e.g., PageView)
-    --within-key <string> Limit the search to the subtree of the element with
-                          this key (repeated cards, grid cells, embedded apps)
+    --ancestor-key <str>  Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps).
+                          Repeat it, outermost first, to go deeper
     --direction <dir>     left, right, up, or down (required for this mode)
     --distance <number>   Swipe distance in pixels (default: 200)
 
@@ -315,8 +321,9 @@ Scroll until an element becomes visible.
     --key <string>        Match by ValueKey<String>
     --identifier <string> Match by Semantics identifier
     --text <string>       Match by visible text content
-    --within-key <string> Limit the search to the subtree of the element with
-                          this key (repeated cards, grid cells, embedded apps)
+    --ancestor-key <str>  Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps).
+                          Repeat it, outermost first, to go deeper
 
   Example:
     marionette -i my-app scroll-to --text "Bottom Item"
@@ -506,8 +513,9 @@ If a command fails with a connection error, the app may have stopped.
 - Prefer --key over --text for matching elements (keys are stable, text may change)
 - --identifier (Semantics identifier) is an equally stable alternative to --key
   when a widget has no ValueKey but does set an accessibility identifier
-- --within-key scopes a match to one subtree when the same key repeats across
-  identical subtrees; the scope key must exist or the command fails
+- --ancestor-key scopes a match to one subtree when the same key repeats across
+  identical subtrees; repeat it (outermost first) when the wrapper key itself
+  repeats. Every key must exist or the command fails
 - Run `get-interactive-elements` first to discover what's on screen before interacting
 - Instance names are alphanumeric with hyphens/underscores: [a-zA-Z0-9_-]+
 - Commands are stateless — each opens a fresh connection, so no session management needed

--- a/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/help_ai_command.dart
@@ -145,6 +145,8 @@ Tap an element. Provide exactly one matching strategy.
     --type <string>       Match by widget type name (e.g., ElevatedButton)
     --x <number>          X screen coordinate (use with --y)
     --y <number>          Y screen coordinate (use with --x)
+    --within-key <string> Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps)
 
   Examples:
     marionette -i my-app tap --key submit_button
@@ -152,6 +154,7 @@ Tap an element. Provide exactly one matching strategy.
     marionette -i my-app tap --text "Submit"
     marionette --uri ws://127.0.0.1:8181/ws tap --key submit_button
     marionette -i my-app tap --x 100 --y 200
+    marionette -i my-app tap --key cell.joinButton --within-key grid.cell_2
 
   Output (stdout):
     Tapped element matching {key: submit_button}
@@ -173,6 +176,8 @@ strategy.
     --type <string>       Match by widget type name (e.g., ElevatedButton)
     --x <number>          X screen coordinate (use with --y)
     --y <number>          Y screen coordinate (use with --x)
+    --within-key <string> Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps)
 
   Examples:
     marionette -i my-app secondary-tap --key file_item
@@ -196,6 +201,8 @@ Enter text into a text field.
     --identifier <string> Match text field by Semantics identifier
     --text <string>       Match text field by visible text
     --focused             Target the currently focused text field
+    --within-key <string> Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps)
     --input <string>      Text to enter (mandatory)
 
   Example:
@@ -276,6 +283,8 @@ Use either element-based mode (matcher + direction) or coordinate-based mode.
     --identifier <string> Match by Semantics identifier (stable alternative)
     --text <string>       Match by visible text content
     --type <string>       Match by widget type name (e.g., PageView)
+    --within-key <string> Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps)
     --direction <dir>     left, right, up, or down (required for this mode)
     --distance <number>   Swipe distance in pixels (default: 200)
 
@@ -306,6 +315,8 @@ Scroll until an element becomes visible.
     --key <string>        Match by ValueKey<String>
     --identifier <string> Match by Semantics identifier
     --text <string>       Match by visible text content
+    --within-key <string> Limit the search to the subtree of the element with
+                          this key (repeated cards, grid cells, embedded apps)
 
   Example:
     marionette -i my-app scroll-to --text "Bottom Item"
@@ -495,6 +506,8 @@ If a command fails with a connection error, the app may have stopped.
 - Prefer --key over --text for matching elements (keys are stable, text may change)
 - --identifier (Semantics identifier) is an equally stable alternative to --key
   when a widget has no ValueKey but does set an accessibility identifier
+- --within-key scopes a match to one subtree when the same key repeats across
+  identical subtrees; the scope key must exist or the command fails
 - Run `get-interactive-elements` first to discover what's on screen before interacting
 - Instance names are alphanumeric with hyphens/underscores: [a-zA-Z0-9_-]+
 - Commands are stateless — each opens a fresh connection, so no session management needed

--- a/packages/marionette_cli/lib/src/cli/commands/long_press_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/long_press_command.dart
@@ -14,7 +14,7 @@ class LongPressCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., ListTile).')
       ..addOption('x', help: 'X coordinate for positional long press.')
       ..addOption('y', help: 'Y coordinate for positional long press.')
-      ..addOption('within-key', help: withinKeyHelp)
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp)
       ..addOption(
         'duration',
         help: 'Hold duration in milliseconds.',
@@ -43,7 +43,7 @@ class LongPressCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     if (!hasSelector(matcher)) {

--- a/packages/marionette_cli/lib/src/cli/commands/long_press_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/long_press_command.dart
@@ -14,6 +14,7 @@ class LongPressCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., ListTile).')
       ..addOption('x', help: 'X coordinate for positional long press.')
       ..addOption('y', help: 'Y coordinate for positional long press.')
+      ..addOption('within-key', help: withinKeyHelp)
       ..addOption(
         'duration',
         help: 'Hold duration in milliseconds.',
@@ -42,9 +43,10 @@ class LongPressCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
+      withinKey: argResults?['within-key'] as String?,
     );
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, --text, --type, '
         'or --x/--y.',

--- a/packages/marionette_cli/lib/src/cli/commands/pinch_zoom_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/pinch_zoom_command.dart
@@ -14,6 +14,7 @@ class PinchZoomCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., InteractiveViewer).')
       ..addOption('x', help: 'X coordinate for pinch center.')
       ..addOption('y', help: 'Y coordinate for pinch center.')
+      ..addOption('within-key', help: withinKeyHelp)
       ..addOption(
         'scale',
         help: 'Zoom scale factor. >1.0 zooms in, <1.0 zooms out.',
@@ -48,6 +49,7 @@ class PinchZoomCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
+      withinKey: argResults?['within-key'] as String?,
     );
 
     final xStr = argResults?['x'] as String?;
@@ -56,7 +58,7 @@ class PinchZoomCommand extends InstanceCommand {
       usageException('--x and --y must be provided together.');
     }
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, --text, --type, '
         'or --x/--y.',

--- a/packages/marionette_cli/lib/src/cli/commands/pinch_zoom_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/pinch_zoom_command.dart
@@ -14,7 +14,7 @@ class PinchZoomCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., InteractiveViewer).')
       ..addOption('x', help: 'X coordinate for pinch center.')
       ..addOption('y', help: 'Y coordinate for pinch center.')
-      ..addOption('within-key', help: withinKeyHelp)
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp)
       ..addOption(
         'scale',
         help: 'Zoom scale factor. >1.0 zooms in, <1.0 zooms out.',
@@ -49,7 +49,7 @@ class PinchZoomCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     final xStr = argResults?['x'] as String?;

--- a/packages/marionette_cli/lib/src/cli/commands/scroll_to_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/scroll_to_command.dart
@@ -10,7 +10,8 @@ class ScrollToCommand extends InstanceCommand {
     argParser
       ..addOption('key', help: 'Element key (ValueKey<String>).')
       ..addOption('identifier', help: 'Semantics identifier of the element.')
-      ..addOption('text', help: 'Visible text of the element to scroll to.');
+      ..addOption('text', help: 'Visible text of the element to scroll to.')
+      ..addOption('within-key', help: withinKeyHelp);
   }
 
   final InstanceRegistry _registry;
@@ -31,9 +32,10 @@ class ScrollToCommand extends InstanceCommand {
       key: argResults?['key'] as String?,
       identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
+      withinKey: argResults?['within-key'] as String?,
     );
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, or --text.',
       );

--- a/packages/marionette_cli/lib/src/cli/commands/scroll_to_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/scroll_to_command.dart
@@ -11,7 +11,7 @@ class ScrollToCommand extends InstanceCommand {
       ..addOption('key', help: 'Element key (ValueKey<String>).')
       ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text of the element to scroll to.')
-      ..addOption('within-key', help: withinKeyHelp);
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp);
   }
 
   final InstanceRegistry _registry;
@@ -32,7 +32,7 @@ class ScrollToCommand extends InstanceCommand {
       key: argResults?['key'] as String?,
       identifier: argResults?['identifier'] as String?,
       text: argResults?['text'] as String?,
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     if (!hasSelector(matcher)) {

--- a/packages/marionette_cli/lib/src/cli/commands/secondary_tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/secondary_tap_command.dart
@@ -13,7 +13,8 @@ class SecondaryTapCommand extends InstanceCommand {
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
       ..addOption('x', help: 'X coordinate for positional secondary tap.')
-      ..addOption('y', help: 'Y coordinate for positional secondary tap.');
+      ..addOption('y', help: 'Y coordinate for positional secondary tap.')
+      ..addOption('within-key', help: withinKeyHelp);
   }
 
   final InstanceRegistry _registry;
@@ -38,9 +39,10 @@ class SecondaryTapCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
+      withinKey: argResults?['within-key'] as String?,
     );
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, --text, --type, '
         'or --x/--y.',

--- a/packages/marionette_cli/lib/src/cli/commands/secondary_tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/secondary_tap_command.dart
@@ -14,7 +14,7 @@ class SecondaryTapCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
       ..addOption('x', help: 'X coordinate for positional secondary tap.')
       ..addOption('y', help: 'Y coordinate for positional secondary tap.')
-      ..addOption('within-key', help: withinKeyHelp);
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp);
   }
 
   final InstanceRegistry _registry;
@@ -39,7 +39,7 @@ class SecondaryTapCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     if (!hasSelector(matcher)) {

--- a/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
@@ -12,7 +12,7 @@ class SwipeCommand extends InstanceCommand {
       ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., PageView).')
-      ..addOption('within-key', help: withinKeyHelp)
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp)
       ..addOption(
         'direction',
         help: 'Swipe direction for element-based mode: left, right, up, down.',
@@ -60,7 +60,7 @@ class SwipeCommand extends InstanceCommand {
         argResults?['identifier'] != null ||
         argResults?['text'] != null ||
         argResults?['type'] != null ||
-        argResults?['within-key'] != null ||
+        (argResults?['ancestor-key'] as List<String>? ?? const []).isNotEmpty ||
         argResults?['direction'] != null ||
         (argResults?.wasParsed('distance') ?? false);
 
@@ -68,7 +68,7 @@ class SwipeCommand extends InstanceCommand {
       usageException(
         'Cannot mix coordinate-based options '
         '(--start-x/--start-y/--end-x/--end-y) with element-based options '
-        '(--key/--identifier/--text/--type/--within-key/--direction'
+        '(--key/--identifier/--text/--type/--ancestor-key/--direction'
         '/--distance). Use one mode.',
       );
     }
@@ -96,7 +96,7 @@ class SwipeCommand extends InstanceCommand {
         identifier: argResults?['identifier'] as String?,
         text: argResults?['text'] as String?,
         type: argResults?['type'] as String?,
-        withinKey: argResults?['within-key'] as String?,
+        ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
       );
       if (!hasSelector(matcher)) {
         usageException(

--- a/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/swipe_command.dart
@@ -12,6 +12,7 @@ class SwipeCommand extends InstanceCommand {
       ..addOption('identifier', help: 'Semantics identifier of the element.')
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., PageView).')
+      ..addOption('within-key', help: withinKeyHelp)
       ..addOption(
         'direction',
         help: 'Swipe direction for element-based mode: left, right, up, down.',
@@ -59,6 +60,7 @@ class SwipeCommand extends InstanceCommand {
         argResults?['identifier'] != null ||
         argResults?['text'] != null ||
         argResults?['type'] != null ||
+        argResults?['within-key'] != null ||
         argResults?['direction'] != null ||
         (argResults?.wasParsed('distance') ?? false);
 
@@ -66,8 +68,8 @@ class SwipeCommand extends InstanceCommand {
       usageException(
         'Cannot mix coordinate-based options '
         '(--start-x/--start-y/--end-x/--end-y) with element-based options '
-        '(--key/--identifier/--text/--type/--direction/--distance). '
-        'Use one mode.',
+        '(--key/--identifier/--text/--type/--within-key/--direction'
+        '/--distance). Use one mode.',
       );
     }
 
@@ -94,8 +96,9 @@ class SwipeCommand extends InstanceCommand {
         identifier: argResults?['identifier'] as String?,
         text: argResults?['text'] as String?,
         type: argResults?['type'] as String?,
+        withinKey: argResults?['within-key'] as String?,
       );
-      if (matcher.isEmpty) {
+      if (!hasSelector(matcher)) {
         usageException(
           'Element-based swipe requires a matcher: --key, --identifier, '
           '--text, or --type. Alternatively provide '

--- a/packages/marionette_cli/lib/src/cli/commands/tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/tap_command.dart
@@ -13,7 +13,8 @@ class TapCommand extends InstanceCommand {
       ..addOption('text', help: 'Visible text content of the element.')
       ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
       ..addOption('x', help: 'X coordinate for positional tap.')
-      ..addOption('y', help: 'Y coordinate for positional tap.');
+      ..addOption('y', help: 'Y coordinate for positional tap.')
+      ..addOption('within-key', help: withinKeyHelp);
   }
 
   final InstanceRegistry _registry;
@@ -37,9 +38,10 @@ class TapCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
+      withinKey: argResults?['within-key'] as String?,
     );
 
-    if (matcher.isEmpty) {
+    if (!hasSelector(matcher)) {
       usageException(
         'At least one matcher required: --key, --identifier, --text, --type, '
         'or --x/--y.',

--- a/packages/marionette_cli/lib/src/cli/commands/tap_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/tap_command.dart
@@ -14,7 +14,7 @@ class TapCommand extends InstanceCommand {
       ..addOption('type', help: 'Widget type name (e.g., ElevatedButton).')
       ..addOption('x', help: 'X coordinate for positional tap.')
       ..addOption('y', help: 'Y coordinate for positional tap.')
-      ..addOption('within-key', help: withinKeyHelp);
+      ..addMultiOption('ancestor-key', help: ancestorKeyHelp);
   }
 
   final InstanceRegistry _registry;
@@ -38,7 +38,7 @@ class TapCommand extends InstanceCommand {
       type: argResults?['type'] as String?,
       x: _parseNum(argResults?['x'] as String?),
       y: _parseNum(argResults?['y'] as String?),
-      withinKey: argResults?['within-key'] as String?,
+      ancestorKeys: argResults?['ancestor-key'] as List<String>? ?? const [],
     );
 
     if (!hasSelector(matcher)) {

--- a/packages/marionette_cli/lib/src/cli/matcher_builder.dart
+++ b/packages/marionette_cli/lib/src/cli/matcher_builder.dart
@@ -1,7 +1,8 @@
 /// Builds a widget matcher map from CLI arguments.
 ///
-/// Accepts named args like --key, --identifier, --text, --type, --x, --y and
-/// constructs the matcher map expected by [VmServiceConnector].
+/// Accepts named args like --key, --identifier, --text, --type, --x, --y,
+/// --within-key and constructs the matcher map expected by
+/// [VmServiceConnector].
 Map<String, dynamic> buildMatcherFromArgs({
   String? key,
   String? identifier,
@@ -10,6 +11,7 @@ Map<String, dynamic> buildMatcherFromArgs({
   num? x,
   num? y,
   bool focused = false,
+  String? withinKey,
 }) {
   final matcher = <String, dynamic>{};
   if (key != null) matcher['key'] = key;
@@ -19,5 +21,20 @@ Map<String, dynamic> buildMatcherFromArgs({
   if (x != null) matcher['x'] = x;
   if (y != null) matcher['y'] = y;
   if (focused) matcher['focused'] = true;
+  if (withinKey != null) matcher['within_key'] = withinKey;
   return matcher;
 }
+
+/// Whether [matcher] identifies an element to act on.
+///
+/// `within_key` only narrows where the search happens, so a matcher carrying
+/// nothing but a scope still selects nothing.
+bool hasSelector(Map<String, dynamic> matcher) {
+  return matcher.keys.any((field) => field != 'within_key');
+}
+
+/// Help text for the `--within-key` option, shared by every matcher-based
+/// command.
+const withinKeyHelp = 'Limit the search to the subtree of the element with '
+    'this key. Use it when the same key appears in several identical '
+    'subtrees (grid cells, repeated cards).';

--- a/packages/marionette_cli/lib/src/cli/matcher_builder.dart
+++ b/packages/marionette_cli/lib/src/cli/matcher_builder.dart
@@ -1,7 +1,9 @@
+import 'dart:convert';
+
 /// Builds a widget matcher map from CLI arguments.
 ///
 /// Accepts named args like --key, --identifier, --text, --type, --x, --y,
-/// --within-key and constructs the matcher map expected by
+/// --ancestor-key and constructs the matcher map expected by
 /// [VmServiceConnector].
 Map<String, dynamic> buildMatcherFromArgs({
   String? key,
@@ -11,7 +13,7 @@ Map<String, dynamic> buildMatcherFromArgs({
   num? x,
   num? y,
   bool focused = false,
-  String? withinKey,
+  List<String> ancestorKeys = const [],
 }) {
   final matcher = <String, dynamic>{};
   if (key != null) matcher['key'] = key;
@@ -21,20 +23,26 @@ Map<String, dynamic> buildMatcherFromArgs({
   if (x != null) matcher['x'] = x;
   if (y != null) matcher['y'] = y;
   if (focused) matcher['focused'] = true;
-  if (withinKey != null) matcher['within_key'] = withinKey;
+  // The VM service only carries string values, so the scope chain travels
+  // JSON-encoded — a delimiter could appear inside a key.
+  if (ancestorKeys.isNotEmpty) {
+    matcher['ancestor_keys'] = jsonEncode(ancestorKeys);
+  }
   return matcher;
 }
 
 /// Whether [matcher] identifies an element to act on.
 ///
-/// `within_key` only narrows where the search happens, so a matcher carrying
-/// nothing but a scope still selects nothing.
+/// `ancestor_keys` only narrows where the search happens, so a matcher
+/// carrying nothing but a scope still selects nothing.
 bool hasSelector(Map<String, dynamic> matcher) {
-  return matcher.keys.any((field) => field != 'within_key');
+  return matcher.keys.any((field) => field != 'ancestor_keys');
 }
 
-/// Help text for the `--within-key` option, shared by every matcher-based
+/// Help text for the `--ancestor-key` option, shared by every matcher-based
 /// command.
-const withinKeyHelp = 'Limit the search to the subtree of the element with '
+const ancestorKeyHelp = 'Limit the search to the subtree of the element with '
     'this key. Use it when the same key appears in several identical '
-    'subtrees (grid cells, repeated cards).';
+    'subtrees (grid cells, repeated cards). Repeat the option, outermost '
+    'wrapper first, to go deeper: each key is looked up inside the previous '
+    "one's subtree.";

--- a/packages/marionette_cli/test/matcher_builder_test.dart
+++ b/packages/marionette_cli/test/matcher_builder_test.dart
@@ -40,5 +40,34 @@ void main() {
         equals({'type': 'ElevatedButton'}),
       );
     });
+
+    test('within key arg', () {
+      expect(
+        buildMatcherFromArgs(key: 'join_button', withinKey: 'grid.cell_2'),
+        equals({'key': 'join_button', 'within_key': 'grid.cell_2'}),
+      );
+    });
+  });
+
+  group('hasSelector', () {
+    test('empty matcher has no selector', () {
+      expect(hasSelector(buildMatcherFromArgs()), isFalse);
+    });
+
+    test('a scope alone is not a selector', () {
+      expect(
+        hasSelector(buildMatcherFromArgs(withinKey: 'grid.cell_2')),
+        isFalse,
+      );
+    });
+
+    test('a scoped key is a selector', () {
+      expect(
+        hasSelector(
+          buildMatcherFromArgs(key: 'join_button', withinKey: 'grid.cell_2'),
+        ),
+        isTrue,
+      );
+    });
   });
 }

--- a/packages/marionette_cli/test/matcher_builder_test.dart
+++ b/packages/marionette_cli/test/matcher_builder_test.dart
@@ -41,10 +41,23 @@ void main() {
       );
     });
 
-    test('within key arg', () {
+    test('ancestor keys are JSON-encoded for the string-only wire', () {
       expect(
-        buildMatcherFromArgs(key: 'join_button', withinKey: 'grid.cell_2'),
-        equals({'key': 'join_button', 'within_key': 'grid.cell_2'}),
+        buildMatcherFromArgs(
+          key: 'join_button',
+          ancestorKeys: ['session_2', 'grid.cell_3'],
+        ),
+        equals({
+          'key': 'join_button',
+          'ancestor_keys': '["session_2","grid.cell_3"]',
+        }),
+      );
+    });
+
+    test('an empty ancestor chain is omitted', () {
+      expect(
+        buildMatcherFromArgs(key: 'join_button', ancestorKeys: const []),
+        equals({'key': 'join_button'}),
       );
     });
   });
@@ -56,7 +69,7 @@ void main() {
 
     test('a scope alone is not a selector', () {
       expect(
-        hasSelector(buildMatcherFromArgs(withinKey: 'grid.cell_2')),
+        hasSelector(buildMatcherFromArgs(ancestorKeys: ['grid.cell_2'])),
         isFalse,
       );
     });
@@ -64,7 +77,10 @@ void main() {
     test('a scoped key is a selector', () {
       expect(
         hasSelector(
-          buildMatcherFromArgs(key: 'join_button', withinKey: 'grid.cell_2'),
+          buildMatcherFromArgs(
+            key: 'join_button',
+            ancestorKeys: ['grid.cell_2'],
+          ),
         ),
         isTrue,
       );

--- a/packages/marionette_flutter/example/pubspec.lock
+++ b/packages/marionette_flutter/example/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
@@ -20,7 +20,12 @@ void registerGestureExtensions({
     name: 'marionette.tap',
     callback: (params) async {
       final matcher = WidgetMatcher.fromJson(params);
-      await gestureDispatcher.tap(matcher, widgetFinder, configuration);
+      await gestureDispatcher.tap(
+        matcher,
+        widgetFinder,
+        configuration,
+        scope: WidgetMatcher.scopeFromJson(params),
+      );
       return MarionetteExtensionResult.success({
         'message': 'Tapped element matching: ${matcher.toJson()}',
       });
@@ -32,7 +37,11 @@ void registerGestureExtensions({
     callback: (params) async {
       final matcher = WidgetMatcher.fromJson(params);
       await gestureDispatcher.secondaryTap(
-          matcher, widgetFinder, configuration);
+        matcher,
+        widgetFinder,
+        configuration,
+        scope: WidgetMatcher.scopeFromJson(params),
+      );
       return MarionetteExtensionResult.success({
         'message': 'Secondary-tapped element matching: ${matcher.toJson()}',
       });
@@ -57,6 +66,7 @@ void registerGestureExtensions({
         widgetFinder,
         configuration,
         delay: parsed.duration!,
+        scope: WidgetMatcher.scopeFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Double tapped element matching: ${matcher.toJson()}',
@@ -81,6 +91,7 @@ void registerGestureExtensions({
         widgetFinder,
         configuration,
         duration: parsed.duration!,
+        scope: WidgetMatcher.scopeFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Long pressed element matching: ${matcher.toJson()}',
@@ -159,6 +170,7 @@ void registerGestureExtensions({
         configuration,
         direction: direction,
         distance: distance,
+        scope: WidgetMatcher.scopeFromJson(params),
       );
 
       return MarionetteExtensionResult.success({
@@ -210,6 +222,7 @@ void registerGestureExtensions({
         configuration,
         scale: scale,
         startDistance: distanceParse.value!,
+        scope: WidgetMatcher.scopeFromJson(params),
       );
 
       return MarionetteExtensionResult.success({
@@ -223,7 +236,11 @@ void registerGestureExtensions({
     name: 'marionette.scrollTo',
     callback: (params) async {
       final matcher = WidgetMatcher.fromJson(params);
-      await scrollSimulator.scrollUntilVisible(matcher, configuration);
+      await scrollSimulator.scrollUntilVisible(
+        matcher,
+        configuration,
+        scope: WidgetMatcher.scopeFromJson(params),
+      );
       return MarionetteExtensionResult.success({
         'message': 'Scrolled to element matching: ${matcher.toJson()}',
       });

--- a/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
@@ -24,7 +24,7 @@ void registerGestureExtensions({
         matcher,
         widgetFinder,
         configuration,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Tapped element matching: ${matcher.toJson()}',
@@ -40,7 +40,7 @@ void registerGestureExtensions({
         matcher,
         widgetFinder,
         configuration,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Secondary-tapped element matching: ${matcher.toJson()}',
@@ -66,7 +66,7 @@ void registerGestureExtensions({
         widgetFinder,
         configuration,
         delay: parsed.duration!,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Double tapped element matching: ${matcher.toJson()}',
@@ -91,7 +91,7 @@ void registerGestureExtensions({
         widgetFinder,
         configuration,
         duration: parsed.duration!,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Long pressed element matching: ${matcher.toJson()}',
@@ -170,7 +170,7 @@ void registerGestureExtensions({
         configuration,
         direction: direction,
         distance: distance,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
 
       return MarionetteExtensionResult.success({
@@ -222,7 +222,7 @@ void registerGestureExtensions({
         configuration,
         scale: scale,
         startDistance: distanceParse.value!,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
 
       return MarionetteExtensionResult.success({
@@ -239,7 +239,7 @@ void registerGestureExtensions({
       await scrollSimulator.scrollUntilVisible(
         matcher,
         configuration,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
       return MarionetteExtensionResult.success({
         'message': 'Scrolled to element matching: ${matcher.toJson()}',

--- a/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/gesture_extensions.dart
@@ -211,8 +211,8 @@ void registerGestureExtensions({
         matcher = WidgetMatcher.fromJson(params);
       } on ArgumentError {
         return MarionetteExtensionResult.invalidParams(
-          'Missing required selector: provide "key", "text", "type", '
-          'or "x" & "y" coordinates.',
+          'Missing required selector: provide "key", "identifier", "text", '
+          '"type", or "x" & "y" coordinates.',
         );
       }
 

--- a/packages/marionette_flutter/lib/src/binding/extensions/text_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/text_extensions.dart
@@ -25,7 +25,7 @@ void registerTextExtensions({
         matcher,
         input,
         configuration,
-        scope: WidgetMatcher.scopeFromJson(params),
+        ancestors: WidgetMatcher.ancestorsFromJson(params),
       );
 
       return MarionetteExtensionResult.success({

--- a/packages/marionette_flutter/lib/src/binding/extensions/text_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/text_extensions.dart
@@ -21,7 +21,12 @@ void registerTextExtensions({
         );
       }
 
-      await textInputSimulator.enterText(matcher, input, configuration);
+      await textInputSimulator.enterText(
+        matcher,
+        input,
+        configuration,
+        scope: WidgetMatcher.scopeFromJson(params),
+      );
 
       return MarionetteExtensionResult.success({
         'message': 'Entered text into element matching: ${matcher.toJson()}',

--- a/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
+++ b/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
@@ -18,19 +18,25 @@ class GestureDispatcher {
   /// Simulates a tap on an element that matches the given [matcher].
   ///
   /// If [matcher] is a [CoordinatesMatcher], taps directly at the specified
-  /// coordinates without searching the widget tree (fast path).
+  /// coordinates without searching the widget tree (fast path), and [scope]
+  /// is ignored.
   Future<void> tap(
     WidgetMatcher matcher,
     WidgetFinder widgetFinder,
-    MarionetteConfiguration configuration,
-  ) async {
+    MarionetteConfiguration configuration, {
+    KeyMatcher? scope,
+  }) async {
     // Fast path for coordinate-based tapping
     if (matcher is CoordinatesMatcher) {
       await _dispatchTapAtPosition(matcher.offset);
       return;
     }
 
-    final element = widgetFinder.findHittableElement(matcher, configuration);
+    final element = widgetFinder.findHittableElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');
@@ -92,23 +98,29 @@ class GestureDispatcher {
   Future<void> secondaryTap(
     WidgetMatcher matcher,
     WidgetFinder widgetFinder,
-    MarionetteConfiguration configuration,
-  ) =>
+    MarionetteConfiguration configuration, {
+    KeyMatcher? scope,
+  }) =>
       _mouseTap(matcher, widgetFinder, configuration,
-          buttons: kSecondaryButton);
+          buttons: kSecondaryButton, scope: scope);
 
   Future<void> _mouseTap(
     WidgetMatcher matcher,
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
     required int buttons,
+    KeyMatcher? scope,
   }) async {
     if (matcher is CoordinatesMatcher) {
       await _dispatchMouseTapAtPosition(matcher.offset, buttons);
       return;
     }
 
-    final element = widgetFinder.findHittableElement(matcher, configuration);
+    final element = widgetFinder.findHittableElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');
@@ -168,6 +180,7 @@ class GestureDispatcher {
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
     Duration delay = const Duration(milliseconds: 100),
+    KeyMatcher? scope,
   }) async {
     if (delay.isNegative || delay == Duration.zero) {
       throw ArgumentError('delay must be positive');
@@ -178,7 +191,11 @@ class GestureDispatcher {
       return;
     }
 
-    final element = widgetFinder.findHittableElement(matcher, configuration);
+    final element = widgetFinder.findHittableElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');
@@ -218,6 +235,7 @@ class GestureDispatcher {
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
     Duration duration = const Duration(milliseconds: 600),
+    KeyMatcher? scope,
   }) async {
     if (duration.isNegative || duration == Duration.zero) {
       throw ArgumentError('duration must be positive');
@@ -228,7 +246,11 @@ class GestureDispatcher {
       return;
     }
 
-    final element = widgetFinder.findHittableElement(matcher, configuration);
+    final element = widgetFinder.findHittableElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');
@@ -285,8 +307,13 @@ class GestureDispatcher {
     MarionetteConfiguration configuration, {
     required String direction,
     double distance = 200.0,
+    KeyMatcher? scope,
   }) async {
-    final element = widgetFinder.findElement(matcher, configuration);
+    final element = widgetFinder.findElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');
@@ -319,6 +346,7 @@ class GestureDispatcher {
     MarionetteConfiguration configuration, {
     required double scale,
     double startDistance = 200.0,
+    KeyMatcher? scope,
   }) async {
     if (scale <= 0) {
       throw ArgumentError('scale must be positive');
@@ -336,7 +364,11 @@ class GestureDispatcher {
       return;
     }
 
-    final element = widgetFinder.findHittableElement(matcher, configuration);
+    final element = widgetFinder.findHittableElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');

--- a/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
+++ b/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
@@ -18,13 +18,13 @@ class GestureDispatcher {
   /// Simulates a tap on an element that matches the given [matcher].
   ///
   /// If [matcher] is a [CoordinatesMatcher], taps directly at the specified
-  /// coordinates without searching the widget tree (fast path), and [scope]
-  /// is ignored.
+  /// coordinates without searching the widget tree (fast path), and
+  /// [ancestors] is ignored.
   Future<void> tap(
     WidgetMatcher matcher,
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     // Fast path for coordinate-based tapping
     if (matcher is CoordinatesMatcher) {
@@ -35,7 +35,7 @@ class GestureDispatcher {
     final element = widgetFinder.findHittableElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {
@@ -99,17 +99,17 @@ class GestureDispatcher {
     WidgetMatcher matcher,
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) =>
       _mouseTap(matcher, widgetFinder, configuration,
-          buttons: kSecondaryButton, scope: scope);
+          buttons: kSecondaryButton, ancestors: ancestors);
 
   Future<void> _mouseTap(
     WidgetMatcher matcher,
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
     required int buttons,
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     if (matcher is CoordinatesMatcher) {
       await _dispatchMouseTapAtPosition(matcher.offset, buttons);
@@ -119,7 +119,7 @@ class GestureDispatcher {
     final element = widgetFinder.findHittableElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {
@@ -180,7 +180,7 @@ class GestureDispatcher {
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
     Duration delay = const Duration(milliseconds: 100),
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     if (delay.isNegative || delay == Duration.zero) {
       throw ArgumentError('delay must be positive');
@@ -194,7 +194,7 @@ class GestureDispatcher {
     final element = widgetFinder.findHittableElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {
@@ -235,7 +235,7 @@ class GestureDispatcher {
     WidgetFinder widgetFinder,
     MarionetteConfiguration configuration, {
     Duration duration = const Duration(milliseconds: 600),
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     if (duration.isNegative || duration == Duration.zero) {
       throw ArgumentError('duration must be positive');
@@ -249,7 +249,7 @@ class GestureDispatcher {
     final element = widgetFinder.findHittableElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {
@@ -307,12 +307,12 @@ class GestureDispatcher {
     MarionetteConfiguration configuration, {
     required String direction,
     double distance = 200.0,
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     final element = widgetFinder.findElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {
@@ -346,7 +346,7 @@ class GestureDispatcher {
     MarionetteConfiguration configuration, {
     required double scale,
     double startDistance = 200.0,
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     if (scale <= 0) {
       throw ArgumentError('scale must be positive');
@@ -367,7 +367,7 @@ class GestureDispatcher {
     final element = widgetFinder.findHittableElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -22,7 +22,9 @@ class ScrollSimulator {
   /// Scrolls until the widget matching [matcher] is visible.
   ///
   /// Finds the first [Scrollable] in the tree and scrolls it until the target
-  /// widget becomes visible or max attempts are exhausted.
+  /// widget becomes visible or max attempts are exhausted. When [scope] is
+  /// given, both the target and the fallback [Scrollable] are searched for
+  /// inside its subtree only.
   ///
   /// Throws an [Exception] if:
   /// - The target widget is not found
@@ -30,9 +32,10 @@ class ScrollSimulator {
   /// - The target widget is not visible after all attempts are exhausted
   Future<void> scrollUntilVisible(
     WidgetMatcher matcher,
-    MarionetteConfiguration configuration,
-  ) async {
-    final scrollable = _findScrollableElement(matcher, configuration);
+    MarionetteConfiguration configuration, {
+    KeyMatcher? scope,
+  }) async {
+    final scrollable = _findScrollableElement(matcher, configuration, scope);
     if (scrollable == null) {
       throw Exception('No Scrollable widget found in the tree');
     }
@@ -59,24 +62,29 @@ class ScrollSimulator {
       initialMoveStep,
       maxScrollAttempts,
       configuration,
+      scope,
     );
   }
 
   Element? _findScrollableElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
+    KeyMatcher? scope,
   ) {
-    final initialTarget = _widgetFinder.findElement(matcher, configuration);
+    final root = _widgetFinder.resolveScopeRoot(scope, configuration);
+    if (root == null) {
+      return null;
+    }
+
+    final initialTarget =
+        _widgetFinder.findElementFrom(matcher, root, configuration);
     if (initialTarget != null) {
+      // The enclosing Scrollable may well sit above the scope — scrolling it
+      // is what brings the scoped target into view.
       final ancestorScrollable = _findScrollableAncestor(initialTarget);
       if (ancestorScrollable != null) {
         return ancestorScrollable;
       }
-    }
-
-    final root = WidgetsBinding.instance.rootElement;
-    if (root == null) {
-      return null;
     }
 
     Element? fallbackScrollable;
@@ -123,6 +131,7 @@ class ScrollSimulator {
     Offset initialMoveStep,
     int maxScrollAttempts,
     MarionetteConfiguration configuration,
+    KeyMatcher? scope,
   ) async {
     var moveStep = initialMoveStep;
     var searchingTowardEnd = true;
@@ -131,7 +140,11 @@ class ScrollSimulator {
 
     for (var i = 0; i < maxScrollAttempts; i++) {
       // Find the target element
-      final target = _widgetFinder.findElement(targetMatcher, configuration);
+      final target = _widgetFinder.findElement(
+        targetMatcher,
+        configuration,
+        scope: scope,
+      );
       // Check if target is visible
       if (target != null && isElementHittable(target)) {
         return;

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -22,9 +22,9 @@ class ScrollSimulator {
   /// Scrolls until the widget matching [matcher] is visible.
   ///
   /// Finds the first [Scrollable] in the tree and scrolls it until the target
-  /// widget becomes visible or max attempts are exhausted. When [scope] is
+  /// widget becomes visible or max attempts are exhausted. When [ancestors] is
   /// given, both the target and the fallback [Scrollable] are searched for
-  /// inside its subtree only.
+  /// inside that subtree only.
   ///
   /// Throws an [Exception] if:
   /// - The target widget is not found
@@ -33,9 +33,10 @@ class ScrollSimulator {
   Future<void> scrollUntilVisible(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration, {
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
-    final scrollable = _findScrollableElement(matcher, configuration, scope);
+    final scrollable =
+        _findScrollableElement(matcher, configuration, ancestors);
     if (scrollable == null) {
       throw Exception('No Scrollable widget found in the tree');
     }
@@ -62,16 +63,16 @@ class ScrollSimulator {
       initialMoveStep,
       maxScrollAttempts,
       configuration,
-      scope,
+      ancestors,
     );
   }
 
   Element? _findScrollableElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors,
   ) {
-    final root = _widgetFinder.resolveScopeRoot(scope, configuration);
+    final root = _widgetFinder.resolveScopeRoot(ancestors, configuration);
     if (root == null) {
       return null;
     }
@@ -131,7 +132,7 @@ class ScrollSimulator {
     Offset initialMoveStep,
     int maxScrollAttempts,
     MarionetteConfiguration configuration,
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors,
   ) async {
     var moveStep = initialMoveStep;
     var searchingTowardEnd = true;
@@ -143,7 +144,7 @@ class ScrollSimulator {
       final target = _widgetFinder.findElement(
         targetMatcher,
         configuration,
-        scope: scope,
+        ancestors: ancestors,
       );
       // Check if target is visible
       if (target != null && isElementHittable(target)) {

--- a/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
@@ -10,14 +10,18 @@ class TextInputSimulator {
   final WidgetFinder _widgetFinder;
 
   /// Enters text into a text field identified by the given matcher.
+  ///
+  /// When [scope] is given, the field is searched for inside its subtree only.
+  /// It is ignored for [FocusedElementMatcher], which does not search the tree.
   Future<void> enterText(
     WidgetMatcher matcher,
     String text,
-    MarionetteConfiguration configuration,
-  ) async {
+    MarionetteConfiguration configuration, {
+    KeyMatcher? scope,
+  }) async {
     final editableTextState = switch (matcher) {
       FocusedElementMatcher() => _findEditableTextStateFromFocusedElement(),
-      _ => _findEditableTextStateFromMatcher(matcher, configuration),
+      _ => _findEditableTextStateFromMatcher(matcher, configuration, scope),
     };
 
     _applyText(editableTextState, text);
@@ -56,8 +60,13 @@ class TextInputSimulator {
   EditableTextState _findEditableTextStateFromMatcher(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
+    KeyMatcher? scope,
   ) {
-    final element = _widgetFinder.findHittableElement(matcher, configuration);
+    final element = _widgetFinder.findHittableElement(
+      matcher,
+      configuration,
+      scope: scope,
+    );
 
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');

--- a/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/text_input_simulator.dart
@@ -11,17 +11,18 @@ class TextInputSimulator {
 
   /// Enters text into a text field identified by the given matcher.
   ///
-  /// When [scope] is given, the field is searched for inside its subtree only.
-  /// It is ignored for [FocusedElementMatcher], which does not search the tree.
+  /// When [ancestors] is given, the field is searched for inside that subtree
+  /// only. It is ignored for [FocusedElementMatcher], which does not search
+  /// the tree.
   Future<void> enterText(
     WidgetMatcher matcher,
     String text,
     MarionetteConfiguration configuration, {
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) async {
     final editableTextState = switch (matcher) {
       FocusedElementMatcher() => _findEditableTextStateFromFocusedElement(),
-      _ => _findEditableTextStateFromMatcher(matcher, configuration, scope),
+      _ => _findEditableTextStateFromMatcher(matcher, configuration, ancestors),
     };
 
     _applyText(editableTextState, text);
@@ -60,12 +61,12 @@ class TextInputSimulator {
   EditableTextState _findEditableTextStateFromMatcher(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors,
   ) {
     final element = _widgetFinder.findHittableElement(
       matcher,
       configuration,
-      scope: scope,
+      ancestors: ancestors,
     );
 
     if (element == null) {

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -12,6 +12,10 @@ class WidgetFinder {
   /// [ancestors] is given, only the subtree it resolves to is traversed.
   ///
   /// Returns null if no matching element is found.
+  ///
+  /// Throws when [ancestors] is given but cannot be resolved — a missing scope
+  /// is a different failure from a missing target, so it is reported rather
+  /// than folded into a null. See [resolveScopeRoot].
   Element? findElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration, {
@@ -62,6 +66,11 @@ class WidgetFinder {
   /// [findElement] instead.
   ///
   /// When [ancestors] is given, only the subtree it resolves to is traversed.
+  ///
+  /// Returns null if no matching element is found, and throws when
+  /// [ancestors] is given but cannot be resolved — a missing scope is a
+  /// different failure from a missing target, so it is reported rather than
+  /// folded into a null. See [resolveScopeRoot].
   Element? findHittableElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration, {

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -8,16 +8,18 @@ class WidgetFinder {
   /// Finds the first element that matches the given [matcher].
   ///
   /// Traverses the widget tree starting from the root element and returns
-  /// the first element whose widget matches the provided matcher.
+  /// the first element whose widget matches the provided matcher. When [scope]
+  /// is given, only the subtree of the element it matches is traversed.
   ///
   /// Returns null if no matching element is found.
   Element? findElement(
     WidgetMatcher matcher,
-    MarionetteConfiguration configuration,
-  ) {
+    MarionetteConfiguration configuration, {
+    KeyMatcher? scope,
+  }) {
     return findElementFrom(
       matcher,
-      WidgetsBinding.instance.rootElement,
+      resolveScopeRoot(scope, configuration),
       configuration,
     );
   }
@@ -58,15 +60,44 @@ class WidgetFinder {
   /// where matching a non-hittable widget would result in a silent failure.
   /// Tools that need to find offscreen elements (e.g. scroll_to) should use
   /// [findElement] instead.
+  ///
+  /// When [scope] is given, only the subtree of the element it matches is
+  /// traversed.
   Element? findHittableElement(
     WidgetMatcher matcher,
-    MarionetteConfiguration configuration,
-  ) {
+    MarionetteConfiguration configuration, {
+    KeyMatcher? scope,
+  }) {
     return _findHittableElementFrom(
       matcher,
-      WidgetsBinding.instance.rootElement,
+      resolveScopeRoot(scope, configuration),
       configuration,
     );
+  }
+
+  /// Resolves the element that a `within_key` [scope] limits a search to.
+  ///
+  /// Returns the app's root element when [scope] is null.
+  ///
+  /// Throws when [scope] is given but matches no element: falling back to a
+  /// tree-wide search would silently act on a different subtree than the one
+  /// that was asked for.
+  Element? resolveScopeRoot(
+    KeyMatcher? scope,
+    MarionetteConfiguration configuration,
+  ) {
+    final root = WidgetsBinding.instance.rootElement;
+    if (scope == null) {
+      return root;
+    }
+
+    final scopeElement = findElementFrom(scope, root, configuration);
+    if (scopeElement == null) {
+      throw Exception(
+        'Scope element with key "${scope.keyValue}" (within_key) not found',
+      );
+    }
+    return scopeElement;
   }
 
   Element? _findHittableElementFrom(

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -8,18 +8,18 @@ class WidgetFinder {
   /// Finds the first element that matches the given [matcher].
   ///
   /// Traverses the widget tree starting from the root element and returns
-  /// the first element whose widget matches the provided matcher. When [scope]
-  /// is given, only the subtree of the element it matches is traversed.
+  /// the first element whose widget matches the provided matcher. When
+  /// [ancestors] is given, only the subtree it resolves to is traversed.
   ///
   /// Returns null if no matching element is found.
   Element? findElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration, {
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) {
     return findElementFrom(
       matcher,
-      resolveScopeRoot(scope, configuration),
+      resolveScopeRoot(ancestors, configuration),
       configuration,
     );
   }
@@ -61,43 +61,48 @@ class WidgetFinder {
   /// Tools that need to find offscreen elements (e.g. scroll_to) should use
   /// [findElement] instead.
   ///
-  /// When [scope] is given, only the subtree of the element it matches is
-  /// traversed.
+  /// When [ancestors] is given, only the subtree it resolves to is traversed.
   Element? findHittableElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration, {
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors = const [],
   }) {
     return _findHittableElementFrom(
       matcher,
-      resolveScopeRoot(scope, configuration),
+      resolveScopeRoot(ancestors, configuration),
       configuration,
     );
   }
 
-  /// Resolves the element that a `within_key` [scope] limits a search to.
+  /// Resolves the element that an `ancestor_keys` chain limits a search to.
   ///
-  /// Returns the app's root element when [scope] is null.
+  /// [ancestors] is ordered outermost first and nests: each key is looked up
+  /// inside the subtree of the one before it, so a chain can reach a subtree
+  /// whose own key repeats elsewhere. An empty chain resolves to the app's
+  /// root element.
   ///
-  /// Throws when [scope] is given but matches no element: falling back to a
-  /// tree-wide search would silently act on a different subtree than the one
-  /// that was asked for.
+  /// Throws when a link matches no element: falling back to a tree-wide search
+  /// would silently act on a different subtree than the one that was asked
+  /// for. The message names the link that broke and where it was looked for.
   Element? resolveScopeRoot(
-    KeyMatcher? scope,
+    List<KeyMatcher> ancestors,
     MarionetteConfiguration configuration,
   ) {
-    final root = WidgetsBinding.instance.rootElement;
-    if (scope == null) {
-      return root;
+    Element? scopeRoot = WidgetsBinding.instance.rootElement;
+
+    for (var i = 0; i < ancestors.length; i++) {
+      final found = findElementFrom(ancestors[i], scopeRoot, configuration);
+      if (found == null) {
+        final within = i == 0 ? '' : ' inside "${ancestors[i - 1].keyValue}"';
+        throw Exception(
+          'Scope element with key "${ancestors[i].keyValue}" '
+          '(ancestor_keys[$i]) not found$within',
+        );
+      }
+      scopeRoot = found;
     }
 
-    final scopeElement = findElementFrom(scope, root, configuration);
-    if (scopeElement == null) {
-      throw Exception(
-        'Scope element with key "${scope.keyValue}" (within_key) not found',
-      );
-    }
-    return scopeElement;
+    return scopeRoot;
   }
 
   Element? _findHittableElementFrom(

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -33,6 +33,22 @@ sealed class WidgetMatcher {
     }
   }
 
+  /// Parses the optional `within_key` scope that accompanies a matcher.
+  ///
+  /// The scope is not part of the target matcher: it names the subtree the
+  /// target is searched in, so that a key repeated across identical subtrees
+  /// (grid cells, embedded app instances) can be disambiguated.
+  ///
+  /// Returns null when `within_key` is absent, meaning the whole tree is
+  /// searched.
+  static KeyMatcher? scopeFromJson(Map<String, dynamic> json) {
+    final withinKey = json['within_key'];
+    if (withinKey == null) {
+      return null;
+    }
+    return KeyMatcher(withinKey as String);
+  }
+
   /// Converts this matcher to a JSON-serializable map.
   Map<String, dynamic> toJson();
 }

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
 
@@ -33,20 +35,54 @@ sealed class WidgetMatcher {
     }
   }
 
-  /// Parses the optional `within_key` scope that accompanies a matcher.
+  /// Parses the optional `ancestor_keys` scope that accompanies a matcher.
   ///
   /// The scope is not part of the target matcher: it names the subtree the
   /// target is searched in, so that a key repeated across identical subtrees
-  /// (grid cells, embedded app instances) can be disambiguated.
+  /// (grid cells, embedded app instances) can be disambiguated. The keys are
+  /// ordered outermost first and nest — each one is looked up inside the
+  /// subtree of the previous — so a chain can reach a cell whose own key also
+  /// repeats, e.g. `['session_2', 'grid.cell_3']`.
   ///
-  /// Returns null when `within_key` is absent, meaning the whole tree is
-  /// searched.
-  static KeyMatcher? scopeFromJson(Map<String, dynamic> json) {
-    final withinKey = json['within_key'];
-    if (withinKey == null) {
-      return null;
+  /// Returns an empty list when `ancestor_keys` is absent, meaning the whole
+  /// tree is searched.
+  ///
+  /// Extension params arrive as a flat `string → string` map, so the list
+  /// travels JSON-encoded — the same convention the custom-extension path uses
+  /// for nested values, and one that (unlike a delimiter) cannot collide with
+  /// characters inside a key.
+  static List<KeyMatcher> ancestorsFromJson(Map<String, dynamic> json) {
+    final raw = json['ancestor_keys'];
+    if (raw == null) {
+      return const [];
     }
-    return KeyMatcher(withinKey as String);
+
+    final decoded = raw is String ? _decodeAncestorKeys(raw) : raw;
+    if (decoded is! List) {
+      throw ArgumentError(
+        '"ancestor_keys" must be a JSON array of key strings, got: $raw',
+      );
+    }
+
+    return [
+      for (final key in decoded)
+        if (key is String)
+          KeyMatcher(key)
+        else
+          throw ArgumentError(
+            '"ancestor_keys" must contain only key strings, got: $key',
+          ),
+    ];
+  }
+
+  static Object? _decodeAncestorKeys(String raw) {
+    try {
+      return jsonDecode(raw);
+    } on FormatException catch (e) {
+      throw ArgumentError(
+        '"ancestor_keys" must be a JSON array of key strings, got: $raw (${e.message})',
+      );
+    }
   }
 
   /// Converts this matcher to a JSON-serializable map.

--- a/packages/marionette_flutter/test/gesture_dispatcher_test.dart
+++ b/packages/marionette_flutter/test/gesture_dispatcher_test.dart
@@ -858,4 +858,138 @@ void main() {
       },
     );
   });
+
+  group('GestureDispatcher - within_key scope', () {
+    /// Two structurally identical cells; only the wrapping cell key tells the
+    /// colliding `cell.joinButton` instances apart.
+    Widget grid({
+      required void Function(String label) onJoin,
+      bool secondCellHittable = true,
+    }) {
+      Widget cell(String cellKey, String label, {bool hittable = true}) {
+        final content = Column(
+          key: ValueKey(cellKey),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              key: const ValueKey('cell.joinButton'),
+              onPressed: () => onJoin(label),
+              child: Text('Join $label'),
+            ),
+          ],
+        );
+        return hittable ? content : IgnorePointer(child: content);
+      }
+
+      return MaterialApp(
+        home: Scaffold(
+          body: Row(
+            children: [
+              Expanded(child: cell('grid.cell_1', 'First')),
+              Expanded(
+                child: cell(
+                  'grid.cell_2',
+                  'Second',
+                  hittable: secondCellHittable,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'tap hits the target inside the scope, not the first match',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final joined = <String>[];
+        await tester.pumpWidget(grid(onJoin: joined.add));
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.tap(
+              const KeyMatcher('cell.joinButton'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+              scope: const KeyMatcher('grid.cell_2'),
+            ));
+        await tester.pump();
+
+        expect(joined, ['Second']);
+      },
+    );
+
+    testWidgets(
+      'tap throws naming the scope key when the scope is not found',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        await tester.pumpWidget(grid(onJoin: (_) {}));
+
+        await expectLater(
+          () => GestureDispatcher().tap(
+            const KeyMatcher('cell.joinButton'),
+            WidgetFinder(),
+            const MarionetteConfiguration(),
+            scope: const KeyMatcher('grid.cell_3'),
+          ),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('grid.cell_3'),
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'tap still enforces hittability inside the scope',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final joined = <String>[];
+        await tester.pumpWidget(
+          grid(onJoin: joined.add, secondCellHittable: false),
+        );
+
+        await expectLater(
+          () => GestureDispatcher().tap(
+            const KeyMatcher('cell.joinButton'),
+            WidgetFinder(),
+            const MarionetteConfiguration(),
+            scope: const KeyMatcher('grid.cell_2'),
+          ),
+          throwsA(isA<Exception>()),
+        );
+        expect(
+          joined,
+          isEmpty,
+          reason: 'must not fall back to the hittable button outside the scope',
+        );
+      },
+    );
+
+    testWidgets(
+      'coordinate taps ignore the scope',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final joined = <String>[];
+        await tester.pumpWidget(grid(onJoin: joined.add));
+
+        final target = tester.getCenter(
+          find.widgetWithText(ElevatedButton, 'Join First'),
+        );
+
+        await tester.runAsync(() => GestureDispatcher().tap(
+              CoordinatesMatcher(target.dx, target.dy),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+              scope: const KeyMatcher('grid.cell_3'),
+            ));
+        await tester.pump();
+
+        expect(joined, ['First']);
+      },
+    );
+  });
 }

--- a/packages/marionette_flutter/test/gesture_dispatcher_test.dart
+++ b/packages/marionette_flutter/test/gesture_dispatcher_test.dart
@@ -859,7 +859,7 @@ void main() {
     );
   });
 
-  group('GestureDispatcher - within_key scope', () {
+  group('GestureDispatcher - ancestor_keys scope', () {
     /// Two structurally identical cells; only the wrapping cell key tells the
     /// colliding `cell.joinButton` instances apart.
     Widget grid({
@@ -911,7 +911,7 @@ void main() {
               const KeyMatcher('cell.joinButton'),
               WidgetFinder(),
               const MarionetteConfiguration(),
-              scope: const KeyMatcher('grid.cell_2'),
+              ancestors: const [KeyMatcher('grid.cell_2')],
             ));
         await tester.pump();
 
@@ -920,7 +920,7 @@ void main() {
     );
 
     testWidgets(
-      'tap throws naming the scope key when the scope is not found',
+      'tap throws naming the ancestor key that was not found',
       timeout: _timeout,
       (WidgetTester tester) async {
         await tester.pumpWidget(grid(onJoin: (_) {}));
@@ -930,7 +930,7 @@ void main() {
             const KeyMatcher('cell.joinButton'),
             WidgetFinder(),
             const MarionetteConfiguration(),
-            scope: const KeyMatcher('grid.cell_3'),
+            ancestors: const [KeyMatcher('grid.cell_3')],
           ),
           throwsA(
             isA<Exception>().having(
@@ -957,7 +957,7 @@ void main() {
             const KeyMatcher('cell.joinButton'),
             WidgetFinder(),
             const MarionetteConfiguration(),
-            scope: const KeyMatcher('grid.cell_2'),
+            ancestors: const [KeyMatcher('grid.cell_2')],
           ),
           throwsA(isA<Exception>()),
         );
@@ -984,7 +984,7 @@ void main() {
               CoordinatesMatcher(target.dx, target.dy),
               WidgetFinder(),
               const MarionetteConfiguration(),
-              scope: const KeyMatcher('grid.cell_3'),
+              ancestors: const [KeyMatcher('grid.cell_3')],
             ));
         await tester.pump();
 

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -117,7 +117,7 @@ void main() {
     );
 
     testWidgets(
-      'scrolls the list inside the within_key scope, not the first one',
+      'scrolls the list inside the ancestor scope, not the first one',
       timeout: _timeout,
       (WidgetTester tester) async {
         final firstController = ScrollController();
@@ -163,7 +163,7 @@ void main() {
         await simulator.scrollUntilVisible(
           const KeyMatcher('item_15'),
           _configuration,
-          scope: const KeyMatcher('grid.cell_2'),
+          ancestors: const [KeyMatcher('grid.cell_2')],
         );
         await tester.pump();
 

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -115,6 +115,66 @@ void main() {
         expect(dispatcher.dragCount, 200);
       },
     );
+
+    testWidgets(
+      'scrolls the list inside the within_key scope, not the first one',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final firstController = ScrollController();
+        final secondController = ScrollController();
+        addTearDown(firstController.dispose);
+        addTearDown(secondController.dispose);
+
+        Widget cell(String cellKey, ScrollController controller) {
+          return Expanded(
+            child: Column(
+              key: ValueKey(cellKey),
+              children: [
+                Expanded(
+                  child: _buildItems(
+                    controller: controller,
+                    itemCount: 20,
+                    itemExtent: 80,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: [
+                  cell('grid.cell_1', firstController),
+                  cell('grid.cell_2', secondController),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _PositionalGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const KeyMatcher('item_15'),
+          _configuration,
+          scope: const KeyMatcher('grid.cell_2'),
+        );
+        await tester.pump();
+
+        expect(secondController.offset, greaterThan(0));
+        expect(
+          firstController.offset,
+          0,
+          reason: 'the list outside the scope must not be scrolled',
+        );
+      },
+    );
   });
 }
 
@@ -125,22 +185,48 @@ Widget _buildItemsApp({
 }) {
   return MaterialApp(
     home: Scaffold(
-      body: ListView.builder(
+      body: _buildItems(
         controller: controller,
-        physics: const ClampingScrollPhysics(),
         itemCount: itemCount,
-        itemBuilder: (BuildContext context, int index) {
-          return ListTile(
-            key: ValueKey('item_$index'),
-            leading: CircleAvatar(child: Text('${index + 1}')),
-            title: Text('Item $index'),
-            subtitle: const Text('Scroll target for marionette.scrollTo'),
-            minTileHeight: itemExtent,
-          );
-        },
+        itemExtent: itemExtent,
       ),
     ),
   );
+}
+
+Widget _buildItems({
+  required ScrollController controller,
+  required int itemCount,
+  required double itemExtent,
+}) {
+  return ListView.builder(
+    controller: controller,
+    physics: const ClampingScrollPhysics(),
+    itemCount: itemCount,
+    itemBuilder: (BuildContext context, int index) {
+      return ListTile(
+        key: ValueKey('item_$index'),
+        leading: CircleAvatar(child: Text('${index + 1}')),
+        title: Text('Item $index'),
+        subtitle: const Text('Scroll target for marionette.scrollTo'),
+        minTileHeight: itemExtent,
+      );
+    },
+  );
+}
+
+/// Drags wherever the simulator asks, so the scrollable it picked is the one
+/// that actually moves.
+class _PositionalGestureDispatcher extends GestureDispatcher {
+  _PositionalGestureDispatcher(this._tester);
+
+  final WidgetTester _tester;
+
+  @override
+  Future<void> drag(Offset from, Offset to) async {
+    await _tester.dragFrom(from, to - from);
+    await _tester.pump();
+  }
 }
 
 class _WidgetTesterGestureDispatcher extends GestureDispatcher {

--- a/packages/marionette_flutter/test/text_input_simulator_test.dart
+++ b/packages/marionette_flutter/test/text_input_simulator_test.dart
@@ -478,5 +478,56 @@ void main() {
         expect(secondController.text, 'updated-second');
       });
     });
+
+    group('within_key scope', () {
+      testWidgets('types into the field inside the scope', (
+        WidgetTester tester,
+      ) async {
+        final firstController = TextEditingController();
+        final secondController = TextEditingController();
+        addTearDown(firstController.dispose);
+        addTearDown(secondController.dispose);
+
+        Widget cell(String cellKey, TextEditingController controller) {
+          return Expanded(
+            child: Column(
+              key: ValueKey(cellKey),
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  key: const ValueKey('cell.nameField'),
+                  controller: controller,
+                ),
+              ],
+            ),
+          );
+        }
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: [
+                  cell('grid.cell_1', firstController),
+                  cell('grid.cell_2', secondController),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final simulator = TextInputSimulator(WidgetFinder());
+        await simulator.enterText(
+          const KeyMatcher('cell.nameField'),
+          'scoped',
+          configuration,
+          scope: const KeyMatcher('grid.cell_2'),
+        );
+        await tester.pump();
+
+        expect(firstController.text, isEmpty);
+        expect(secondController.text, 'scoped');
+      });
+    });
   });
 }

--- a/packages/marionette_flutter/test/text_input_simulator_test.dart
+++ b/packages/marionette_flutter/test/text_input_simulator_test.dart
@@ -479,7 +479,7 @@ void main() {
       });
     });
 
-    group('within_key scope', () {
+    group('ancestor_keys scope', () {
       testWidgets('types into the field inside the scope', (
         WidgetTester tester,
       ) async {
@@ -521,7 +521,7 @@ void main() {
           const KeyMatcher('cell.nameField'),
           'scoped',
           configuration,
-          scope: const KeyMatcher('grid.cell_2'),
+          ancestors: const [KeyMatcher('grid.cell_2')],
         );
         await tester.pump();
 

--- a/packages/marionette_flutter/test/widget_finder_scope_test.dart
+++ b/packages/marionette_flutter/test/widget_finder_scope_test.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+import 'package:marionette_flutter/src/services/widget_finder.dart';
+
+const _configuration = MarionetteConfiguration();
+
+/// A grid cell whose inner keys are identical in every cell — only the
+/// [cellKey] wrapper tells the instances apart.
+Widget _cell({
+  required String cellKey,
+  required String label,
+  bool hasJoinButton = true,
+  bool hittable = true,
+}) {
+  final content = Column(
+    key: ValueKey(cellKey),
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text(label),
+      if (hasJoinButton)
+        ElevatedButton(
+          key: const ValueKey('cell.joinButton'),
+          onPressed: () {},
+          child: Text('Join $label'),
+        ),
+    ],
+  );
+
+  return hittable ? content : IgnorePointer(child: content);
+}
+
+Widget _grid(List<Widget> cells) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Row(
+        children: [for (final cell in cells) Expanded(child: cell)],
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('WidgetFinder.findElement with scope', () {
+    testWidgets('matches inside the requested scope, not the first cell',
+        (tester) async {
+      await tester.pumpWidget(_grid([
+        _cell(cellKey: 'grid.cell_1', label: 'First'),
+        _cell(cellKey: 'grid.cell_2', label: 'Second'),
+      ]));
+
+      final element = WidgetFinder().findElement(
+        const KeyMatcher('cell.joinButton'),
+        _configuration,
+        scope: const KeyMatcher('grid.cell_2'),
+      );
+
+      expect(
+        element,
+        tester.element(find.widgetWithText(ElevatedButton, 'Join Second')),
+        reason: 'a tree-wide search would have matched the first cell',
+      );
+    });
+
+    testWidgets('searches the whole tree when no scope is given',
+        (tester) async {
+      await tester.pumpWidget(_grid([
+        _cell(cellKey: 'grid.cell_1', label: 'First'),
+        _cell(cellKey: 'grid.cell_2', label: 'Second'),
+      ]));
+
+      final element = WidgetFinder().findElement(
+        const KeyMatcher('cell.joinButton'),
+        _configuration,
+      );
+
+      expect(
+        element,
+        tester.element(find.widgetWithText(ElevatedButton, 'Join First')),
+      );
+    });
+
+    testWidgets('throws naming the scope key when the scope is not found',
+        (tester) async {
+      await tester.pumpWidget(_grid([
+        _cell(cellKey: 'grid.cell_1', label: 'First'),
+      ]));
+
+      expect(
+        () => WidgetFinder().findElement(
+          const KeyMatcher('cell.joinButton'),
+          _configuration,
+          scope: const KeyMatcher('grid.cell_2'),
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('grid.cell_2'),
+          ),
+        ),
+      );
+    });
+
+    testWidgets(
+      'returns null instead of falling back to a match outside the scope',
+      (tester) async {
+        await tester.pumpWidget(_grid([
+          _cell(cellKey: 'grid.cell_1', label: 'First'),
+          _cell(
+            cellKey: 'grid.cell_2',
+            label: 'Second',
+            hasJoinButton: false,
+          ),
+        ]));
+
+        final finder = WidgetFinder();
+
+        expect(
+          finder.findElement(
+            const KeyMatcher('cell.joinButton'),
+            _configuration,
+            scope: const KeyMatcher('grid.cell_2'),
+          ),
+          isNull,
+        );
+        expect(
+          finder.findElement(
+              const KeyMatcher('cell.joinButton'), _configuration),
+          isNotNull,
+          reason: 'an identical target does exist outside the scope',
+        );
+      },
+    );
+  });
+
+  group('WidgetFinder.findHittableElement with scope', () {
+    testWidgets('matches inside the requested scope', (tester) async {
+      await tester.pumpWidget(_grid([
+        _cell(cellKey: 'grid.cell_1', label: 'First'),
+        _cell(cellKey: 'grid.cell_2', label: 'Second'),
+      ]));
+
+      final element = WidgetFinder().findHittableElement(
+        const KeyMatcher('cell.joinButton'),
+        _configuration,
+        scope: const KeyMatcher('grid.cell_2'),
+      );
+
+      expect(
+        element,
+        tester.element(find.widgetWithText(ElevatedButton, 'Join Second')),
+      );
+    });
+
+    testWidgets('still enforces hittability inside the scope', (tester) async {
+      await tester.pumpWidget(_grid([
+        _cell(cellKey: 'grid.cell_1', label: 'First'),
+        _cell(cellKey: 'grid.cell_2', label: 'Second', hittable: false),
+      ]));
+
+      final finder = WidgetFinder();
+
+      expect(
+        finder.findHittableElement(
+          const KeyMatcher('cell.joinButton'),
+          _configuration,
+          scope: const KeyMatcher('grid.cell_2'),
+        ),
+        isNull,
+        reason: 'the scoped target is behind an IgnorePointer',
+      );
+      expect(
+        finder.findElement(
+          const KeyMatcher('cell.joinButton'),
+          _configuration,
+          scope: const KeyMatcher('grid.cell_2'),
+        ),
+        isNotNull,
+        reason: 'findElement should still find the non-hittable target',
+      );
+      expect(
+        finder.findHittableElement(
+          const KeyMatcher('cell.joinButton'),
+          _configuration,
+        ),
+        isNotNull,
+        reason: 'a hittable target does exist outside the scope',
+      );
+    });
+
+    testWidgets('throws naming the scope key when the scope is not found',
+        (tester) async {
+      await tester.pumpWidget(_grid([
+        _cell(cellKey: 'grid.cell_1', label: 'First'),
+      ]));
+
+      expect(
+        () => WidgetFinder().findHittableElement(
+          const KeyMatcher('cell.joinButton'),
+          _configuration,
+          scope: const KeyMatcher('grid.cell_2'),
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('grid.cell_2'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/marionette_flutter/test/widget_finder_scope_test.dart
+++ b/packages/marionette_flutter/test/widget_finder_scope_test.dart
@@ -30,18 +30,34 @@ Widget _cell({
   return hittable ? content : IgnorePointer(child: content);
 }
 
-Widget _grid(List<Widget> cells) {
-  return MaterialApp(
-    home: Scaffold(
-      body: Row(
-        children: [for (final cell in cells) Expanded(child: cell)],
-      ),
+/// A session that embeds a whole grid, so even the cell keys repeat across
+/// sessions and only the full ancestor chain identifies one cell.
+Widget _session(String sessionKey, List<Widget> cells) {
+  return Expanded(
+    child: Column(
+      key: ValueKey(sessionKey),
+      mainAxisSize: MainAxisSize.min,
+      children: cells,
     ),
   );
 }
 
+Widget _app(List<Widget> children) {
+  return MaterialApp(
+    home: Scaffold(body: Row(children: children)),
+  );
+}
+
+Widget _grid(List<Widget> cells) {
+  return _app([for (final cell in cells) Expanded(child: cell)]);
+}
+
+List<KeyMatcher> _ancestors(List<String> keys) {
+  return [for (final key in keys) KeyMatcher(key)];
+}
+
 void main() {
-  group('WidgetFinder.findElement with scope', () {
+  group('WidgetFinder.findElement with ancestors', () {
     testWidgets('matches inside the requested scope, not the first cell',
         (tester) async {
       await tester.pumpWidget(_grid([
@@ -52,7 +68,7 @@ void main() {
       final element = WidgetFinder().findElement(
         const KeyMatcher('cell.joinButton'),
         _configuration,
-        scope: const KeyMatcher('grid.cell_2'),
+        ancestors: _ancestors(['grid.cell_2']),
       );
 
       expect(
@@ -62,7 +78,34 @@ void main() {
       );
     });
 
-    testWidgets('searches the whole tree when no scope is given',
+    testWidgets('resolves each ancestor inside the previous one',
+        (tester) async {
+      await tester.pumpWidget(_app([
+        _session('session_1', [
+          _cell(cellKey: 'grid.cell_1', label: 'A1'),
+          _cell(cellKey: 'grid.cell_2', label: 'A2'),
+        ]),
+        _session('session_2', [
+          _cell(cellKey: 'grid.cell_1', label: 'B1'),
+          _cell(cellKey: 'grid.cell_2', label: 'B2'),
+        ]),
+      ]));
+
+      final element = WidgetFinder().findElement(
+        const KeyMatcher('cell.joinButton'),
+        _configuration,
+        ancestors: _ancestors(['session_2', 'grid.cell_2']),
+      );
+
+      expect(
+        element,
+        tester.element(find.widgetWithText(ElevatedButton, 'Join B2')),
+        reason: 'scoping to grid.cell_2 alone would have matched the cell in '
+            'the first session',
+      );
+    });
+
+    testWidgets('searches the whole tree when no ancestors are given',
         (tester) async {
       await tester.pumpWidget(_grid([
         _cell(cellKey: 'grid.cell_1', label: 'First'),
@@ -80,7 +123,7 @@ void main() {
       );
     });
 
-    testWidgets('throws naming the scope key when the scope is not found',
+    testWidgets('throws naming the ancestor key that was not found',
         (tester) async {
       await tester.pumpWidget(_grid([
         _cell(cellKey: 'grid.cell_1', label: 'First'),
@@ -90,17 +133,52 @@ void main() {
         () => WidgetFinder().findElement(
           const KeyMatcher('cell.joinButton'),
           _configuration,
-          scope: const KeyMatcher('grid.cell_2'),
+          ancestors: _ancestors(['grid.cell_2']),
         ),
         throwsA(
           isA<Exception>().having(
             (e) => e.toString(),
             'message',
-            contains('grid.cell_2'),
+            allOf(contains('grid.cell_2'), contains('ancestor_keys[0]')),
           ),
         ),
       );
     });
+
+    testWidgets(
+      'throws naming the failing link and its parent for a nested chain',
+      (tester) async {
+        await tester.pumpWidget(_app([
+          _session('session_1', [
+            _cell(cellKey: 'grid.cell_2', label: 'A2'),
+          ]),
+          _session('session_2', [
+            _cell(cellKey: 'grid.cell_1', label: 'B1'),
+          ]),
+        ]));
+
+        expect(
+          () => WidgetFinder().findElement(
+            const KeyMatcher('cell.joinButton'),
+            _configuration,
+            ancestors: _ancestors(['session_2', 'grid.cell_2']),
+          ),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              allOf(
+                contains('grid.cell_2'),
+                contains('ancestor_keys[1]'),
+                contains('session_2'),
+              ),
+            ),
+          ),
+          reason: 'grid.cell_2 exists, but not inside session_2 — the error '
+              'must say which link of the chain broke and where',
+        );
+      },
+    );
 
     testWidgets(
       'returns null instead of falling back to a match outside the scope',
@@ -120,7 +198,7 @@ void main() {
           finder.findElement(
             const KeyMatcher('cell.joinButton'),
             _configuration,
-            scope: const KeyMatcher('grid.cell_2'),
+            ancestors: _ancestors(['grid.cell_2']),
           ),
           isNull,
         );
@@ -134,7 +212,7 @@ void main() {
     );
   });
 
-  group('WidgetFinder.findHittableElement with scope', () {
+  group('WidgetFinder.findHittableElement with ancestors', () {
     testWidgets('matches inside the requested scope', (tester) async {
       await tester.pumpWidget(_grid([
         _cell(cellKey: 'grid.cell_1', label: 'First'),
@@ -144,7 +222,7 @@ void main() {
       final element = WidgetFinder().findHittableElement(
         const KeyMatcher('cell.joinButton'),
         _configuration,
-        scope: const KeyMatcher('grid.cell_2'),
+        ancestors: _ancestors(['grid.cell_2']),
       );
 
       expect(
@@ -165,7 +243,7 @@ void main() {
         finder.findHittableElement(
           const KeyMatcher('cell.joinButton'),
           _configuration,
-          scope: const KeyMatcher('grid.cell_2'),
+          ancestors: _ancestors(['grid.cell_2']),
         ),
         isNull,
         reason: 'the scoped target is behind an IgnorePointer',
@@ -174,7 +252,7 @@ void main() {
         finder.findElement(
           const KeyMatcher('cell.joinButton'),
           _configuration,
-          scope: const KeyMatcher('grid.cell_2'),
+          ancestors: _ancestors(['grid.cell_2']),
         ),
         isNotNull,
         reason: 'findElement should still find the non-hittable target',
@@ -189,7 +267,7 @@ void main() {
       );
     });
 
-    testWidgets('throws naming the scope key when the scope is not found',
+    testWidgets('throws naming the ancestor key that was not found',
         (tester) async {
       await tester.pumpWidget(_grid([
         _cell(cellKey: 'grid.cell_1', label: 'First'),
@@ -199,13 +277,13 @@ void main() {
         () => WidgetFinder().findHittableElement(
           const KeyMatcher('cell.joinButton'),
           _configuration,
-          scope: const KeyMatcher('grid.cell_2'),
+          ancestors: _ancestors(['grid.cell_2']),
         ),
         throwsA(
           isA<Exception>().having(
             (e) => e.toString(),
             'message',
-            contains('grid.cell_2'),
+            allOf(contains('grid.cell_2'), contains('ancestor_keys[0]')),
           ),
         ),
       );

--- a/packages/marionette_flutter/test/widget_matcher_test.dart
+++ b/packages/marionette_flutter/test/widget_matcher_test.dart
@@ -42,6 +42,39 @@ void main() {
 
       expect(matcher, isA<IdentifierMatcher>());
     });
+
+    test('within_key does not select the target matcher', () {
+      final matcher = WidgetMatcher.fromJson({
+        'key': 'join_button',
+        'within_key': 'grid.cell_2',
+      });
+
+      expect(matcher, isA<KeyMatcher>());
+      expect((matcher as KeyMatcher).keyValue, 'join_button');
+    });
+
+    test('within_key alone is not a valid matcher', () {
+      expect(
+        () => WidgetMatcher.fromJson({'within_key': 'grid.cell_2'}),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('WidgetMatcher.scopeFromJson', () {
+    test('returns null when within_key is absent', () {
+      expect(WidgetMatcher.scopeFromJson({'key': 'join_button'}), isNull);
+    });
+
+    test('returns a KeyMatcher for within_key', () {
+      final scope = WidgetMatcher.scopeFromJson({
+        'key': 'join_button',
+        'within_key': 'grid.cell_2',
+      });
+
+      expect(scope, isA<KeyMatcher>());
+      expect(scope!.keyValue, 'grid.cell_2');
+    });
   });
 
   group('FocusedElementMatcher', () {

--- a/packages/marionette_flutter/test/widget_matcher_test.dart
+++ b/packages/marionette_flutter/test/widget_matcher_test.dart
@@ -72,7 +72,8 @@ void main() {
 
     test('is empty for an empty ancestor_keys array', () {
       expect(
-        WidgetMatcher.ancestorsFromJson({'ancestor_keys': jsonEncode(<String>[])}),
+        WidgetMatcher.ancestorsFromJson(
+            {'ancestor_keys': jsonEncode(<String>[])}),
         isEmpty,
       );
     });

--- a/packages/marionette_flutter/test/widget_matcher_test.dart
+++ b/packages/marionette_flutter/test/widget_matcher_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:test/test.dart';
 
@@ -43,37 +45,60 @@ void main() {
       expect(matcher, isA<IdentifierMatcher>());
     });
 
-    test('within_key does not select the target matcher', () {
+    test('ancestor_keys does not select the target matcher', () {
       final matcher = WidgetMatcher.fromJson({
         'key': 'join_button',
-        'within_key': 'grid.cell_2',
+        'ancestor_keys': jsonEncode(['grid.cell_2']),
       });
 
       expect(matcher, isA<KeyMatcher>());
       expect((matcher as KeyMatcher).keyValue, 'join_button');
     });
 
-    test('within_key alone is not a valid matcher', () {
+    test('ancestor_keys alone is not a valid matcher', () {
       expect(
-        () => WidgetMatcher.fromJson({'within_key': 'grid.cell_2'}),
+        () => WidgetMatcher.fromJson({
+          'ancestor_keys': jsonEncode(['grid.cell_2']),
+        }),
         throwsArgumentError,
       );
     });
   });
 
-  group('WidgetMatcher.scopeFromJson', () {
-    test('returns null when within_key is absent', () {
-      expect(WidgetMatcher.scopeFromJson({'key': 'join_button'}), isNull);
+  group('WidgetMatcher.ancestorsFromJson', () {
+    test('is empty when ancestor_keys is absent', () {
+      expect(WidgetMatcher.ancestorsFromJson({'key': 'join_button'}), isEmpty);
     });
 
-    test('returns a KeyMatcher for within_key', () {
-      final scope = WidgetMatcher.scopeFromJson({
+    test('is empty for an empty ancestor_keys array', () {
+      expect(
+        WidgetMatcher.ancestorsFromJson({'ancestor_keys': jsonEncode(<String>[])}),
+        isEmpty,
+      );
+    });
+
+    test('parses a single ancestor key', () {
+      final ancestors = WidgetMatcher.ancestorsFromJson({
         'key': 'join_button',
-        'within_key': 'grid.cell_2',
+        'ancestor_keys': jsonEncode(['grid.cell_2']),
       });
 
-      expect(scope, isA<KeyMatcher>());
-      expect(scope!.keyValue, 'grid.cell_2');
+      expect(ancestors.map((m) => m.keyValue), ['grid.cell_2']);
+    });
+
+    test('preserves outermost-first order of a nested chain', () {
+      final ancestors = WidgetMatcher.ancestorsFromJson({
+        'ancestor_keys': jsonEncode(['session_2', 'grid.cell_2']),
+      });
+
+      expect(ancestors.map((m) => m.keyValue), ['session_2', 'grid.cell_2']);
+    });
+
+    test('rejects a malformed ancestor_keys payload', () {
+      expect(
+        () => WidgetMatcher.ancestorsFromJson({'ancestor_keys': 'grid.cell_2'}),
+        throwsArgumentError,
+      );
     });
   });
 

--- a/packages/marionette_mcp/example/pubspec.lock
+++ b/packages/marionette_mcp/example/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -226,10 +226,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -263,5 +263,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/packages/marionette_mcp/lib/src/formatting.dart
+++ b/packages/marionette_mcp/lib/src/formatting.dart
@@ -1,8 +1,20 @@
 import 'dart:convert';
 
+/// Shared description of the `within_key` field across every matcher-based
+/// tool, so agents read the same contract wherever they discover it.
+const withinKeyDescription =
+    'Optional. Restricts the search to the subtree of the element whose key '
+    '(a ValueKey<String>) is this value. Use it when the same inner key '
+    'appears in several identical subtrees — grid cells, repeated cards, '
+    'embedded app instances — to pick the one you mean, e.g. '
+    '{"key": "cell.joinButton", "within_key": "grid.cell_2"}. Fails if no '
+    'element has this key; ignored when matching by coordinates or '
+    'focused_element.';
+
 /// Builds a widget matcher map from tool/CLI arguments.
 ///
-/// Supports matching by key, identifier, text, type, and coordinates.
+/// Supports matching by key, identifier, text, type, and coordinates, plus the
+/// optional `within_key` scope.
 Map<String, dynamic> buildMatcher(Map<String, dynamic> args) {
   final matcher = <String, dynamic>{};
   if (args['focused_element'] == true) {
@@ -31,7 +43,18 @@ Map<String, dynamic> buildMatcher(Map<String, dynamic> args) {
   if (args.containsKey('y')) {
     matcher['y'] = args['y'];
   }
+  if (args.containsKey('within_key')) {
+    matcher['within_key'] = args['within_key'];
+  }
   return matcher;
+}
+
+/// Whether [matcher] identifies an element to act on.
+///
+/// `within_key` only narrows where the search happens, so a matcher carrying
+/// nothing but a scope still selects nothing.
+bool hasSelector(Map<String, dynamic> matcher) {
+  return matcher.keys.any((field) => field != 'within_key');
 }
 
 /// Formats an element map for human-readable display.

--- a/packages/marionette_mcp/lib/src/formatting.dart
+++ b/packages/marionette_mcp/lib/src/formatting.dart
@@ -1,20 +1,22 @@
 import 'dart:convert';
 
-/// Shared description of the `within_key` field across every matcher-based
+/// Shared description of the `ancestor_keys` field across every matcher-based
 /// tool, so agents read the same contract wherever they discover it.
-const withinKeyDescription =
+const ancestorKeysDescription =
     'Optional. Restricts the search to the subtree of the element whose key '
     '(a ValueKey<String>) is this value. Use it when the same inner key '
     'appears in several identical subtrees — grid cells, repeated cards, '
     'embedded app instances — to pick the one you mean, e.g. '
-    '{"key": "cell.joinButton", "within_key": "grid.cell_2"}. Fails if no '
-    'element has this key; ignored when matching by coordinates or '
-    'focused_element.';
+    '{"key": "cell.joinButton", "ancestor_keys": ["grid.cell_2"]}. List the '
+    'keys outermost first to go deeper: each one is looked up inside the '
+    'subtree of the previous, so ["session_2", "grid.cell_3"] reaches a cell '
+    'whose own key also repeats in other sessions. Fails if any of these keys '
+    'has no element; ignored when matching by coordinates or focused_element.';
 
 /// Builds a widget matcher map from tool/CLI arguments.
 ///
 /// Supports matching by key, identifier, text, type, and coordinates, plus the
-/// optional `within_key` scope.
+/// optional `ancestor_keys` scope.
 Map<String, dynamic> buildMatcher(Map<String, dynamic> args) {
   final matcher = <String, dynamic>{};
   if (args['focused_element'] == true) {
@@ -43,18 +45,22 @@ Map<String, dynamic> buildMatcher(Map<String, dynamic> args) {
   if (args.containsKey('y')) {
     matcher['y'] = args['y'];
   }
-  if (args.containsKey('within_key')) {
-    matcher['within_key'] = args['within_key'];
+  // The VM service only carries string values, so the scope chain travels
+  // JSON-encoded rather than as a list (whose toString() is un-parseable) or
+  // a delimited string (whose delimiter could appear inside a key).
+  if (args['ancestor_keys'] case final List<dynamic> ancestorKeys
+      when ancestorKeys.isNotEmpty) {
+    matcher['ancestor_keys'] = jsonEncode(ancestorKeys);
   }
   return matcher;
 }
 
 /// Whether [matcher] identifies an element to act on.
 ///
-/// `within_key` only narrows where the search happens, so a matcher carrying
-/// nothing but a scope still selects nothing.
+/// `ancestor_keys` only narrows where the search happens, so a matcher
+/// carrying nothing but a scope still selects nothing.
 bool hasSelector(Map<String, dynamic> matcher) {
-  return matcher.keys.any((field) => field != 'within_key');
+  return matcher.keys.any((field) => field != 'ancestor_keys');
 }
 
 /// Formats an element map for human-readable display.

--- a/packages/marionette_mcp/lib/src/mcp_server_runner.dart
+++ b/packages/marionette_mcp/lib/src/mcp_server_runner.dart
@@ -19,6 +19,8 @@ Usage:
 7. Use "hot_restart" to fully restart the app from main() and reset all state — needed for changes a hot reload cannot pick up (e.g. main()/bootstrap edits, global singletons, or state shape). Requires the app to be running via `flutter run`.
 
 Important: Elements are matched by their key (ValueKey<String>), Semantics identifier, or text content. Keys are the most reliable; a Semantics identifier (set via `Semantics(identifier: ...)`) is an equally stable alternative when adding a key is not practical. If you cannot locate a widget, you may need to add a ValueKey to it in the Flutter source code. For example: `ElevatedButton(key: ValueKey('submit_button'), ...)`.
+
+When the same key exists in several identical subtrees (grid cells, repeated cards, embedded app instances), a plain match always hits the first one. Pass "within_key" alongside the selector to scope the search to one subtree, e.g. `{"key": "cell.joinButton", "within_key": "grid.cell_2"}`.
 ''';
 
 /// Runs the Marionette MCP server with the given configuration.

--- a/packages/marionette_mcp/lib/src/mcp_server_runner.dart
+++ b/packages/marionette_mcp/lib/src/mcp_server_runner.dart
@@ -20,7 +20,7 @@ Usage:
 
 Important: Elements are matched by their key (ValueKey<String>), Semantics identifier, or text content. Keys are the most reliable; a Semantics identifier (set via `Semantics(identifier: ...)`) is an equally stable alternative when adding a key is not practical. If you cannot locate a widget, you may need to add a ValueKey to it in the Flutter source code. For example: `ElevatedButton(key: ValueKey('submit_button'), ...)`.
 
-When the same key exists in several identical subtrees (grid cells, repeated cards, embedded app instances), a plain match always hits the first one. Pass "within_key" alongside the selector to scope the search to one subtree, e.g. `{"key": "cell.joinButton", "within_key": "grid.cell_2"}`.
+When the same key exists in several identical subtrees (grid cells, repeated cards, embedded app instances), a plain match always hits the first one. Pass "ancestor_keys" alongside the selector to scope the search to one subtree, e.g. `{"key": "cell.joinButton", "ancestor_keys": ["grid.cell_2"]}`. The keys nest, outermost first — each is looked up inside the previous one's subtree — so `["session_2", "grid.cell_3"]` reaches a cell whose own key also repeats in the other sessions.
 ''';
 
 /// Runs the Marionette MCP server with the given configuration.

--- a/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
@@ -15,7 +15,7 @@ void registerGestureTools(
     ..registerTool(
       'tap',
       description:
-          'Simulates a tap gesture on an element in the Flutter app that matches the given criteria. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content (but not accessibility label!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, identifier, text, type, or coordinates. Prefer using the key if available, as it is more reliable; the Semantics identifier is the next-best stable selector. Limit yourself to elements from get_interactive_elements only if you can. Tapping a text field gives it focus, after which you can use enter_text with focused_element to type into it. Requires an active connection established via connect.',
+          'Simulates a tap gesture on an element in the Flutter app that matches the given criteria. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content (but not accessibility label!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, identifier, text, type, or coordinates. Prefer using the key if available, as it is more reliable; the Semantics identifier is the next-best stable selector. Limit yourself to elements from get_interactive_elements only if you can. Tapping a text field gives it focus, after which you can use enter_text with focused_element to type into it. When the same key appears in several identical subtrees (grid cells, repeated cards), add within_key to scope the search to one of them. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -52,6 +52,7 @@ void registerGestureTools(
             },
             required: ['x', 'y'],
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
       ),
       callback: (args, extra) async {
@@ -69,7 +70,7 @@ void registerGestureTools(
     ..registerTool(
       'secondary_tap',
       description:
-          'Simulates a secondary tap (right mouse button click) on an element in the Flutter app. Desktop only — dispatches a mouse pointer with the secondary button pressed, which is what Flutter recognises as onSecondaryTap (e.g. for opening context menus). You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content, by their widget type, or by screen coordinates. Only one matching method should be used. Prefer using the key if available, as it is more reliable. Requires an active connection established via connect.',
+          'Simulates a secondary tap (right mouse button click) on an element in the Flutter app. Desktop only — dispatches a mouse pointer with the secondary button pressed, which is what Flutter recognises as onSecondaryTap (e.g. for opening context menus). You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content, by their widget type, or by screen coordinates. Only one matching method should be used. Prefer using the key if available, as it is more reliable. Add within_key to scope the search to one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Secondary Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -104,6 +105,7 @@ void registerGestureTools(
             },
             required: ['x', 'y'],
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
       ),
       callback: (args, extra) async {
@@ -123,7 +125,7 @@ void registerGestureTools(
     ..registerTool(
       'double_tap',
       description:
-          'Simulates a double tap gesture on an element in the Flutter app. This is useful for triggering text selection, zoom, or any widget that responds to double tap. You can match elements by their key, identifier, text, type, or coordinates. An optional delay parameter controls the time between the two taps (default: 100ms). Requires an active connection established via connect.',
+          'Simulates a double tap gesture on an element in the Flutter app. This is useful for triggering text selection, zoom, or any widget that responds to double tap. You can match elements by their key, identifier, text, type, or coordinates. An optional delay parameter controls the time between the two taps (default: 100ms). Add within_key to scope the search to one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Double Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -162,6 +164,7 @@ void registerGestureTools(
             description:
                 'Time between the two taps in milliseconds. Defaults to 100ms which is within Flutter\'s double-tap recognition window (40ms-300ms).',
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
       ),
       callback: (args, extra) async {
@@ -192,7 +195,7 @@ void registerGestureTools(
     ..registerTool(
       'long_press',
       description:
-          'Simulates a long press gesture on an element in the Flutter app. This is useful for triggering context menus, reorderable lists, or any widget that responds to long press. You can match elements by their key, identifier, text, type, or coordinates. An optional duration parameter controls how long the press is held (default: 600ms). Requires an active connection established via connect.',
+          'Simulates a long press gesture on an element in the Flutter app. This is useful for triggering context menus, reorderable lists, or any widget that responds to long press. You can match elements by their key, identifier, text, type, or coordinates. An optional duration parameter controls how long the press is held (default: 600ms). Add within_key to scope the search to one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Long Press Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -231,6 +234,7 @@ void registerGestureTools(
             description:
                 'How long to hold the press in milliseconds. Defaults to 600ms which matches Flutter\'s long press behavior.',
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
       ),
       callback: (args, extra) async {
@@ -258,6 +262,7 @@ void registerGestureTools(
           '1. Element-based: provide key, identifier, or text to identify the element, plus a direction (left, right, up, down) and optional distance in pixels (default 200). '
           '2. Coordinate-based: provide startX, startY, endX, endY for precise control. '
           'Useful for interacting with PageView, Dismissible, Drawer, Slider, and other swipe-based widgets. '
+          'In element-based mode, add within_key to scope the search to one subtree when the same key appears in several identical subtrees. '
           'Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Swipe'),
       inputSchema: ToolInputSchema(
@@ -296,6 +301,7 @@ void registerGestureTools(
           'endY': JsonSchema.number(
             description: 'End Y coordinate for coordinate-based swipe.',
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
       ),
       callback: (args, extra) async {
@@ -356,7 +362,9 @@ void registerGestureTools(
           'Use scale > 1.0 to zoom in (fingers move apart) and scale < 1.0 '
           'to zoom out (fingers move together). You can target the element by '
           'key, identifier, text, type, or coordinates. Useful for maps, '
-          'images, PDFs, and other zoomable content. '
+          'images, PDFs, and other zoomable content. Add within_key to scope '
+          'the search to one subtree when the same key appears in several '
+          'identical subtrees. '
           'Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Pinch Zoom'),
       inputSchema: ToolInputSchema(
@@ -395,12 +403,13 @@ void registerGestureTools(
             description: 'Initial distance between the two fingers in pixels '
                 '(default: 200).',
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
         required: ['scale'],
       ),
       callback: (args, extra) async {
         final matcher = buildMatcher(args);
-        if (matcher.isEmpty) {
+        if (!hasSelector(matcher)) {
           return CallToolResult(
             isError: true,
             content: [
@@ -482,7 +491,7 @@ void registerGestureTools(
     ..registerTool(
       'scroll_to',
       description:
-          'Scrolls the view until an element matching the given criteria becomes visible. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, or by their visible text content. This is useful when you need to interact with elements that are not currently visible on screen. Requires an active connection established via connect.',
+          'Scrolls the view until an element matching the given criteria becomes visible. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, or by their visible text content. This is useful when you need to interact with elements that are not currently visible on screen. Add within_key to scroll the list inside one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Scroll to Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -500,6 +509,7 @@ void registerGestureTools(
             description:
                 'The visible text content of the element to scroll to.',
           ),
+          'within_key': JsonSchema.string(description: withinKeyDescription),
         },
       ),
       callback: (args, extra) async {

--- a/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
@@ -414,8 +414,8 @@ void registerGestureTools(
             isError: true,
             content: [
               const TextContent(
-                text: 'Missing required selector: provide "key", "text", '
-                    '"type", or "coordinates".',
+                text: 'Missing required selector: provide "key", '
+                    '"identifier", "text", "type", or "coordinates".',
               ),
             ],
           );

--- a/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/gesture_tools.dart
@@ -15,7 +15,7 @@ void registerGestureTools(
     ..registerTool(
       'tap',
       description:
-          'Simulates a tap gesture on an element in the Flutter app that matches the given criteria. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content (but not accessibility label!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, identifier, text, type, or coordinates. Prefer using the key if available, as it is more reliable; the Semantics identifier is the next-best stable selector. Limit yourself to elements from get_interactive_elements only if you can. Tapping a text field gives it focus, after which you can use enter_text with focused_element to type into it. When the same key appears in several identical subtrees (grid cells, repeated cards), add within_key to scope the search to one of them. Requires an active connection established via connect.',
+          'Simulates a tap gesture on an element in the Flutter app that matches the given criteria. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content (but not accessibility label!), by their widget type, or by screen coordinates. Only one matching method should be used: either key, identifier, text, type, or coordinates. Prefer using the key if available, as it is more reliable; the Semantics identifier is the next-best stable selector. Limit yourself to elements from get_interactive_elements only if you can. Tapping a text field gives it focus, after which you can use enter_text with focused_element to type into it. When the same key appears in several identical subtrees (grid cells, repeated cards), add ancestor_keys to scope the search to one of them, outermost wrapper key first. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -52,7 +52,10 @@ void registerGestureTools(
             },
             required: ['x', 'y'],
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
       ),
       callback: (args, extra) async {
@@ -70,7 +73,7 @@ void registerGestureTools(
     ..registerTool(
       'secondary_tap',
       description:
-          'Simulates a secondary tap (right mouse button click) on an element in the Flutter app. Desktop only — dispatches a mouse pointer with the secondary button pressed, which is what Flutter recognises as onSecondaryTap (e.g. for opening context menus). You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content, by their widget type, or by screen coordinates. Only one matching method should be used. Prefer using the key if available, as it is more reliable. Add within_key to scope the search to one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
+          'Simulates a secondary tap (right mouse button click) on an element in the Flutter app. Desktop only — dispatches a mouse pointer with the secondary button pressed, which is what Flutter recognises as onSecondaryTap (e.g. for opening context menus). You can match elements by their key (a ValueKey<String>), by their Semantics identifier, by their text content, by their widget type, or by screen coordinates. Only one matching method should be used. Prefer using the key if available, as it is more reliable. Add ancestor_keys to scope the search to one subtree when the same key appears in several identical subtrees; list the wrapper keys outermost first to go deeper. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Secondary Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -105,7 +108,10 @@ void registerGestureTools(
             },
             required: ['x', 'y'],
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
       ),
       callback: (args, extra) async {
@@ -125,7 +131,7 @@ void registerGestureTools(
     ..registerTool(
       'double_tap',
       description:
-          'Simulates a double tap gesture on an element in the Flutter app. This is useful for triggering text selection, zoom, or any widget that responds to double tap. You can match elements by their key, identifier, text, type, or coordinates. An optional delay parameter controls the time between the two taps (default: 100ms). Add within_key to scope the search to one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
+          'Simulates a double tap gesture on an element in the Flutter app. This is useful for triggering text selection, zoom, or any widget that responds to double tap. You can match elements by their key, identifier, text, type, or coordinates. An optional delay parameter controls the time between the two taps (default: 100ms). Add ancestor_keys to scope the search to one subtree when the same key appears in several identical subtrees; list the wrapper keys outermost first to go deeper. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Double Tap Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -164,7 +170,10 @@ void registerGestureTools(
             description:
                 'Time between the two taps in milliseconds. Defaults to 100ms which is within Flutter\'s double-tap recognition window (40ms-300ms).',
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
       ),
       callback: (args, extra) async {
@@ -195,7 +204,7 @@ void registerGestureTools(
     ..registerTool(
       'long_press',
       description:
-          'Simulates a long press gesture on an element in the Flutter app. This is useful for triggering context menus, reorderable lists, or any widget that responds to long press. You can match elements by their key, identifier, text, type, or coordinates. An optional duration parameter controls how long the press is held (default: 600ms). Add within_key to scope the search to one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
+          'Simulates a long press gesture on an element in the Flutter app. This is useful for triggering context menus, reorderable lists, or any widget that responds to long press. You can match elements by their key, identifier, text, type, or coordinates. An optional duration parameter controls how long the press is held (default: 600ms). Add ancestor_keys to scope the search to one subtree when the same key appears in several identical subtrees; list the wrapper keys outermost first to go deeper. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Long Press Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -234,7 +243,10 @@ void registerGestureTools(
             description:
                 'How long to hold the press in milliseconds. Defaults to 600ms which matches Flutter\'s long press behavior.',
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
       ),
       callback: (args, extra) async {
@@ -262,7 +274,7 @@ void registerGestureTools(
           '1. Element-based: provide key, identifier, or text to identify the element, plus a direction (left, right, up, down) and optional distance in pixels (default 200). '
           '2. Coordinate-based: provide startX, startY, endX, endY for precise control. '
           'Useful for interacting with PageView, Dismissible, Drawer, Slider, and other swipe-based widgets. '
-          'In element-based mode, add within_key to scope the search to one subtree when the same key appears in several identical subtrees. '
+          'In element-based mode, add ancestor_keys to scope the search to one subtree when the same key appears in several identical subtrees. '
           'Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Swipe'),
       inputSchema: ToolInputSchema(
@@ -301,7 +313,10 @@ void registerGestureTools(
           'endY': JsonSchema.number(
             description: 'End Y coordinate for coordinate-based swipe.',
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
       ),
       callback: (args, extra) async {
@@ -362,9 +377,9 @@ void registerGestureTools(
           'Use scale > 1.0 to zoom in (fingers move apart) and scale < 1.0 '
           'to zoom out (fingers move together). You can target the element by '
           'key, identifier, text, type, or coordinates. Useful for maps, '
-          'images, PDFs, and other zoomable content. Add within_key to scope '
-          'the search to one subtree when the same key appears in several '
-          'identical subtrees. '
+          'images, PDFs, and other zoomable content. Add ancestor_keys to '
+          'scope the search to one subtree when the same key appears in '
+          'several identical subtrees. '
           'Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Pinch Zoom'),
       inputSchema: ToolInputSchema(
@@ -403,7 +418,10 @@ void registerGestureTools(
             description: 'Initial distance between the two fingers in pixels '
                 '(default: 200).',
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
         required: ['scale'],
       ),
@@ -491,7 +509,7 @@ void registerGestureTools(
     ..registerTool(
       'scroll_to',
       description:
-          'Scrolls the view until an element matching the given criteria becomes visible. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, or by their visible text content. This is useful when you need to interact with elements that are not currently visible on screen. Add within_key to scroll the list inside one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
+          'Scrolls the view until an element matching the given criteria becomes visible. You can match elements by their key (a ValueKey<String>), by their Semantics identifier, or by their visible text content. This is useful when you need to interact with elements that are not currently visible on screen. Add ancestor_keys to scroll the list inside one subtree when the same key appears in several identical subtrees. Requires an active connection established via connect.',
       annotations: const ToolAnnotations(title: 'Scroll to Element'),
       inputSchema: ToolInputSchema(
         properties: {
@@ -509,7 +527,10 @@ void registerGestureTools(
             description:
                 'The visible text content of the element to scroll to.',
           ),
-          'within_key': JsonSchema.string(description: withinKeyDescription),
+          'ancestor_keys': JsonSchema.array(
+            items: JsonSchema.string(),
+            description: ancestorKeysDescription,
+          ),
         },
       ),
       callback: (args, extra) async {

--- a/packages/marionette_mcp/lib/src/vm_service/tools/text_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/text_tools.dart
@@ -13,7 +13,7 @@ void registerTextTools(
   server.registerTool(
     'enter_text',
     description:
-        'Enters text into a text field in the Flutter app. You can target the field in three ways: 1. By key: provide the key parameter with the ValueKey<String> of the field. You can discover available keys by calling get_interactive_elements. 2. By Semantics identifier: provide the identifier parameter with the accessibility identifier of the field. Useful when the field has no ValueKey but does set a Semantics identifier. 3. By focused element: first tap a text field to give it focus, then call enter_text with focused_element set to true. Important: when targeting by focused element, a text field must be focused before calling this (for example by using the tap tool), otherwise it will fail with an error. Exactly one of key, identifier, or focused_element must be provided. Requires an active connection established via connect.',
+        'Enters text into a text field in the Flutter app. You can target the field in three ways: 1. By key: provide the key parameter with the ValueKey<String> of the field. You can discover available keys by calling get_interactive_elements. 2. By Semantics identifier: provide the identifier parameter with the accessibility identifier of the field. Useful when the field has no ValueKey but does set a Semantics identifier. 3. By focused element: first tap a text field to give it focus, then call enter_text with focused_element set to true. Important: when targeting by focused element, a text field must be focused before calling this (for example by using the tap tool), otherwise it will fail with an error. Exactly one of key, identifier, or focused_element must be provided. When targeting by key or identifier, add within_key to scope the search to one subtree if the same key appears in several identical subtrees. Requires an active connection established via connect.',
     annotations: const ToolAnnotations(title: 'Enter Text'),
     inputSchema: ToolInputSchema(
       properties: {
@@ -35,6 +35,7 @@ void registerTextTools(
               'If true, enters text into the currently focused text field. '
               'A text field must be focused first (for example by using tap), otherwise this will fail.',
         ),
+        'within_key': JsonSchema.string(description: withinKeyDescription),
       },
       required: ['input'],
     ),

--- a/packages/marionette_mcp/lib/src/vm_service/tools/text_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/text_tools.dart
@@ -13,7 +13,7 @@ void registerTextTools(
   server.registerTool(
     'enter_text',
     description:
-        'Enters text into a text field in the Flutter app. You can target the field in three ways: 1. By key: provide the key parameter with the ValueKey<String> of the field. You can discover available keys by calling get_interactive_elements. 2. By Semantics identifier: provide the identifier parameter with the accessibility identifier of the field. Useful when the field has no ValueKey but does set a Semantics identifier. 3. By focused element: first tap a text field to give it focus, then call enter_text with focused_element set to true. Important: when targeting by focused element, a text field must be focused before calling this (for example by using the tap tool), otherwise it will fail with an error. Exactly one of key, identifier, or focused_element must be provided. When targeting by key or identifier, add within_key to scope the search to one subtree if the same key appears in several identical subtrees. Requires an active connection established via connect.',
+        'Enters text into a text field in the Flutter app. You can target the field in three ways: 1. By key: provide the key parameter with the ValueKey<String> of the field. You can discover available keys by calling get_interactive_elements. 2. By Semantics identifier: provide the identifier parameter with the accessibility identifier of the field. Useful when the field has no ValueKey but does set a Semantics identifier. 3. By focused element: first tap a text field to give it focus, then call enter_text with focused_element set to true. Important: when targeting by focused element, a text field must be focused before calling this (for example by using the tap tool), otherwise it will fail with an error. Exactly one of key, identifier, or focused_element must be provided. When targeting by key or identifier, add ancestor_keys to scope the search to one subtree if the same key appears in several identical subtrees, outermost wrapper key first. Requires an active connection established via connect.',
     annotations: const ToolAnnotations(title: 'Enter Text'),
     inputSchema: ToolInputSchema(
       properties: {
@@ -35,7 +35,10 @@ void registerTextTools(
               'If true, enters text into the currently focused text field. '
               'A text field must be focused first (for example by using tap), otherwise this will fail.',
         ),
-        'within_key': JsonSchema.string(description: withinKeyDescription),
+        'ancestor_keys': JsonSchema.array(
+          items: JsonSchema.string(),
+          description: ancestorKeysDescription,
+        ),
       },
       required: ['input'],
     ),

--- a/packages/marionette_mcp/test/formatting_test.dart
+++ b/packages/marionette_mcp/test/formatting_test.dart
@@ -19,16 +19,33 @@ void main() {
       );
     });
 
-    test('forwards within_key alongside the selector', () {
+    test('encodes ancestor_keys as JSON for the string-only wire', () {
       expect(
-        buildMatcher({'key': 'join_button', 'within_key': 'grid.cell_2'}),
-        equals({'key': 'join_button', 'within_key': 'grid.cell_2'}),
+        buildMatcher({
+          'key': 'join_button',
+          'ancestor_keys': ['session_2', 'grid.cell_3'],
+        }),
+        equals({
+          'key': 'join_button',
+          'ancestor_keys': '["session_2","grid.cell_3"]',
+        }),
       );
     });
 
-    test('omits within_key when it is absent', () {
+    test('omits ancestor_keys when it is absent', () {
       expect(
-          buildMatcher({'key': 'join_button'}), equals({'key': 'join_button'}));
+        buildMatcher({'key': 'join_button'}),
+        equals({'key': 'join_button'}),
+      );
+    });
+
+    test('omits an empty ancestor_keys array', () {
+      expect(
+        buildMatcher({'key': 'join_button', 'ancestor_keys': <String>[]}),
+        equals({'key': 'join_button'}),
+        reason: 'an empty chain means no scope, so nothing should go on the '
+            'wire and behavior must match omitting the field',
+      );
     });
   });
 
@@ -38,14 +55,20 @@ void main() {
     });
 
     test('a scope alone is not a selector', () {
-      expect(hasSelector(buildMatcher({'within_key': 'grid.cell_2'})), isFalse);
+      expect(
+        hasSelector(buildMatcher({
+          'ancestor_keys': ['grid.cell_2'],
+        })),
+        isFalse,
+      );
     });
 
     test('a scoped key is a selector', () {
       expect(
-        hasSelector(
-          buildMatcher({'key': 'join_button', 'within_key': 'grid.cell_2'}),
-        ),
+        hasSelector(buildMatcher({
+          'key': 'join_button',
+          'ancestor_keys': ['grid.cell_2'],
+        })),
         isTrue,
       );
     });

--- a/packages/marionette_mcp/test/formatting_test.dart
+++ b/packages/marionette_mcp/test/formatting_test.dart
@@ -1,0 +1,53 @@
+import 'package:marionette_mcp/src/formatting.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildMatcher', () {
+    test('forwards key and identifier', () {
+      expect(
+        buildMatcher({'key': 'join_button', 'identifier': 'join'}),
+        equals({'key': 'join_button', 'identifier': 'join'}),
+      );
+    });
+
+    test('flattens coordinates', () {
+      expect(
+        buildMatcher({
+          'coordinates': <String, dynamic>{'x': 10, 'y': 20},
+        }),
+        equals({'x': 10, 'y': 20}),
+      );
+    });
+
+    test('forwards within_key alongside the selector', () {
+      expect(
+        buildMatcher({'key': 'join_button', 'within_key': 'grid.cell_2'}),
+        equals({'key': 'join_button', 'within_key': 'grid.cell_2'}),
+      );
+    });
+
+    test('omits within_key when it is absent', () {
+      expect(
+          buildMatcher({'key': 'join_button'}), equals({'key': 'join_button'}));
+    });
+  });
+
+  group('hasSelector', () {
+    test('empty matcher has no selector', () {
+      expect(hasSelector(buildMatcher({})), isFalse);
+    });
+
+    test('a scope alone is not a selector', () {
+      expect(hasSelector(buildMatcher({'within_key': 'grid.cell_2'})), isFalse);
+    });
+
+    test('a scoped key is a selector', () {
+      expect(
+        hasSelector(
+          buildMatcher({'key': 'join_button', 'within_key': 'grid.cell_2'}),
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Every matcher-based tool searches the whole widget tree from the root and takes the first DFS match, so a key that repeats across identical subtrees always resolves to the first instance — a grid of cards where each cell contains `cell.joinButton`, or a dev screen embedding several instances of the same app UI. The workarounds are tapping by coordinates (breaks on any layout shift) or baking indices into every leaf key (pollutes production keys and fights the usual `feature.screen.element` naming). Closes #100.

This adds an optional `ancestor_keys` — a list of wrapper `ValueKey<String>`s, ordered **outermost first** — that scopes the search to one subtree:

```json
{ "key": "cell.joinButton", "ancestor_keys": ["grid.cell_2"] }
```

Each key is resolved inside the previous one's subtree, which is what lets you reach a wrapper whose *own* key repeats too. In the session-grid case every session embeds the same grid, so `grid.cell_3` alone would still land in the first session:

```json
{ "key": "cell.joinButton", "ancestor_keys": ["session_2", "grid.cell_3"] }
```

The issue proposed a single `within_key`; see the note below on why this ships as a list instead.

If any key in the chain matches no element the call **fails, naming the link that broke and where it was looked for** — `Scope element with key "grid.cell_3" (ancestor_keys[1]) not found inside "session_2"` — rather than falling back to a tree-wide search that would silently act on a different instance. Gestures keep their `isElementHittable` check inside the scope. `coordinates` and `focused_element` bypass tree search, so they ignore the field. Omitting `ancestor_keys` (or passing an empty list) leaves today's behavior unchanged — the change is purely additive.

`get_interactive_elements` is deliberately out of scope, per the issue.

## What changed

**`marionette_flutter`**
- `WidgetMatcher.ancestorsFromJson` parses the chain *alongside* — not inside — the target matcher, so `fromJson`'s precedence chain is untouched and `ancestor_keys` alone is still an invalid matcher.
- `WidgetFinder.resolveScopeRoot` folds the chain into a single subtree root and is the only source of the fail-loud policy and its message. `findElement`/`findHittableElement` gain an optional `ancestors`.
- `GestureDispatcher`, `TextInputSimulator` and `ScrollSimulator` take the chain as **matchers**, not a resolved `Element`, so it is re-resolved on every search. That matters for `scroll_to`, which searches repeatedly while the tree rebuilds under it.
- `ScrollSimulator` also roots its fallback `Scrollable` search inside the scope. Walking *up* to an ancestor `Scrollable` deliberately stays unscoped: that ancestor is exactly what scrolls the scoped target into view.

**`marionette_mcp`**
- `buildMatcher` forwards `ancestor_keys`; new `hasSelector` replaces the `matcher.isEmpty` guard in `pinch_zoom`, because a scope on its own selects no element.
- `ancestor_keys` added to the input schema of `tap`, `secondary_tap`, `double_tap`, `long_press`, `swipe`, `pinch_zoom`, `scroll_to`, `enter_text`, mentioned in each tool `description`, and in the server instructions so agents discover it.

**`marionette_cli`** — `--ancestor-key` on the same eight commands, repeatable (`--ancestor-key session_2 --ancestor-key grid.cell_3`), plus `hasSelector` in place of the `isEmpty` guards.

**Docs** — `docs/mcp-tools.md`, `docs/cli.md`, and the CLI `help-ai` reference.

Both packages change together because they verify an exact version match during the connect handshake. No CHANGELOG entry or version bump, matching #89/#90/#97.

### Wire format

Extension params are a flat `string → string` map, so the list travels JSON-encoded. That is the convention `coerceToStringMap` already documents for nested values (a list's `toString()` is un-parseable), and unlike a delimiter it cannot collide with characters inside a key. The CLI needs no encoding at all — the option is simply repeatable.

## Tests

Written test-first. `widget_finder_scope_test.dart` is new; the gesture, text-input and scroll suites gained scoped cases; `formatting_test.dart` is new on the MCP side. Coverage:

- two subtrees with identical inner keys — the scope hits the second instance, the one a global search would *not* reach first;
- **a nested chain reaches a cell no single key can name** — two sessions each containing `grid.cell_1`/`grid.cell_2`, where `["session_2", "grid.cell_2"]` must land in the second session;
- a broken chain errors naming the failing key, its index, and its parent;
- target missing inside the scope while an identical one exists outside → null/throw, never a silent fallback;
- hittability still enforced inside the scope (an `IgnorePointer`ed cell throws even though a hittable twin exists elsewhere);
- coordinate taps ignore an unresolvable scope;
- `scroll_to` scrolls the list inside the scope and leaves the other one at offset 0;
- `ancestor_keys` round-trips through the JSON wire encoding, an empty list is omitted, and a malformed payload is rejected;
- no `ancestor_keys` → all pre-existing tests unchanged and passing.

```
packages/marionette_flutter  flutter test   166 passed
packages/marionette_mcp      dart test      158 passed
packages/marionette_cli      dart test       94 passed
dart analyze --fatal-infos + dart format    clean across all packages
```
