### PR TITLE
fix(marionette_mcp): surface extension error details, not "Server error"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix extension errors being reported as the generic `Server error` instead of the detail the extension returned — this silently swallowed every validation message and setup instruction, including the `get_logs` log-collector onboarding help
+
 # 0.6.0
 
 - Promote schema-bearing custom extensions to first-class MCP tools via the new `ExtensionInputSchema`/`ExtensionParam` DSL

--- a/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
+++ b/packages/marionette_mcp/lib/src/vm_service/vm_service_connector.dart
@@ -40,6 +40,27 @@ class VmServiceExtensionException implements Exception {
   }
 }
 
+/// Builds the [VmServiceExtensionException] for an extension call that came
+/// back as an [RPCError].
+///
+/// A failing extension answers with `ServiceExtensionResponse.error`, which
+/// carries two separate strings over the wire: the generic JSON-RPC label
+/// (`"Server error"`), which lands in [RPCError.message], and the detail the
+/// extension itself produced, which lands in [RPCError.details]. Only the
+/// detail says anything actionable — it is where the binding puts validation
+/// messages and setup instructions, such as the log-collector onboarding help
+/// — so it wins whenever it is present.
+VmServiceExtensionException extensionExceptionFromRpcError(
+  String extensionName,
+  RPCError error,
+) {
+  return VmServiceExtensionException(
+    'Extension $extensionName failed',
+    errorCode: error.code,
+    error: error.details ?? error.message,
+  );
+}
+
 /// Modifier keys accepted by [VmServiceConnector.pressKey].
 ///
 /// Must stay in sync with the modifiers the `marionette_flutter`
@@ -211,11 +232,7 @@ class VmServiceConnector {
       return responseJson;
     } on RPCError catch (e) {
       _logger.severe('Error calling extension $extensionName', e);
-      throw VmServiceExtensionException(
-        'Extension $extensionName failed',
-        errorCode: e.code,
-        error: e.message,
-      );
+      throw extensionExceptionFromRpcError(extensionName, e);
     } catch (err) {
       _logger.severe('Error calling extension $extensionName', err);
       rethrow;

--- a/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
+++ b/packages/marionette_mcp/test/vm_service/vm_service_connector_test.dart
@@ -1,7 +1,41 @@
 import 'package:marionette_mcp/src/vm_service/vm_service_connector.dart';
 import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
 
 void main() {
+  group('extensionExceptionFromRpcError', () {
+    test('surfaces the extension detail, not the generic JSON-RPC label', () {
+      // What a binding extension returning MarionetteExtensionResult.error
+      // looks like on the wire: the useful text is the detail, while `message`
+      // is the JSON-RPC label the VM fills in. Forwarding `message` used to
+      // reduce every extension failure — including onboarding help text — to
+      // "Server error".
+      final exception = extensionExceptionFromRpcError(
+        'marionette.getLogs',
+        RPCError.withDetails(
+          'ext.flutter.marionette.getLogs',
+          -32000,
+          'Server error',
+          details: 'Log collection is not configured.',
+        ),
+      );
+
+      expect(exception.error, 'Log collection is not configured.');
+      expect(exception.errorCode, -32000);
+      expect(exception.message, 'Extension marionette.getLogs failed');
+      expect(exception.toString(), contains('Log collection is not '));
+    });
+
+    test('falls back to the message when there is no detail', () {
+      final exception = extensionExceptionFromRpcError(
+        'marionette.tap',
+        RPCError('ext.flutter.marionette.tap', -32601, 'Method not found'),
+      );
+
+      expect(exception.error, 'Method not found');
+    });
+  });
+
   group('VmServiceConnector.callCustomExtension', () {
     late VmServiceConnector connector;
 


### PR DESCRIPTION
A failing `marionette.*` extension answers with
`ServiceExtensionResponse.error`, which carries two strings: the generic JSON-RPC label and the detail the extension produced. The connector forwarded `RPCError.message` — always the label — and never read `RPCError.details`, so every `MarionetteExtensionResult.error` payload was discarded before reaching the CLI or an agent. The `get_logs` log-collector onboarding help, for instance, arrived as `Error: Server error`.

Extract the mapping into `extensionExceptionFromRpcError` so it can be tested without a live VM service, and prefer the detail.