### PR TITLE
fix(marionette_mcp): preserve VM extension error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix extension errors being reported as the generic `Server error` instead of the detail the extension returned — this silently swallowed every validation message and setup instruction, including the `get_logs` log-collector onboarding help
+
 # 0.6.0
 
 - Promote schema-bearing custom extensions to first-class MCP tools via the new `ExtensionInputSchema`/`ExtensionParam` DSL

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -22,6 +22,19 @@ class VmServiceExtensionException implements Exception {
     this.stackTrace,
   });
 
+  /// Creates an exception that preserves the application-side VM extension
+  /// details when they are available.
+  factory VmServiceExtensionException.fromRpcError(
+    String extensionName,
+    RPCError rpcError,
+  ) {
+    return VmServiceExtensionException(
+      'Extension $extensionName failed',
+      errorCode: rpcError.code,
+      error: rpcError.details ?? rpcError.message,
+    );
+  }
+
   final String message;
   final int? errorCode;
   final String? error;
@@ -211,11 +224,7 @@ class VmServiceConnector {
       return responseJson;
     } on RPCError catch (e) {
       _logger.severe('Error calling extension $extensionName', e);
-      throw VmServiceExtensionException(
-        'Extension $extensionName failed',
-        errorCode: e.code,
-        error: e.message,
-      );
+      throw VmServiceExtensionException.fromRpcError(extensionName, e);
     } catch (err) {
       _logger.severe('Error calling extension $extensionName', err);
       rethrow;

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -28,10 +28,11 @@ class VmServiceExtensionException implements Exception {
     String extensionName,
     RPCError rpcError,
   ) {
+    final details = rpcError.data?['details'];
     return VmServiceExtensionException(
       'Extension $extensionName failed',
       errorCode: rpcError.code,
-      error: rpcError.details ?? rpcError.message,
+      error: details?.toString() ?? rpcError.message,
     );
   }
 
@@ -222,8 +223,8 @@ class VmServiceConnector {
       _logger.finest('Extension response: $responseJson');
 
       return responseJson;
-    } on RPCError catch (e) {
-      _logger.severe('Error calling extension $extensionName', e);
+    } on RPCError catch (e, stackTrace) {
+      _logger.severe('Error calling extension $extensionName', e, stackTrace);
       throw VmServiceExtensionException.fromRpcError(extensionName, e);
     } catch (err) {
       _logger.severe('Error calling extension $extensionName', err);

--- a/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
+++ b/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
@@ -29,6 +29,24 @@ void main() {
 
       expect(exception.error, 'Server error');
     });
+
+    test('stringifies structured application-side details', () {
+      final exception = VmServiceExtensionException.fromRpcError(
+        'custom.failure',
+        RPCError.withDetails(
+          'ext.flutter.custom.failure',
+          -32000,
+          'Server error',
+          details: <String, Object?>{
+            'reason': 'callback failed',
+            'retryable': false,
+          },
+        ),
+      );
+
+      expect(exception.error, contains('callback failed'));
+      expect(exception.error, contains('retryable: false'));
+    });
   });
 
   group('VmServiceConnector.callCustomExtension', () {

--- a/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
+++ b/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
@@ -1,7 +1,36 @@
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
 
 void main() {
+  group('VmServiceExtensionException.fromRpcError', () {
+    test('preserves application-side extension details', () {
+      final exception = VmServiceExtensionException.fromRpcError(
+        'custom.failure',
+        RPCError.withDetails(
+          'ext.flutter.custom.failure',
+          -32000,
+          'Server error',
+          details: 'callback failed\napplication stack',
+        ),
+      );
+
+      expect(exception.message, 'Extension custom.failure failed');
+      expect(exception.errorCode, -32000);
+      expect(exception.error, contains('callback failed'));
+      expect(exception.error, contains('application stack'));
+    });
+
+    test('falls back to the protocol message without details', () {
+      final exception = VmServiceExtensionException.fromRpcError(
+        'custom.failure',
+        RPCError('ext.flutter.custom.failure', -32000, 'Server error'),
+      );
+
+      expect(exception.error, 'Server error');
+    });
+  });
+
   group('VmServiceConnector.callCustomExtension', () {
     late VmServiceConnector connector;
 


### PR DESCRIPTION
## Summary

- preserve application-side VM extension error details in `VmServiceExtensionException`
- fall back to the protocol error message when an RPC response has no details
- cover both paths with focused unit tests

## Why

`vm_service` puts the exception text and application stack emitted by a failing service extension in `RPCError.details`. Marionette currently keeps only `RPCError.message`, which is commonly the generic `Server error`. As a result, MCP and CLI callers lose the actionable failure reason even though the VM service supplied it.

This change keeps the existing exception type, message, and error code. It only makes the existing `error` field more informative.

## Validation

- `dart test test/vm_service/vm_service_connector_test.dart` (17 tests)
- `dart analyze` (no issues)

The added tests verify both preservation of extension details and fallback behavior.
