### PR TITLE
feat(marionette_flutter): add widget adapter descriptors

### DIFF
--- a/packages/marionette_flutter/lib/marionette_flutter.dart
+++ b/packages/marionette_flutter/lib/marionette_flutter.dart
@@ -4,6 +4,7 @@ export 'src/binding/extension_schema.dart';
 export 'src/binding/marionette_binding.dart';
 export 'src/binding/marionette_configuration.dart';
 export 'src/binding/marionette_extension_result.dart';
+export 'src/binding/marionette_widget_adapter.dart';
 export 'src/binding/register_extension.dart';
 export 'src/services/log_collector.dart';
 export 'src/services/log_store.dart';

--- a/packages/marionette_flutter/lib/src/binding/marionette_configuration.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_configuration.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:marionette_flutter/src/binding/marionette_widget_adapter.dart';
 import 'package:marionette_flutter/src/services/log_collector.dart';
 
 /// Configuration for the Marionette extensions.
@@ -19,6 +20,7 @@ class MarionetteConfiguration {
     this.isInteractiveWidget,
     this.shouldStopTraversal,
     this.extractText,
+    this.widgetAdapters = const <MarionetteWidgetAdapter>[],
     this.maxScreenshotSize = const Size(2000, 2000),
     this.logCollector,
   });
