### PR TITLE
Add versioned context to interactive-element responses

### DIFF
--- a/packages/marionette_cli/lib/src/cli/commands/get_interactive_elements_command.dart
+++ b/packages/marionette_cli/lib/src/cli/commands/get_interactive_elements_command.dart
@@ -5,6 +5,9 @@ import 'package:marionette_cli/src/instance_registry.dart';
 import 'package:marionette_mcp/src/formatting.dart';
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 
+String formatInteractiveElementsCommandOutput(Map<String, dynamic> response) =>
+    formatInteractiveElementsResponse(response);
+
 class ElementsCommand extends InstanceCommand {
   ElementsCommand(this._registry);
 
@@ -23,13 +26,7 @@ class ElementsCommand extends InstanceCommand {
   @override
   Future<int> execute(VmServiceConnector connector) async {
     final response = await connector.getInteractiveElements();
-    final elements = response['elements'] as List<dynamic>;
-
-    stdout.writeln('Found ${elements.length} interactive element(s):\n');
-
-    for (final element in elements) {
-      stdout.writeln(formatElement(element as Map<String, dynamic>));
-    }
+    stdout.write(formatInteractiveElementsCommandOutput(response));
 
     return 0;
   }

--- a/packages/marionette_cli/test/get_interactive_elements_command_test.dart
+++ b/packages/marionette_cli/test/get_interactive_elements_command_test.dart
@@ -1,0 +1,16 @@
+import 'package:marionette_cli/src/cli/commands/get_interactive_elements_command.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('formats versioned response context', () {
+    final output = formatInteractiveElementsCommandOutput({
+      'schemaVersion': 1,
+      'context': {'route': '/checkout'},
+      'elements': <Object?>[],
+    });
+
+    expect(output, contains('Schema version: 1'));
+    expect(output, contains('Context: {"route":"/checkout"}'));
+    expect(output, contains('Found 0 interactive element(s):'));
+  });
+}

--- a/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
+++ b/packages/marionette_flutter/lib/src/binding/extensions/info_extensions.dart
@@ -1,9 +1,27 @@
+import 'dart:convert';
+
 import 'package:marionette_flutter/src/binding/marionette_extension_result.dart';
 import 'package:marionette_flutter/src/binding/register_extension.dart';
 import 'package:marionette_flutter/src/binding/register_extension_internal.dart';
 import 'package:marionette_flutter/src/services/element_tree_finder.dart';
 import 'package:marionette_flutter/src/services/log_store.dart';
 import 'package:marionette_flutter/src/version.g.dart' as v;
+
+/// Current wire schema for the interactive-elements response.
+const interactiveElementsSchemaVersion = 1;
+
+/// Builds a versioned response while safely snapshotting optional app context.
+Map<String, dynamic> buildInteractiveElementsResponse(
+  List<Map<String, dynamic>> elements, {
+  Map<String, Object?> Function()? contextProvider,
+}) {
+  final context = _readContext(contextProvider);
+  return <String, dynamic>{
+    'schemaVersion': interactiveElementsSchemaVersion,
+    if (context != null) 'context': context,
+    'elements': elements,
+  };
+}
 
 /// Help text returned by `marionette.getLogs` when no log collector has been
 /// configured. Carries setup instructions for the user.
@@ -42,6 +60,7 @@ See https://pub.dev/packages/marionette_flutter for more details.''';
 void registerInfoExtensions({
   required ElementTreeFinder elementTreeFinder,
   required LogStore? Function() logStoreProvider,
+  Map<String, Object?> Function()? contextProvider,
 }) {
   registerInternalMarionetteExtension(
     name: 'marionette.getVersion',
@@ -54,7 +73,12 @@ void registerInfoExtensions({
     name: 'marionette.interactiveElements',
     callback: (params) async {
       final elements = elementTreeFinder.findInteractiveElements();
-      return MarionetteExtensionResult.success({'elements': elements});
+      return MarionetteExtensionResult.success(
+        buildInteractiveElementsResponse(
+          elements,
+          contextProvider: contextProvider,
+        ),
+      );
     },
   );
 
@@ -89,4 +113,21 @@ void registerInfoExtensions({
       });
     },
   );
+}
+
+Map<String, Object?>? _readContext(Map<String, Object?> Function()? provider) {
+  if (provider == null) {
+    return null;
+  }
+  try {
+    final context = Map<String, Object?>.unmodifiable(provider());
+    if (context.isEmpty) {
+      return null;
+    }
+    jsonEncode(context);
+    return context;
+  } on Object {
+    // Context is optional and must never make element discovery unavailable.
+    return null;
+  }
 }

--- a/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_binding.dart
@@ -144,6 +144,7 @@ class MarionetteBinding extends WidgetsFlutterBinding {
     registerInfoExtensions(
       elementTreeFinder: _elementTreeFinder,
       logStoreProvider: () => _logStore,
+      contextProvider: configuration.contextProvider,
     );
     registerGestureExtensions(
       gestureDispatcher: _gestureDispatcher,

--- a/packages/marionette_flutter/lib/src/binding/marionette_configuration.dart
+++ b/packages/marionette_flutter/lib/src/binding/marionette_configuration.dart
@@ -19,6 +19,7 @@ class MarionetteConfiguration {
     this.isInteractiveWidget,
     this.shouldStopTraversal,
     this.extractText,
+    this.contextProvider,
     this.maxScreenshotSize = const Size(2000, 2000),
     this.logCollector,
   });
@@ -63,6 +64,14 @@ class MarionetteConfiguration {
   /// )
   /// ```
   final String? Function(Element element)? extractText;
+
+  /// Supplies small, application-owned context alongside interactive elements.
+  ///
+  /// The callback is evaluated for every `get_interactive_elements` request,
+  /// so it can expose current navigation state such as a route or screen name.
+  /// The returned map must be JSON-encodable and must not contain secrets.
+  /// Invalid context is omitted without failing element discovery.
+  final Map<String, Object?> Function()? contextProvider;
 
   /// Maximum size for screenshots in physical pixels.
   ///

--- a/packages/marionette_flutter/test/interactive_elements_response_test.dart
+++ b/packages/marionette_flutter/test/interactive_elements_response_test.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/src/binding/extensions/info_extensions.dart';
+
+void main() {
+  test('response includes a versioned JSON-safe context snapshot', () {
+    final response = buildInteractiveElementsResponse(
+      <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'Button', 'text': 'Continue'},
+      ],
+      contextProvider: () => <String, Object?>{
+        'route': '/checkout',
+        'screen': 'Checkout',
+      },
+    );
+
+    expect(response, <String, Object?>{
+      'schemaVersion': 1,
+      'context': <String, Object?>{'route': '/checkout', 'screen': 'Checkout'},
+      'elements': <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'Button', 'text': 'Continue'},
+      ],
+    });
+    expect(() => jsonEncode(response), returnsNormally);
+  });
+
+  test('legacy callers can still read the unchanged elements field', () {
+    final elements = <Map<String, dynamic>>[
+      <String, dynamic>{'type': 'TextField'},
+    ];
+
+    final response = buildInteractiveElementsResponse(elements);
+
+    expect(response['elements'], same(elements));
+    expect(response['schemaVersion'], 1);
+    expect(response, isNot(contains('context')));
+  });
+
+  test('invalid optional context does not fail element discovery', () {
+    final throwing = buildInteractiveElementsResponse(
+      const <Map<String, dynamic>>[],
+      contextProvider: () => throw StateError('navigation is unavailable'),
+    );
+    final nonJson = buildInteractiveElementsResponse(
+      const <Map<String, dynamic>>[],
+      contextProvider: () => <String, Object?>{'value': Object()},
+    );
+    final empty = buildInteractiveElementsResponse(
+      const <Map<String, dynamic>>[],
+      contextProvider: () => const <String, Object?>{},
+    );
+
+    expect(throwing, isNot(contains('context')));
+    expect(nonJson, isNot(contains('context')));
+    expect(empty, isNot(contains('context')));
+  });
+}

--- a/packages/marionette_mcp/lib/src/formatting.dart
+++ b/packages/marionette_mcp/lib/src/formatting.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 ///
 /// Legacy responses containing only `elements` retain their previous output.
 String formatInteractiveElementsResponse(Map<String, dynamic> response) {
-  final elements = response['elements'] as List<dynamic>? ?? const [];
+  final elements = response['elements'] as List<dynamic>;
   final buffer = StringBuffer();
   if (response['schemaVersion'] != null) {
     buffer.writeln('Schema version: ${response['schemaVersion']}');

--- a/packages/marionette_mcp/lib/src/formatting.dart
+++ b/packages/marionette_mcp/lib/src/formatting.dart
@@ -1,5 +1,28 @@
 import 'dart:convert';
 
+/// Formats a versioned interactive-elements response for text-only clients.
+///
+/// Legacy responses containing only `elements` retain their previous output.
+String formatInteractiveElementsResponse(Map<String, dynamic> response) {
+  final elements = response['elements'] as List<dynamic>? ?? const [];
+  final buffer = StringBuffer();
+  if (response['schemaVersion'] != null) {
+    buffer.writeln('Schema version: ${response['schemaVersion']}');
+  }
+  if (response['context'] case final Map<dynamic, dynamic> context
+      when context.isNotEmpty) {
+    buffer.writeln('Context: ${jsonEncode(context)}');
+  }
+  if (buffer.isNotEmpty) {
+    buffer.writeln();
+  }
+  buffer.writeln('Found ${elements.length} interactive element(s):\n');
+  for (final element in elements) {
+    buffer.writeln(formatElement(element as Map<String, dynamic>));
+  }
+  return buffer.toString();
+}
+
 /// Builds a widget matcher map from tool/CLI arguments.
 ///
 /// Supports matching by key, identifier, text, type, and coordinates.

--- a/packages/marionette_mcp/lib/src/vm_service/tools/inspection_tools.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/tools/inspection_tools.dart
@@ -26,18 +26,7 @@ void registerInspectionTools(
         logger.info('Getting interactive elements');
         return runTool(logger, 'get interactive elements', () async {
           final response = await connector.getInteractiveElements();
-          final elements = response['elements'] as List<dynamic>;
-
-          final buffer = StringBuffer()
-            ..writeln('Found ${elements.length} interactive element(s):\n');
-
-          for (final element in elements) {
-            buffer.writeln(formatElement(element as Map<String, dynamic>));
-          }
-
-          return CallToolResult(
-            content: [TextContent(text: buffer.toString())],
-          );
+          return buildInteractiveElementsToolResult(response);
         });
       },
     )
@@ -125,4 +114,15 @@ void registerInspectionTools(
         });
       },
     );