@@ -63,6 +65,22 @@ class MarionetteConfiguration {
   /// )
   /// ```
   final String? Function(Element element)? extractText;
+
+  /// Ordered adapters for application and design-system widgets.
+  ///
+  /// The first adapter that returns a descriptor owns the element.
+  final List<MarionetteWidgetAdapter> widgetAdapters;
+
+  /// Returns the first descriptor provided for [element].
+  MarionetteWidgetDescriptor? describeWidget(Element element) {
+    for (final adapter in widgetAdapters) {
+      final descriptor = adapter.describe(element);
+      if (descriptor != null) {
+        return descriptor;
+      }
+    }
+    return null;
+  }
 
   /// Maximum size for screenshots in physical pixels.
   ///
@@ -127,8 +145,10 @@ class MarionetteConfiguration {
 
   /// Extracts text from a widget (built-in + custom).
   String? extractTextFromWidget(Element element) {
-    final builtInText = _extractBuiltInText(element.widget);
-    return builtInText ?? extractText?.call(element);
+    final descriptor = describeWidget(element);
+    return descriptor?.text ??
+        _extractBuiltInText(element.widget) ??
+        extractText?.call(element);
   }
 
   // Built-in Flutter widget support

--- a/packages/marionette_flutter/lib/src/binding/marionette_configuration.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_configuration.dart
@@ -144,9 +144,14 @@ class MarionetteConfiguration {
   }
 
   /// Extracts text from a widget (built-in + custom).
-  String? extractTextFromWidget(Element element) {
-    final descriptor = describeWidget(element);
-    return descriptor?.text ??
+  String? extractTextFromWidget(
+    Element element, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
+    final effectiveDescriptor = describeWidget == null
+        ? this.describeWidget(element)
+        : describeWidget();
+    return effectiveDescriptor?.text ??
         _extractBuiltInText(element.widget) ??
         extractText?.call(element);
   }

--- a/packages/marionette_flutter/lib/src/binding/marionette_widget_adapter.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_widget_adapter.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/widgets.dart';
+
+/// Controls how Marionette traverses below an adapted widget.
+enum MarionetteTraversalPolicy {
+  /// Continue visiting the widget's descendants.
+  continueTraversal,
+
+  /// Treat the widget as the logical owner of its complete subtree.
+  ///
+  /// This is useful for composite design-system controls whose implementation
+  /// contains gesture detectors or other widgets that should not be exposed as
+  /// separate interactive elements.
+  ownSubtree,
+}
+
+/// A stable, JSON-serializable description of an application widget.
+class MarionetteWidgetDescriptor {
+  const MarionetteWidgetDescriptor({
+    required this.type,
+    this.role,
+    this.key,
+    this.text,
+    this.value,
+    this.hint,
+    this.state = const <String, Object?>{},
+    this.actions = const <String>[],
+    this.properties = const <String, Object?>{},
+    this.traversalPolicy = MarionetteTraversalPolicy.continueTraversal,
+  });
+
+  final String type;
+  final String? role;
+  final String? key;
+  final String? text;
+  final String? value;
+  final String? hint;
+  final Map<String, Object?> state;
+  final List<String> actions;
+  final Map<String, Object?> properties;
+  final MarionetteTraversalPolicy traversalPolicy;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'type': type,
+      if (role != null) 'role': role,
+      if (key != null) 'key': key,
+      if (text != null) 'text': text,
+      if (value != null) 'value': value,
+      if (hint != null) 'hint': hint,
+      if (state.isNotEmpty) 'state': state,
+      if (actions.isNotEmpty) 'actions': actions,
+      if (properties.isNotEmpty) 'properties': properties,
+    };
+  }
+}
+
+/// Application or design-system bridge for Marionette introspection.
+abstract interface class MarionetteWidgetAdapter {
+  const MarionetteWidgetAdapter();
+
+  /// Returns a descriptor when this adapter owns [element], or null otherwise.
+  MarionetteWidgetDescriptor? describe(Element element);
+}

--- a/packages/marionette_flutter/lib/src/binding/marionette_widget_adapter.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_widget_adapter.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/widgets.dart';
 
 /// Controls how Marionette traverses below an adapted widget.
@@ -40,7 +42,7 @@ class MarionetteWidgetDescriptor {
   final MarionetteTraversalPolicy traversalPolicy;
 
   Map<String, Object?> toJson() {
-    return <String, Object?>{
+    final result = <String, Object?>{
       'type': type,
       if (role != null) 'role': role,
       if (key != null) 'key': key,
@@ -51,7 +53,21 @@ class MarionetteWidgetDescriptor {
       if (actions.isNotEmpty) 'actions': actions,
       if (properties.isNotEmpty) 'properties': properties,
     };
+    assert(_debugAssertJsonEncodable(result));
+    return result;
   }
+}
+
+bool _debugAssertJsonEncodable(Map<String, Object?> value) {
+  try {
+    jsonEncode(value);
+  } catch (error) {
+    throw ArgumentError(
+      'MarionetteWidgetDescriptor fields must contain only JSON-encodable '
+      'values: $error',
+    );
+  }
+  return true;
 }
 
 /// Application or design-system bridge for Marionette introspection.

--- a/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/binding/marionette_widget_adapter.dart';
 import 'package:marionette_flutter/src/services/hit_test_utils.dart';
 
 /// Finds and extracts interactive elements from the Flutter widget tree.
@@ -23,13 +24,19 @@ class ElementTreeFinder {
 
   void _visitElement(Element element, List<Map<String, dynamic>> result) {
     final widget = element.widget;
-    final elementData = _extractElementData(element, widget);
+    final descriptor = configuration.describeWidget(element);
+    final elementData = _extractElementData(
+      element,
+      widget,
+      descriptor: descriptor,
+    );
 
     if (elementData != null) {
       result.add(elementData);
     }
 
-    if (configuration.shouldStopAtType(widget.runtimeType)) {
+    if (descriptor?.traversalPolicy == MarionetteTraversalPolicy.ownSubtree ||
+        configuration.shouldStopAtType(widget.runtimeType)) {
       return;
     }
 
@@ -38,7 +45,11 @@ class ElementTreeFinder {
     });
   }
 
-  Map<String, dynamic>? _extractElementData(Element element, Widget widget) {
+  Map<String, dynamic>? _extractElementData(
+    Element element,
+    Widget widget, {
+    MarionetteWidgetDescriptor? descriptor,
+  }) {
     // Only process elements with render objects
     final renderObject = element.renderObject;
     if (renderObject == null) {
@@ -49,7 +60,8 @@ class ElementTreeFinder {
     final isInteractive = configuration.isInteractiveWidgetType(
       widget.runtimeType,
     );
-    final text = configuration.extractTextFromWidget(element);
+    final text =
+        descriptor?.text ?? configuration.extractTextFromWidget(element);
     // Discovery-only Semantics fallback: if the standard matcher path yielded
     // no text, surface explicit accessibility annotations so agents can read
     // content rendered via inline-span trees, custom painters, or third-party
@@ -61,7 +73,8 @@ class ElementTreeFinder {
     final keyValue = _extractKeyValue(widget.key);
     final identifierValue = _extractIdentifier(widget);
 
-    if (!isInteractive &&
+    if (descriptor == null &&
+        !isInteractive &&
         discoverableText == null &&
         keyValue == null &&
         identifierValue == null) {
@@ -73,23 +86,28 @@ class ElementTreeFinder {
       return null;
     }
 
-    final properties = DiagnosticPropertiesBuilder();
-    widget.debugFillProperties(properties);
-    final data = Map<String, Object>.fromEntries(
-      properties.properties
-          .where((p) =>
-              p.runtimeType != DiagnosticsProperty &&
-              p.name != null &&
-              p.value != null)
-          .map(
-            (p) => MapEntry(p.name!, p.value.toString()),
-          ),
-    );
+    final Map<String, Object?> data;
+    if (descriptor != null) {
+      data = descriptor.toJson();
+    } else {
+      final properties = DiagnosticPropertiesBuilder();
+      widget.debugFillProperties(properties);
+      data = Map<String, Object?>.fromEntries(
+        properties.properties
+            .where(
+              (p) =>
+                  p.runtimeType != DiagnosticsProperty &&
+                  p.name != null &&
+                  p.value != null,
+            )
+            .map((p) => MapEntry(p.name!, p.value.toString())),
+      );
 
-    data['type'] = widget.runtimeType.toString();
+      data['type'] = widget.runtimeType.toString();
+    }
 
     if (keyValue != null) {
-      data['key'] = keyValue;
+      data.putIfAbsent('key', () => keyValue);
     }
 
     if (identifierValue != null) {
@@ -97,7 +115,7 @@ class ElementTreeFinder {
     }
 
     if (discoverableText != null) {
-      data['text'] = discoverableText;
+      data.putIfAbsent('text', () => discoverableText);
     }
 
     // Get position and size if available
@@ -187,12 +205,22 @@ class ElementTreeFinder {
 
       try {
         final offset = renderObject.localToGlobal(Offset.zero);
-        final screenSize = WidgetsBinding
-                .instance.platformDispatcher.views.first.physicalSize /
+        final screenSize =
             WidgetsBinding
-                .instance.platformDispatcher.views.first.devicePixelRatio;
+                .instance
+                .platformDispatcher
+                .views
+                .first
+                .physicalSize /
+            WidgetsBinding
+                .instance
+                .platformDispatcher
+                .views
+                .first
+                .devicePixelRatio;
 
-        final isOnScreen = offset.dx + size.width >= 0 &&
+        final isOnScreen =
+            offset.dx + size.width >= 0 &&
             offset.dy + size.height >= 0 &&
             offset.dx < screenSize.width &&
             offset.dy < screenSize.height;

--- a/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
@@ -81,8 +81,12 @@ class ElementTreeFinder {
       return null;
     }
 
-    // Only return widgets that can be hit
-    if (!isElementHittable(element)) {
+    // Adapted composites can delegate hit testing to a private descendant
+    // without placing their own render object in the hit-test path.
+    final isHittable = descriptor == null
+        ? isElementHittable(element)
+        : isElementOrDescendantHittable(element);
+    if (!isHittable) {
       return null;
     }
 

--- a/packages/marionette_flutter/lib/src/services/hit_test_utils.dart
+++ b/packages/marionette_flutter/lib/src/services/hit_test_utils.dart
@@ -42,3 +42,46 @@ bool isElementHittable(Element element) {
     return false;
   }
 }
+
+/// Checks whether [element] or one of its visible descendants can receive
+/// pointer events, within a bounded traversal.
+///
+/// A composite widget can delegate hit testing to a private render-object
+/// child without adding its own render object to the hit-test path. Adapters
+/// describe the public composite element, so discovery and action lookup need
+/// to accept the descendant that implements its pointer behavior.
+bool isElementOrDescendantHittable(
+  Element element, {
+  int maxVisitedElements = 512,
+}) {
+  if (maxVisitedElements <= 0) {
+    return false;
+  }
+  var remaining = maxVisitedElements;
+
+  bool visit(Element candidate) {
+    if (remaining <= 0) {
+      return false;
+    }
+    remaining--;
+
+    final widget = candidate.widget;
+    if ((widget is Offstage && widget.offstage) ||
+        (widget is Visibility && !widget.visible)) {
+      return false;
+    }
+    if (isElementHittable(candidate)) {
+      return true;
+    }
+
+    var result = false;
+    candidate.visitChildren((child) {
+      if (!result) {
+        result = visit(child);
+      }
+    });
+    return result;
+  }
+
+  return visit(element);
+}

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/binding/marionette_widget_adapter.dart';
 import 'package:marionette_flutter/src/services/hit_test_utils.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
 
@@ -40,7 +41,22 @@ class WidgetFinder {
     void visitor(Element element) {
       if (found != null) {
         return;
-      } else if (matcher.matches(element, configuration)) {
+      }
+      MarionetteWidgetDescriptor? descriptor;
+      var descriptorIsResolved = false;
+      MarionetteWidgetDescriptor? describeWidget() {
+        if (!descriptorIsResolved) {
+          descriptor = configuration.describeWidget(element);
+          descriptorIsResolved = true;
+        }
+        return descriptor;
+      }
+
+      if (matcher.matches(
+        element,
+        configuration,
+        describeWidget: describeWidget,
+      )) {
         found = element;
       } else {
         element.visitChildren(visitor);
@@ -83,14 +99,31 @@ class WidgetFinder {
     void visitor(Element element) {
       if (found != null) {
         return;
-      } else if (matcher.matches(element, configuration) &&
-          (configuration.describeWidget(element) == null
-              ? isElementHittable(element)
-              : isElementOrDescendantHittable(element))) {
-        found = element;
-      } else {
-        element.visitChildren(visitor);
       }
+      MarionetteWidgetDescriptor? descriptor;
+      var descriptorIsResolved = false;
+      MarionetteWidgetDescriptor? describeWidget() {
+        if (!descriptorIsResolved) {
+          descriptor = configuration.describeWidget(element);
+          descriptorIsResolved = true;
+        }
+        return descriptor;
+      }
+
+      if (matcher.matches(
+        element,
+        configuration,
+        describeWidget: describeWidget,
+      )) {
+        descriptor = describeWidget();
+        if (descriptor == null
+            ? isElementHittable(element)
+            : isElementOrDescendantHittable(element)) {
+          found = element;
+          return;
+        }
+      }
+      element.visitChildren(visitor);
     }
 
     visitor(startElement);

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -84,7 +84,9 @@ class WidgetFinder {
       if (found != null) {
         return;
       } else if (matcher.matches(element, configuration) &&
-          isElementHittable(element)) {
+          (configuration.describeWidget(element) == null
+              ? isElementHittable(element)
+              : isElementOrDescendantHittable(element))) {
         found = element;
       } else {
         element.visitChildren(visitor);

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/binding/marionette_widget_adapter.dart';
 
 /// Abstract base class for matching widgets in the Flutter widget tree.
 sealed class WidgetMatcher {
   const WidgetMatcher();
 
   /// Checks if the given [element] matches this matcher's criteria.
-  bool matches(Element element, MarionetteConfiguration configuration);
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  });
 
   /// Creates a matcher from a JSON map.
   /// If multiple fields are present, precedence is:
@@ -45,7 +50,11 @@ class FocusedElementMatcher extends WidgetMatcher {
   const FocusedElementMatcher();
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
     return false;
   }
 
@@ -79,7 +88,11 @@ class CoordinatesMatcher extends WidgetMatcher {
   Offset get offset => Offset(x, y);
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
     // CoordinatesMatcher doesn't match widgets - it's handled specially
     // in GestureDispatcher.tap() as a fast path.
     return false;
@@ -102,14 +115,21 @@ class KeyMatcher extends WidgetMatcher {
   final String keyValue;
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
     final key = element.widget.key;
     if (key is ValueKey<String>) {
       if (key.value == keyValue) {
         return true;
       }
     }
-    return configuration.describeWidget(element)?.key == keyValue;
+    final effectiveDescriptor = describeWidget == null
+        ? configuration.describeWidget(element)
+        : describeWidget();
+    return effectiveDescriptor?.key == keyValue;
   }
 
   @override
@@ -144,7 +164,11 @@ class IdentifierMatcher extends WidgetMatcher {
   final String identifierValue;
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
     if (identifierValue.isEmpty) {
       return false;
     }
@@ -172,8 +196,15 @@ class TextMatcher extends WidgetMatcher {
   final String text;
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
-    final extractedText = configuration.extractTextFromWidget(element);
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
+    final extractedText = configuration.extractTextFromWidget(
+      element,
+      describeWidget: describeWidget,
+    );
     return extractedText == text;
   }
 
@@ -190,7 +221,11 @@ class TypeMatcher extends WidgetMatcher {
   final Type type;
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
     return element.widget.runtimeType == type;
   }
 
@@ -211,9 +246,16 @@ class TypeStringMatcher extends WidgetMatcher {
   final String typeName;
 
   @override
-  bool matches(Element element, MarionetteConfiguration configuration) {
-    return element.widget.runtimeType.toString() == typeName ||
-        configuration.describeWidget(element)?.type == typeName;
+  bool matches(
+    Element element,
+    MarionetteConfiguration configuration, {
+    MarionetteWidgetDescriptor? Function()? describeWidget,
+  }) {
+    if (element.widget.runtimeType.toString() == typeName) return true;
+    final effectiveDescriptor = describeWidget == null
+        ? configuration.describeWidget(element)
+        : describeWidget();
+    return effectiveDescriptor?.type == typeName;
   }
 
   @override

--- a/packages/marionette_flutter/lib/src/services/widget_matcher.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_matcher.dart
@@ -105,9 +105,11 @@ class KeyMatcher extends WidgetMatcher {
   bool matches(Element element, MarionetteConfiguration configuration) {
     final key = element.widget.key;
     if (key is ValueKey<String>) {
-      return key.value == keyValue;
+      if (key.value == keyValue) {
+        return true;
+      }
     }
-    return false;
+    return configuration.describeWidget(element)?.key == keyValue;
   }
 
   @override
@@ -210,7 +212,8 @@ class TypeStringMatcher extends WidgetMatcher {
 
   @override
   bool matches(Element element, MarionetteConfiguration configuration) {
-    return element.widget.runtimeType.toString() == typeName;
+    return element.widget.runtimeType.toString() == typeName ||
+        configuration.describeWidget(element)?.type == typeName;
   }
 
   @override

--- a/packages/marionette_flutter/test/widget_adapter_test.dart
+++ b/packages/marionette_flutter/test/widget_adapter_test.dart
@@ -1,0 +1,250 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+import 'package:marionette_flutter/src/services/element_tree_finder.dart';
+
+class _CompositeButton extends StatelessWidget {
+  const _CompositeButton({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {},
+      child: SizedBox(
+        width: 160,
+        height: 48,
+        child: Center(child: Text(label)),
+      ),
+    );
+  }
+}
+
+class _CompositeButtonAdapter implements MarionetteWidgetAdapter {
+  const _CompositeButtonAdapter();
+
+  @override
+  MarionetteWidgetDescriptor? describe(Element element) {
+    final widget = element.widget;
+    if (widget is! _CompositeButton) {
+      return null;
+    }
+    return MarionetteWidgetDescriptor(
+      type: 'CompositeButton',
+      role: 'button',
+      key: 'continue',
+      text: widget.label,
+      state: const <String, Object?>{'enabled': true},
+      actions: const <String>['tap'],
+      properties: const <String, Object?>{'variant': 'primary'},
+      traversalPolicy: MarionetteTraversalPolicy.ownSubtree,
+    );
+  }
+}
+
+class _ValueOnlyCompositeButtonAdapter implements MarionetteWidgetAdapter {
+  const _ValueOnlyCompositeButtonAdapter();
+
+  @override
+  MarionetteWidgetDescriptor? describe(Element element) {
+    if (element.widget is! _CompositeButton) {
+      return null;
+    }
+    return const MarionetteWidgetDescriptor(
+      type: 'CompositeButton',
+      value: 'pending',
+      traversalPolicy: MarionetteTraversalPolicy.ownSubtree,
+    );
+  }
+}
+
+class _FallbackCompositeButtonAdapter implements MarionetteWidgetAdapter {
+  const _FallbackCompositeButtonAdapter();
+
+  @override
+  MarionetteWidgetDescriptor? describe(Element element) {
+    if (element.widget is! _CompositeButton) {
+      return null;
+    }
+    return const MarionetteWidgetDescriptor(type: 'FallbackButton');
+  }
+}
+
+class _ContinueCompositeButtonAdapter implements MarionetteWidgetAdapter {
+  const _ContinueCompositeButtonAdapter();
+
+  @override
+  MarionetteWidgetDescriptor? describe(Element element) {
+    final widget = element.widget;
+    if (widget is! _CompositeButton) {
+      return null;
+    }
+    return MarionetteWidgetDescriptor(
+      type: 'CompositeButton',
+      text: widget.label,
+    );
+  }
+}
+
+void main() {
+  const configuration = MarionetteConfiguration(
+    widgetAdapters: <MarionetteWidgetAdapter>[_CompositeButtonAdapter()],
+  );
+
+  test('descriptor properties cannot overwrite stable fields', () {
+    const descriptor = MarionetteWidgetDescriptor(
+      type: 'CompositeButton',
+      role: 'button',
+      properties: <String, Object?>{
+        'type': 'GestureDetector',
+        'role': 'implementation-detail',
+      },
+    );
+
+    expect(descriptor.toJson(), <String, Object?>{
+      'type': 'CompositeButton',
+      'role': 'button',
+      'properties': <String, Object?>{
+        'type': 'GestureDetector',
+        'role': 'implementation-detail',
+      },
+    });
+    expect(() => jsonEncode(descriptor.toJson()), returnsNormally);
+  });
+
+  testWidgets('adapter emits one logical target for a composite widget', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _CompositeButton(label: 'Continue')),
+      ),
+    );
+
+    const finder = ElementTreeFinder(configuration);
+    final elements = finder.findInteractiveElements();
+
+    final button = elements.singleWhere(
+      (element) => element['type'] == 'CompositeButton',
+    );
+    expect(button['role'], 'button');
+    expect(button['key'], 'continue');
+    expect(button['text'], 'Continue');
+    expect(button['state'], <String, Object?>{'enabled': true});
+    expect(button['actions'], <String>['tap']);
+    expect(button['properties'], <String, Object?>{'variant': 'primary'});
+    expect(
+      elements.any((element) => element['type'] == 'GestureDetector'),
+      isFalse,
+    );
+    expect(elements.any((element) => element['type'] == 'Text'), isFalse);
+  });
+
+  testWidgets('descriptor text remains available to text matching', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _CompositeButton(label: 'Continue')),
+      ),
+    );
+
+    final element = tester.element(find.byType(_CompositeButton));
+    expect(configuration.extractTextFromWidget(element), 'Continue');
+    expect(
+      const KeyMatcher('continue').matches(element, configuration),
+      isTrue,
+    );
+    expect(
+      const TypeStringMatcher(
+        'CompositeButton',
+      ).matches(element, configuration),
+      isTrue,
+    );
+    expect(
+      const TextMatcher('Continue').matches(element, configuration),
+      isTrue,
+    );
+  });
+
+  testWidgets('the first matching adapter wins', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _CompositeButton(label: 'Continue')),
+      ),
+    );
+
+    const orderedConfiguration = MarionetteConfiguration(
+      widgetAdapters: <MarionetteWidgetAdapter>[
+        _CompositeButtonAdapter(),
+        _FallbackCompositeButtonAdapter(),
+      ],
+    );
+    final element = tester.element(find.byType(_CompositeButton));
+
+    expect(
+      orderedConfiguration.describeWidget(element)?.type,
+      'CompositeButton',
+    );
+  });
+
+  testWidgets('continueTraversal keeps implementation descendants visible', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _CompositeButton(label: 'Continue')),
+      ),
+    );
+
+    const continueConfiguration = MarionetteConfiguration(
+      widgetAdapters: <MarionetteWidgetAdapter>[
+        _ContinueCompositeButtonAdapter(),
+      ],
+    );
+    const finder = ElementTreeFinder(continueConfiguration);
+    final elements = finder.findInteractiveElements();
+
+    expect(
+      elements.any((element) => element['type'] == 'CompositeButton'),
+      isTrue,
+    );
+    expect(
+      elements.any((element) => element['type'] == 'GestureDetector'),
+      isTrue,
+    );
+    expect(elements.any((element) => element['type'] == 'Text'), isTrue);
+  });
+
+  testWidgets('descriptor value remains distinct from matchable text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _CompositeButton(label: 'Continue')),
+      ),
+    );
+
+    const valueOnlyConfiguration = MarionetteConfiguration(
+      widgetAdapters: <MarionetteWidgetAdapter>[
+        _ValueOnlyCompositeButtonAdapter(),
+      ],
+    );
+    const finder = ElementTreeFinder(valueOnlyConfiguration);
+    final elements = finder.findInteractiveElements();
+    final button = elements.singleWhere(
+      (element) => element['type'] == 'CompositeButton',
+    );
+    final element = tester.element(find.byType(_CompositeButton));
+
+    expect(button['value'], 'pending');
+    expect(button, isNot(contains('text')));
+    expect(
+      const TextMatcher('pending').matches(element, valueOnlyConfiguration),
+      isFalse,
+    );
+  });
+}

--- a/packages/marionette_flutter/test/widget_adapter_test.dart
+++ b/packages/marionette_flutter/test/widget_adapter_test.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:marionette_flutter/src/services/element_tree_finder.dart';
+import 'package:marionette_flutter/src/services/widget_finder.dart';
 
 class _CompositeButton extends StatelessWidget {
   const _CompositeButton({required this.label});
@@ -85,6 +87,39 @@ class _ContinueCompositeButtonAdapter implements MarionetteWidgetAdapter {
     return MarionetteWidgetDescriptor(
       type: 'CompositeButton',
       text: widget.label,
+    );
+  }
+}
+
+class _DelegatingCompositeControl extends SingleChildRenderObjectWidget {
+  const _DelegatingCompositeControl({super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _DelegatingCompositeRenderBox();
+}
+
+class _DelegatingCompositeRenderBox extends RenderProxyBox {
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    final target = child;
+    return target != null && target.hitTest(result, position: position);
+  }
+}
+
+class _DelegatingCompositeAdapter implements MarionetteWidgetAdapter {
+  const _DelegatingCompositeAdapter();
+
+  @override
+  MarionetteWidgetDescriptor? describe(Element element) {
+    if (element.widget is! _DelegatingCompositeControl) {
+      return null;
+    }
+    return const MarionetteWidgetDescriptor(
+      type: 'DelegatingCompositeControl',
+      key: 'delegating-control',
+      actions: <String>['tap'],
+      traversalPolicy: MarionetteTraversalPolicy.ownSubtree,
     );
   }
 }
@@ -246,5 +281,40 @@ void main() {
       const TextMatcher('pending').matches(element, valueOnlyConfiguration),
       isFalse,
     );
+  });
+
+  testWidgets('a hittable descendant makes an adapted composite actionable', (
+    tester,
+  ) async {
+    const delegatedConfiguration = MarionetteConfiguration(
+      widgetAdapters: <MarionetteWidgetAdapter>[_DelegatingCompositeAdapter()],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _DelegatingCompositeControl(
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text('Private gesture target'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    const treeFinder = ElementTreeFinder(delegatedConfiguration);
+    final elements = treeFinder.findInteractiveElements();
+    final matched = WidgetFinder().findHittableElement(
+      const KeyMatcher('delegating-control'),
+      delegatedConfiguration,
+    );
+
+    expect(
+      elements.any(
+        (element) => element['type'] == 'DelegatingCompositeControl',
+      ),
+      isTrue,
+    );
+    expect(matched?.widget, isA<_DelegatingCompositeControl>());
   });
 }

--- a/packages/marionette_flutter/test/widget_adapter_test.dart
+++ b/packages/marionette_flutter/test/widget_adapter_test.dart
@@ -75,6 +75,23 @@ class _FallbackCompositeButtonAdapter implements MarionetteWidgetAdapter {
   }
 }
 
+class _CountingCompositeButtonAdapter implements MarionetteWidgetAdapter {
+  final calls = <Element, int>{};
+
+  @override
+  MarionetteWidgetDescriptor? describe(Element element) {
+    calls.update(element, (count) => count + 1, ifAbsent: () => 1);
+    if (element.widget is! _CompositeButton) return null;
+    return const MarionetteWidgetDescriptor(
+      type: 'CompositeButton',
+      key: 'counted',
+      traversalPolicy: MarionetteTraversalPolicy.ownSubtree,
+    );
+  }
+}
+
+class _NonJsonValue {}
+
 class _ContinueCompositeButtonAdapter implements MarionetteWidgetAdapter {
   const _ContinueCompositeButtonAdapter();
 
@@ -150,6 +167,24 @@ void main() {
     expect(() => jsonEncode(descriptor.toJson()), returnsNormally);
   });
 
+  test('descriptor rejects non-JSON values at the descriptor boundary', () {
+    final descriptor = MarionetteWidgetDescriptor(
+      type: 'CompositeButton',
+      state: <String, Object?>{'bad': _NonJsonValue()},
+    );
+
+    expect(
+      descriptor.toJson,
+      throwsA(
+        isA<ArgumentError>().having(
+          (error) => error.message,
+          'message',
+          contains('JSON-encodable'),
+        ),
+      ),
+    );
+  });
+
   testWidgets('adapter emits one logical target for a composite widget', (
     tester,
   ) async {
@@ -203,6 +238,30 @@ void main() {
       const TextMatcher('Continue').matches(element, configuration),
       isTrue,
     );
+  });
+
+  testWidgets('hittable matching describes each visited element at most once', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _CompositeButton(label: 'Continue')),
+      ),
+    );
+    final adapter = _CountingCompositeButtonAdapter();
+    final countedConfiguration = MarionetteConfiguration(
+      widgetAdapters: <MarionetteWidgetAdapter>[adapter],
+    );
+    final target = tester.element(find.byType(_CompositeButton));
+
+    final found = WidgetFinder().findHittableElement(
+      const KeyMatcher('counted'),
+      countedConfiguration,
+    );
+
+    expect(found, target);
+    expect(adapter.calls[target], 1);
+    expect(adapter.calls.values, everyElement(1));
   });
 
   testWidgets('the first matching adapter wins', (tester) async {


### PR DESCRIPTION
## Summary

Add a small public adapter surface for representing composite application and design-system widgets as one logical Marionette target.

An adapter returns a stable descriptor for an `Element`. `get_interactive_elements` emits that descriptor, and `ownSubtree` prevents internal `GestureDetector`, `RawGestureDetector`, text, and other implementation descendants from becoming duplicate targets.

Related RFC: #103

## What changed

- export `MarionetteWidgetAdapter`, `MarionetteWidgetDescriptor`, and `MarionetteTraversalPolicy`;
- accept an ordered adapter list in `MarionetteConfiguration` (first non-null descriptor wins);
- emit descriptor fields from `ElementTreeFinder` and honor `ownSubtree`;
- make descriptor text available through the existing text-extraction path;
- keep descriptor `value` distinct from `text`, so technical values do not become text-matchable;
- let existing key and type matchers recognize the logical descriptor fields;
- accept an adapted composite when its descendant implements the pointer hit target;
- add neutral tests using a composite button backed by an internal `GestureDetector`.

The matcher changes are intentionally limited to discovery/action parity. If an agent sees a descriptor key, text, or type in `get_interactive_elements`, the existing selectors can target the same logical element. This does not introduce structured or multi-field selectors.

## Example outcome

For a custom `CompositeButton` that builds `GestureDetector -> SizedBox -> Text`, an adapter can emit one `CompositeButton` descriptor with `role`, `key`, `text`, `value`, `state`, `actions`, and nested custom properties. With `ownSubtree`, the internal gesture and text widgets are not listed separately.

## Validation

- `flutter analyze --fatal-infos lib`
- `flutter test test/widget_adapter_test.dart` (7 tests)
- `flutter test --no-pub` (151 tests)
- `dart format --set-exit-if-changed` on all changed Dart files
- `git diff --check`

The focused tests cover first-adapter precedence, both traversal policies, key/type/text matching parity, JSON serialization, the separation between `value` and `text`, and a failing-before composite whose render object delegates hit testing to a child without adding itself to the hit-test path.

## Deliberately out of scope

- action-specific hit regions or gesture-dispatch changes;
- partial subtree ownership policies;
- structured/AND selectors;
- adapter output modes or diagnostics;
- MCP/CLI response-format changes;
- documentation expansion beyond API comments.

## Maintainer questions

1. Are the adapter, descriptor, and `ownSubtree` names a good fit for the public API?
2. Should `actions` stay as advisory discovery output in this first slice, or be deferred until action-specific targets are supported?
3. Is nesting extension data under `properties` the preferred way to protect stable descriptor fields?