+}
+
+/// Preserves the versioned response for structured clients and provides a
+/// human-readable equivalent for text-only MCP clients.
+CallToolResult buildInteractiveElementsToolResult(
+  Map<String, dynamic> response,
+) {
+  return CallToolResult(
+    content: [TextContent(text: formatInteractiveElementsResponse(response))],
+    structuredContent: response,
+  );
 }

--- a/packages/marionette_mcp/test/formatting_test.dart
+++ b/packages/marionette_mcp/test/formatting_test.dart
@@ -1,0 +1,31 @@
+import 'package:marionette_mcp/src/formatting.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('versioned response keeps context and elements in text output', () {
+    final output = formatInteractiveElementsResponse(<String, dynamic>{
+      'schemaVersion': 1,
+      'context': <String, Object?>{'route': '/checkout', 'screen': 'Checkout'},
+      'elements': <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'Button', 'text': 'Continue'},
+      ],
+    });
+
+    expect(output, contains('Schema version: 1'));
+    expect(output, contains('"route":"/checkout"'));
+    expect(output, contains('Found 1 interactive element(s)'));
+    expect(output, contains('Type: Button, Text: "Continue"'));
+  });
+
+  test('legacy elements-only response keeps the previous text shape', () {
+    final output = formatInteractiveElementsResponse(<String, dynamic>{
+      'elements': <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'Button'},
+      ],
+    });
+
+    expect(output, startsWith('Found 1 interactive element(s):\n\n'));
+    expect(output, isNot(contains('Schema version:')));
+    expect(output, isNot(contains('Context:')));
+  });
+}

--- a/packages/marionette_mcp/test/formatting_test.dart
+++ b/packages/marionette_mcp/test/formatting_test.dart
@@ -28,4 +28,13 @@ void main() {
     expect(output, isNot(contains('Schema version:')));
     expect(output, isNot(contains('Context:')));
   });
+
+  test('requires the core elements payload', () {
+    expect(
+      () => formatInteractiveElementsResponse(<String, dynamic>{
+        'schemaVersion': 1,
+      }),
+      throwsA(isA<TypeError>()),
+    );
+  });
 }

--- a/packages/marionette_mcp/test/interactive_elements_result_test.dart
+++ b/packages/marionette_mcp/test/interactive_elements_result_test.dart
@@ -1,0 +1,24 @@
+import 'package:marionette_mcp/src/vm_service/tools/inspection_tools.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('MCP result preserves the response as structured content', () {
+    final response = <String, dynamic>{
+      'schemaVersion': 1,
+      'context': <String, Object?>{'route': '/checkout'},
+      'elements': <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'Button', 'text': 'Continue'},
+      ],
+    };
+
+    final result = buildInteractiveElementsToolResult(response);
+
+    expect(result.structuredContent, same(response));
+    expect(result.content.single, isA<TextContent>());
+    expect(
+      (result.content.single as TextContent).text,
+      contains('Context: {"route":"/checkout"}'),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- add a versioned, additive response envelope for interactive-element discovery
- let applications provide a small JSON-safe context snapshot (for example, current route or screen)
- preserve the complete response as MCP structured content and show the context in text-only MCP and CLI output

## Motivation

The current producer returns only `elements`, and both consumers extract that field immediately. As a result, an application cannot attach stable navigation context to the element list, even when identical controls appear on several screens.

This keeps the existing `elements` field unchanged and makes context optional. Legacy elements-only responses retain the previous text output.

Invalid, empty, or throwing context providers are ignored so optional metadata cannot make discovery fail.

## Tests

- Flutter focused response-contract tests: 3 passed
- MCP focused formatting and structured-result tests: 3 passed against `mcp_dart 2.1.0`
- CLI focused formatting test: 1 passed
- Flutter analyzer and full package suite: 147 passed
- MCP analyzer: no issues
- CLI analyzer and full package suite: 90 passed

## Out of scope

Widget adapters, selector semantics, teardown timeouts, and dependency constraints are intentionally excluded.
