### PR TITLE
fix(marionette_flutter): make scroll_to reach targets it currently cannot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
+- Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
 - Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
+- Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
+
 # 0.6.0
 
 - Promote schema-bearing custom extensions to first-class MCP tools via the new `ExtensionInputSchema`/`ExtensionParam` DSL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
 - Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
 - Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
+- Fix `scroll_to` on screens with more than one scrollable: when the target is not built yet it now tries each reachable scrollable in turn rather than committing to a single guess, so a chip row, tab strip or nav rail no longer swallows the gesture
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
 - Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
 - Fix `scroll_to` on screens with more than one scrollable: when the target is not built yet it now tries each reachable scrollable in turn rather than committing to a single guess, so a chip row, tab strip or nav rail no longer swallows the gesture
+- Fix the `scroll_to` failure reading `Widget not found after 0 scroll attempts` when no scrollable could be dragged at all, which hid the real cause
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
 - Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
 - Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
-- Fix `scroll_to` on screens with more than one scrollable: when the target is not built yet it now tries each reachable scrollable in turn rather than committing to a single guess, so a chip row, tab strip or nav rail no longer swallows the gesture
+- Fix `scroll_to` on screens with more than one scrollable: when the target is not built yet it now tries the two best-ranked reachable scrollables in turn rather than committing to a single guess, so a chip row, tab strip or nav rail no longer swallows the gesture
 - Fix the `scroll_to` failure reading `Widget not found after 0 scroll attempts` when no scrollable could be dragged at all, which hid the real cause
 
 # 0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
 - Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
 - Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
+- Fix `scroll_to` on screens with more than one scrollable: when the target is not built yet it now tries each reachable scrollable in turn rather than committing to a single guess, so a chip row, tab strip or nav rail no longer swallows the gesture
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix extension errors being reported as the generic `Server error` instead of the detail the extension returned — this silently swallowed every validation message and setup instruction, including the `get_logs` log-collector onboarding help
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
 - Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
+- Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix extension errors being reported as the generic `Server error` instead of the detail the extension returned — this silently swallowed every validation message and setup instruction, including the `get_logs` log-collector onboarding help
+- Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix extension errors being reported as the generic `Server error` instead of the detail the extension returned — this silently swallowed every validation message and setup instruction, including the `get_logs` log-collector onboarding help
 - Fix `scroll_to` on layered UIs: scroll the list the user can reach and stop at the reachable copy of the target, instead of dragging a screen covered by a bottom sheet, dialog, or pushed route
+- Fix `scroll_to` missing a target that only comes into view on its final drag, at either end of a list
 
 # 0.6.0
 

--- a/packages/marionette_flutter/example/pubspec.lock
+++ b/packages/marionette_flutter/example/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/packages/marionette_flutter/lib/src/services/hit_test_utils.dart
+++ b/packages/marionette_flutter/lib/src/services/hit_test_utils.dart
@@ -13,6 +13,21 @@ bool isElementHittable(Element element) {
     return false;
   }
 
+  return isElementHittableAt(element, renderObject.size.center(Offset.zero));
+}
+
+/// Checks if the [element] can receive pointer events at [localPoint].
+///
+/// [localPoint] is in the element's own coordinate space. Use this to probe
+/// which parts of a large element are actually exposed — a viewport may be
+/// covered by an app bar or a bottom bar over part of its extent while
+/// remaining reachable elsewhere.
+bool isElementHittableAt(Element element, Offset localPoint) {
+  final renderObject = element.renderObject;
+  if (renderObject is! RenderBox || !renderObject.hasSize) {
+    return false;
+  }
+
   if (!renderObject.attached) {
     return false;
   }
@@ -25,8 +40,7 @@ bool isElementHittable(Element element) {
   }
 
   try {
-    final center = renderObject.size.center(Offset.zero);
-    final absoluteOffset = renderObject.localToGlobal(center);
+    final absoluteOffset = renderObject.localToGlobal(localPoint);
 
     final result = HitTestResult();
     WidgetsBinding.instance.hitTestInView(result, absoluteOffset, viewId);

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -21,8 +21,10 @@ class ScrollSimulator {
 
   /// Scrolls until the widget matching [matcher] is visible.
   ///
-  /// Finds the first [Scrollable] in the tree and scrolls it until the target
-  /// widget becomes visible or max attempts are exhausted.
+  /// Picks the [Scrollable] the user can currently reach rather than the first
+  /// one in the tree — a covered layer stays built and comes earlier — and
+  /// drags it until the target becomes reachable or max attempts are
+  /// exhausted.
   ///
   /// Throws an [Exception] if:
   /// - The target widget is not found
@@ -66,33 +68,48 @@ class ScrollSimulator {
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
   ) {
-    final initialTarget = _widgetFinder.findElement(matcher, configuration);
-    if (initialTarget != null) {
-      final ancestorScrollable = _findScrollableAncestor(initialTarget);
-      if (ancestorScrollable != null) {
-        return ancestorScrollable;
-      }
-    }
-
     final root = WidgetsBinding.instance.rootElement;
     if (root == null) {
       return null;
     }
 
+    final targetScrollable = _findScrollableOwningAMatch(
+      matcher,
+      root,
+      configuration,
+    );
+    if (targetScrollable != null) {
+      return targetScrollable;
+    }
+
+    // The target is not in the tree yet, which is normal for lazily built
+    // lists. Fall back to picking a Scrollable, preferring ones the user can
+    // currently reach so a covered layer does not win just by being first.
     Element? fallbackScrollable;
     Element? scrollableWithRange;
+    Element? reachableFallback;
+    Element? reachableWithRange;
 
     void visit(Element element) {
-      if (scrollableWithRange != null) {
+      if (reachableWithRange != null) {
         return;
       }
 
       if (element.widget is Scrollable) {
-        fallbackScrollable ??= element;
         final position = _tryResolveScrollPosition(element);
-        if (position != null && _hasScrollableRange(position)) {
-          scrollableWithRange = element;
-          return;
+        final hasRange = position != null && _hasScrollableRange(position);
+
+        fallbackScrollable ??= element;
+        if (hasRange) {
+          scrollableWithRange ??= element;
+        }
+
+        if (isElementHittable(element)) {
+          reachableFallback ??= element;
+          if (hasRange) {
+            reachableWithRange ??= element;
+            return;
+          }
         }
       }
 
@@ -100,7 +117,53 @@ class ScrollSimulator {
     }
 
     visit(root);
-    return scrollableWithRange ?? fallbackScrollable;
+
+    // Most to least preferred. Reachability outranks scroll range because the
+    // drag starts at the centre of the chosen Scrollable, the exact point
+    // hittability is measured at: one that fails the check cannot be dragged
+    // at all, range or no range. The last two tiers keep the previous
+    // behaviour for trees where hittability is never established.
+    return reachableWithRange ??
+        reachableFallback ??
+        scrollableWithRange ??
+        fallbackScrollable;
+  }
+
+  /// Returns the [Scrollable] containing a match that the user can reach.
+  ///
+  /// Every match is considered, not just the first, because a covered layer
+  /// sits earlier in the element tree than the one on top. The match itself
+  /// does not need to be hittable — it may still be scrolled out of view — so
+  /// reachability is judged on the [Scrollable] that would move it.
+  Element? _findScrollableOwningAMatch(
+    WidgetMatcher matcher,
+    Element root,
+    MarionetteConfiguration configuration,
+  ) {
+    Element? firstScrollable;
+    Element? reachableScrollable;
+
+    void visit(Element element) {
+      if (reachableScrollable != null) {
+        return;
+      }
+
+      if (matcher.matches(element, configuration)) {
+        final scrollable = _findScrollableAncestor(element);
+        if (scrollable != null) {
+          firstScrollable ??= scrollable;
+          if (isElementHittable(scrollable)) {
+            reachableScrollable = scrollable;
+            return;
+          }
+        }
+      }
+
+      element.visitChildren(visit);
+    }
+
+    visit(root);
+    return reachableScrollable ?? firstScrollable;
   }
 
   Element? _findScrollableAncestor(Element element) {
@@ -130,10 +193,14 @@ class ScrollSimulator {
     var stalledAttempts = 0;
 
     for (var i = 0; i < maxScrollAttempts; i++) {
-      // Find the target element
-      final target = _widgetFinder.findElement(targetMatcher, configuration);
-      // Check if target is visible
-      if (target != null && isElementHittable(target)) {
+      // Look for a match that can actually receive pointer events. Matching on
+      // the first hit alone is not enough: a covered layer is earlier in the
+      // tree, so a widget the user cannot reach would mask the one they can.
+      final target = _widgetFinder.findHittableElement(
+        targetMatcher,
+        configuration,
+      );
+      if (target != null) {
         return;
       }
 

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -12,7 +12,8 @@ class ScrollSimulator {
   final GestureDispatcher _gestureDispatcher;
   final WidgetFinder _widgetFinder;
 
-  static const _delta = 64.0;
+  static const _minDelta = 64.0;
+  static const _exposureSamples = 21;
   static const _fallbackMaxScrollAttempts = 50;
   static const _defaultMaxScrollAttemptsCap = 200;
   static const _attemptPadding = 20;
@@ -45,13 +46,14 @@ class ScrollSimulator {
     final position = _resolveScrollPosition(scrollable);
 
     // Calculate move step based on direction
+    final delta = _stepFor(scrollable, direction);
     final initialMoveStep = switch (direction) {
-      AxisDirection.up => const Offset(0, _delta),
-      AxisDirection.down => const Offset(0, -_delta),
-      AxisDirection.left => const Offset(_delta, 0),
-      AxisDirection.right => const Offset(-_delta, 0),
+      AxisDirection.up => Offset(0, delta),
+      AxisDirection.down => Offset(0, -delta),
+      AxisDirection.left => Offset(delta, 0),
+      AxisDirection.right => Offset(-delta, 0),
     };
-    final maxScrollAttempts = _calculateMaxScrollAttempts(position);
+    final maxScrollAttempts = _calculateMaxScrollAttempts(position, delta);
 
     // Scroll until visible
     await _dragUntilVisible(
@@ -307,7 +309,70 @@ class ScrollSimulator {
         _positionEpsilon;
   }
 
-  int _calculateMaxScrollAttempts(ScrollPosition position) {
+  /// The distance to drag per attempt.
+  ///
+  /// Half of the run of the viewport that can actually receive pointer events,
+  /// so consecutive attempts overlap and nothing passes through unseen. A
+  /// widget only counts as visible once its centre can be hit, and a centre
+  /// crosses that run exactly once on the way past, so a step wider than the
+  /// run could stride over a target without ever offering it for inspection.
+  ///
+  /// Scaling to the viewport rather than creeping by a fixed amount is what
+  /// makes long lists reachable at all: the attempt cap is finite, so a small
+  /// step puts a ceiling on how far a list can be traversed.
+  double _stepFor(Element scrollable, AxisDirection direction) {
+    final renderObject = scrollable.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return _minDelta;
+    }
+
+    final size = renderObject.size;
+    final axis = axisDirectionToAxis(direction);
+    final extent = axis == Axis.vertical ? size.height : size.width;
+    if (!extent.isFinite || extent <= 0) {
+      return _minDelta;
+    }
+
+    return (_exposedExtent(scrollable, size, axis) * 0.5)
+        .clamp(_minDelta, double.infinity);
+  }
+
+  /// The longest uninterrupted run of the viewport along [axis] that can
+  /// receive pointer events.
+  ///
+  /// An app bar, a bottom bar, or any overlay drawn over the viewport hides
+  /// part of it from hit testing while leaving the rest usable. Sampling finds
+  /// the usable part; the whole extent is assumed when nothing is reachable,
+  /// since a scrollable covered end to end cannot be dragged at any step size.
+  double _exposedExtent(Element scrollable, Size size, Axis axis) {
+    final extent = axis == Axis.vertical ? size.height : size.width;
+    final cross = axis == Axis.vertical ? size.width / 2 : size.height / 2;
+
+    var longestRun = 0;
+    var currentRun = 0;
+    for (var i = 0; i < _exposureSamples; i++) {
+      final along = extent * (i + 0.5) / _exposureSamples;
+      final point =
+          axis == Axis.vertical ? Offset(cross, along) : Offset(along, cross);
+
+      if (isElementHittableAt(scrollable, point)) {
+        currentRun++;
+        if (currentRun > longestRun) {
+          longestRun = currentRun;
+        }
+      } else {
+        currentRun = 0;
+      }
+    }
+
+    if (longestRun == 0) {
+      return extent;
+    }
+
+    return extent * longestRun / _exposureSamples;
+  }
+
+  int _calculateMaxScrollAttempts(ScrollPosition position, double delta) {
     final scrollExtent =
         (position.maxScrollExtent - position.minScrollExtent).abs();
     if (!scrollExtent.isFinite) {
@@ -316,7 +381,7 @@ class ScrollSimulator {
           .toInt();
     }
 
-    final oneWayAttempts = (scrollExtent / _delta).ceil();
+    final oneWayAttempts = (scrollExtent / delta).ceil();
 
     // Allow one full pass in one direction and another after reverse,
     // with a small buffer for viewport alignment near edges.

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -84,19 +84,22 @@ class ScrollSimulator {
       return targetScrollable;
     }
 
-    // The target is not in the tree yet, which is normal for lazily built
-    // lists. Fall back to picking a Scrollable, preferring ones the user can
-    // currently reach so a covered layer does not win just by being first.
+    // The target isn't built yet (e.g. it's off-screen in a lazily built
+    // list), so it can't be found directly. Fall back to scanning the tree
+    // for candidate Scrollables. A screen can have more than one — a
+    // horizontal chip row or tab strip alongside the main vertical list, for
+    // example — so instead of taking the first scrollable-with-range found
+    // in traversal order (which can latch onto a small auxiliary scrollable
+    // and then scroll the wrong axis entirely), prefer the one covering the
+    // most screen area: the main scroll body is almost always larger than an
+    // auxiliary strip/carousel.
     Element? fallbackScrollable;
     Element? scrollableWithRange;
     Element? reachableFallback;
     Element? reachableWithRange;
+    var bestArea = -1.0;
 
     void visit(Element element) {
-      if (reachableWithRange != null) {
-        return;
-      }
-
       if (element.widget is Scrollable) {
         final position = _tryResolveScrollPosition(element);
         final hasRange = position != null && _hasScrollableRange(position);
@@ -109,8 +112,11 @@ class ScrollSimulator {
         if (isElementHittable(element)) {
           reachableFallback ??= element;
           if (hasRange) {
-            reachableWithRange ??= element;
-            return;
+            final area = _elementArea(element);
+            if (area > bestArea) {
+              bestArea = area;
+              reachableWithRange = element;
+            }
           }
         }
       }
@@ -129,6 +135,15 @@ class ScrollSimulator {
         reachableFallback ??
         scrollableWithRange ??
         fallbackScrollable;
+  }
+
+  double _elementArea(Element element) {
+    final renderObject = element.renderObject;
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return 0;
+    }
+    final size = renderObject.size;
+    return size.width * size.height;
   }
 
   /// Returns the [Scrollable] containing a match that the user can reach.

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -13,6 +13,8 @@ class ScrollSimulator {
   final WidgetFinder _widgetFinder;
 
   static const _minDelta = 64.0;
+  static const _maxScrollableCandidates = 3;
+  static const _totalScrollAttemptsCap = 400;
   static const _exposureSamples = 21;
   static const _fallbackMaxScrollAttempts = 50;
   static const _defaultMaxScrollAttemptsCap = 200;
@@ -35,89 +37,109 @@ class ScrollSimulator {
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
   ) async {
-    final scrollable = _findScrollableElement(matcher, configuration);
-    if (scrollable == null) {
+    final candidates = _findScrollableCandidates(matcher, configuration);
+    if (candidates.isEmpty) {
       throw Exception('No Scrollable widget found in the tree');
     }
 
-    // Get the scroll direction
-    final scrollableWidget = scrollable.widget as Scrollable;
-    final direction = scrollableWidget.axisDirection;
-    final position = _resolveScrollPosition(scrollable);
+    var attemptsLeft = _totalScrollAttemptsCap;
 
-    // Calculate move step based on direction
-    final delta = _stepFor(scrollable, direction);
-    final initialMoveStep = switch (direction) {
-      AxisDirection.up => Offset(0, delta),
-      AxisDirection.down => Offset(0, -delta),
-      AxisDirection.left => Offset(delta, 0),
-      AxisDirection.right => Offset(-delta, 0),
-    };
-    final maxScrollAttempts = _calculateMaxScrollAttempts(position, delta);
+    for (final candidate in candidates) {
+      if (attemptsLeft <= 0) {
+        break;
+      }
 
-    // Scroll until visible
-    await _dragUntilVisible(
-      matcher,
-      scrollable,
-      position,
-      initialMoveStep,
-      maxScrollAttempts,
-      configuration,
+      // Re-resolve rather than trusting what the ranking pass saw. Scrolling
+      // one candidate builds and unbuilds widgets, and a Scrollable that has
+      // gone away since takes its ScrollPosition with it.
+      final position = _tryResolveScrollPosition(candidate);
+      if (position == null) {
+        continue;
+      }
+
+      final direction = (candidate.widget as Scrollable).axisDirection;
+      final delta = _stepFor(candidate, direction);
+      final initialMoveStep = switch (direction) {
+        AxisDirection.up => Offset(0, delta),
+        AxisDirection.down => Offset(0, -delta),
+        AxisDirection.left => Offset(delta, 0),
+        AxisDirection.right => Offset(-delta, 0),
+      };
+      final budget = _calculateMaxScrollAttempts(
+        position,
+        delta,
+      ).clamp(1, attemptsLeft);
+      final startedAt = position.pixels;
+
+      final outcome = await _dragUntilVisible(
+        matcher,
+        candidate,
+        position,
+        initialMoveStep,
+        budget,
+        configuration,
+      );
+      attemptsLeft -= outcome.attempts;
+
+      if (outcome.found) {
+        return;
+      }
+
+      // Wrong guess. Put it back, so the only lasting effect of a scroll_to is
+      // the scrolling that actually found the target.
+      _restoreScrollPosition(candidate, startedAt);
+    }
+
+    throw StateError(
+      'Widget not found after '
+      '${_totalScrollAttemptsCap - attemptsLeft} scroll attempts',
     );
   }
 
-  Element? _findScrollableElement(
+  /// The [Scrollable]s worth dragging to reveal [matcher], best guess first.
+  ///
+  /// A built match settles the question outright — whatever encloses it is
+  /// what moves it — but only when the user can reach that [Scrollable]. A
+  /// covered layer stays built and comes first in the element tree, so the
+  /// only match on screen may well be one nobody can touch.
+  ///
+  /// Without a reachable match the target simply is not built yet, which is
+  /// ordinary for a lazily built list, and nothing in the tree says which
+  /// [Scrollable] would eventually build it. Every ranking is a guess that
+  /// some layout defeats, so rank the plausible ones and let the caller try
+  /// them in turn: whether the target shows up is the only reliable signal.
+  List<Element> _findScrollableCandidates(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,
   ) {
     final root = WidgetsBinding.instance.rootElement;
     if (root == null) {
-      return null;
+      return const <Element>[];
     }
 
-    final targetScrollable = _findScrollableOwningAMatch(
-      matcher,
-      root,
-      configuration,
-    );
-    if (targetScrollable != null) {
-      return targetScrollable;
+    final owners = _findScrollablesOwningAMatch(matcher, root, configuration);
+    final reachableOwner = owners.reachable;
+    if (reachableOwner != null) {
+      return <Element>[reachableOwner];
     }
 
-    // The target isn't built yet (e.g. it's off-screen in a lazily built
-    // list), so it can't be found directly. Fall back to scanning the tree
-    // for candidate Scrollables. A screen can have more than one — a
-    // horizontal chip row or tab strip alongside the main vertical list, for
-    // example — so instead of taking the first scrollable-with-range found
-    // in traversal order (which can latch onto a small auxiliary scrollable
-    // and then scroll the wrong axis entirely), prefer the one covering the
-    // most screen area: the main scroll body is almost always larger than an
-    // auxiliary strip/carousel.
-    Element? fallbackScrollable;
+    final reachableWithRange = <Element>[];
+    final reachableWithoutRange = <Element>[];
     Element? scrollableWithRange;
-    Element? reachableFallback;
-    Element? reachableWithRange;
-    var bestArea = -1.0;
+    Element? anyScrollable;
 
     void visit(Element element) {
       if (element.widget is Scrollable) {
         final position = _tryResolveScrollPosition(element);
         final hasRange = position != null && _hasScrollableRange(position);
 
-        fallbackScrollable ??= element;
+        anyScrollable ??= element;
         if (hasRange) {
           scrollableWithRange ??= element;
         }
 
         if (isElementHittable(element)) {
-          reachableFallback ??= element;
-          if (hasRange) {
-            final area = _elementArea(element);
-            if (area > bestArea) {
-              bestArea = area;
-              reachableWithRange = element;
-            }
-          }
+          (hasRange ? reachableWithRange : reachableWithoutRange).add(element);
         }
       }
 
@@ -126,15 +148,39 @@ class ScrollSimulator {
 
     visit(root);
 
-    // Most to least preferred. Reachability outranks scroll range because the
-    // drag starts at the centre of the chosen Scrollable, the exact point
-    // hittability is measured at: one that fails the check cannot be dragged
-    // at all, range or no range. The last two tiers keep the previous
-    // behaviour for trees where hittability is never established.
-    return reachableWithRange ??
-        reachableFallback ??
-        scrollableWithRange ??
-        fallbackScrollable;
+    // Reachable before out of reach, and with somewhere to go before without:
+    // the drag starts at the centre of the chosen Scrollable, the exact point
+    // hittability is measured at, so one that fails the check cannot be
+    // dragged at all.
+    //
+    // Biggest first within a tier. A chip row, a tab strip or a carousel is
+    // nearly always smaller than the body it decorates, so that is the better
+    // guess to spend the first attempt on — but it is only an ordering, and
+    // guessing wrong now costs an attempt rather than the whole call.
+    _sortByAreaDescending(reachableWithRange);
+    _sortByAreaDescending(reachableWithoutRange);
+
+    final candidates = <Element>[
+      ...reachableWithRange,
+      ...reachableWithoutRange,
+    ];
+
+    if (candidates.isEmpty) {
+      // Nothing on screen answers a hit test, so reachability cannot rank
+      // anything here. Keep the older single-pick behaviour rather than
+      // refuse to scroll at all.
+      final fallback = owners.first ?? scrollableWithRange ?? anyScrollable;
+      if (fallback != null) {
+        candidates.add(fallback);
+      }
+    }
+
+    return candidates.take(_maxScrollableCandidates).toList();
+  }
+
+  void _sortByAreaDescending(List<Element> elements) {
+    elements.sort(
+        (Element a, Element b) => _elementArea(b).compareTo(_elementArea(a)));
   }
 
   double _elementArea(Element element) {
@@ -146,13 +192,31 @@ class ScrollSimulator {
     return size.width * size.height;
   }
 
-  /// Returns the [Scrollable] containing a match that the user can reach.
+  void _restoreScrollPosition(Element scrollable, double pixels) {
+    final position = _tryResolveScrollPosition(scrollable);
+    if (position == null || !position.hasPixels) {
+      return;
+    }
+    if ((position.pixels - pixels).abs() <= _positionEpsilon) {
+      return;
+    }
+    position.jumpTo(pixels);
+  }
+
+  /// The [Scrollable]s containing a match: the first one found, and the first
+  /// one the user can reach.
   ///
   /// Every match is considered, not just the first, because a covered layer
   /// sits earlier in the element tree than the one on top. The match itself
   /// does not need to be hittable — it may still be scrolled out of view — so
   /// reachability is judged on the [Scrollable] that would move it.
-  Element? _findScrollableOwningAMatch(
+  ///
+  /// The two are reported apart because they mean different things. A
+  /// reachable owner is an answer. An unreachable one is a leftover from a
+  /// covered layer, worth keeping only as a last resort: treating it as an
+  /// answer is what made a sheet opened over a page with a same-named widget
+  /// drag the page instead.
+  ({Element? first, Element? reachable}) _findScrollablesOwningAMatch(
     WidgetMatcher matcher,
     Element root,
     MarionetteConfiguration configuration,
@@ -180,7 +244,7 @@ class ScrollSimulator {
     }
 
     visit(root);
-    return reachableScrollable ?? firstScrollable;
+    return (first: firstScrollable, reachable: reachableScrollable);
   }
 
   Element? _findScrollableAncestor(Element element) {
@@ -196,7 +260,10 @@ class ScrollSimulator {
   }
 
   /// Repeatedly drags the scrollable until the target is visible.
-  Future<void> _dragUntilVisible(
+  ///
+  /// Reports whether the target turned up and how many drags it took, so the
+  /// caller can move on to the next candidate and keep a lid on the total.
+  Future<_DragOutcome> _dragUntilVisible(
     WidgetMatcher targetMatcher,
     Element scrollable,
     ScrollPosition position,
@@ -208,6 +275,7 @@ class ScrollSimulator {
     var searchingTowardEnd = true;
     var hasReversedDirection = false;
     var stalledAttempts = 0;
+    var drags = 0;
 
     for (var i = 0; i < maxScrollAttempts; i++) {
       // Look for a match that can actually receive pointer events. Matching on
@@ -218,7 +286,7 @@ class ScrollSimulator {
         configuration,
       );
       if (target != null) {
-        return;
+        return _DragOutcome(found: true, attempts: drags);
       }
 
       final atCurrentEdgeBeforeDrag = searchingTowardEnd
@@ -246,6 +314,7 @@ class ScrollSimulator {
       final to = globalPosition + moveStep;
       final beforePosition = position.pixels;
       await _gestureDispatcher.drag(globalPosition, to);
+      drags++;
 
       final afterPosition = position.pixels;
       final moved = (afterPosition - beforePosition).abs() > _positionEpsilon;
@@ -289,34 +358,32 @@ class ScrollSimulator {
     // The loop checks for the target on entry but leaves from the middle, so
     // the position the last drag landed on has not been examined yet. Look
     // once more before giving up: the target may be sitting on screen.
-    if (_widgetFinder.findHittableElement(targetMatcher, configuration) !=
-        null) {
-      return;
-    }
-
-    // Target still not visible after max scrolls
-    throw StateError(
-      'Widget not found after $maxScrollAttempts scroll attempts',
+    final target = _widgetFinder.findHittableElement(
+      targetMatcher,
+      configuration,
     );
+    return _DragOutcome(found: target != null, attempts: drags);
   }
 
-  ScrollPosition _resolveScrollPosition(Element scrollable) {
-    final position = _tryResolveScrollPosition(scrollable);
-    if (position == null) {
-      throw Exception('Scrollable element does not expose ScrollableState');
-    }
-    return position;
-  }
-
+  /// The live [ScrollPosition] of [scrollable], or null if there is not one.
+  ///
+  /// Deliberately total. Candidates are collected before any of them is
+  /// dragged, and dragging one can unbuild another — a carousel inside a lazy
+  /// list, say — leaving an [Element] still referenced but with nothing behind
+  /// it. That has to read as a miss, not a crash.
   ScrollPosition? _tryResolveScrollPosition(Element scrollable) {
-    if (scrollable is! StatefulElement) {
+    if (!scrollable.mounted || scrollable is! StatefulElement) {
       return null;
     }
     final state = scrollable.state;
     if (state is! ScrollableState) {
       return null;
     }
-    return state.position;
+    try {
+      return state.position;
+    } catch (_) {
+      return null;
+    }
   }
 
   bool _hasScrollableRange(ScrollPosition position) {
@@ -403,4 +470,12 @@ class ScrollSimulator {
     final adaptiveAttempts = oneWayAttempts * 2 + _attemptPadding;
     return adaptiveAttempts.clamp(1, _defaultMaxScrollAttemptsCap).toInt();
   }
+}
+
+/// What one pass over a single [Scrollable] achieved.
+class _DragOutcome {
+  const _DragOutcome({required this.found, required this.attempts});
+
+  final bool found;
+  final int attempts;
 }

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -269,6 +269,14 @@ class ScrollSimulator {
       break;
     }
 
+    // The loop checks for the target on entry but leaves from the middle, so
+    // the position the last drag landed on has not been examined yet. Look
+    // once more before giving up: the target may be sitting on screen.
+    if (_widgetFinder.findHittableElement(targetMatcher, configuration) !=
+        null) {
+      return;
+    }
+
     // Target still not visible after max scrolls
     throw StateError(
       'Widget not found after $maxScrollAttempts scroll attempts',

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -43,6 +43,7 @@ class ScrollSimulator {
     }
 
     var attemptsLeft = _totalScrollAttemptsCap;
+    var draggedSomething = false;
 
     for (final candidate in candidates) {
       if (attemptsLeft <= 0) {
@@ -80,6 +81,7 @@ class ScrollSimulator {
         configuration,
       );
       attemptsLeft -= outcome.attempts;
+      draggedSomething |= outcome.attempts > 0;
 
       if (outcome.found) {
         return;
@@ -88,6 +90,15 @@ class ScrollSimulator {
       // Wrong guess. Put it back, so the only lasting effect of a scroll_to is
       // the scrolling that actually found the target.
       _restoreScrollPosition(candidate, startedAt);
+    }
+
+    if (!draggedSomething) {
+      // Nothing ever moved, so an attempt count names the count rather than
+      // the cause: every candidate either had nowhere to go or was gone by the
+      // time its turn came.
+      throw StateError(
+        'Widget not found: no Scrollable could be scrolled to reveal it',
+      );
     }
 
     throw StateError(
@@ -305,7 +316,11 @@ class ScrollSimulator {
 
       final renderObject = scrollable.renderObject;
       if (renderObject is! RenderBox) {
-        throw Exception('Scrollable does not have a RenderBox');
+        // Total for the same reason _tryResolveScrollPosition is: a candidate
+        // can lose its layout while the loop is running, so reaching for what
+        // is left has to read as a miss rather than a crash. Give this one up
+        // and let the caller carry on to the next.
+        break;
       }
 
       final center = renderObject.size.center(Offset.zero);

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -13,7 +13,13 @@ class ScrollSimulator {
   final WidgetFinder _widgetFinder;
 
   static const _minDelta = 64.0;
-  static const _maxScrollableCandidates = 3;
+
+  // Two, and no more, because of the caps below: one candidate may spend
+  // _defaultMaxScrollAttemptsCap attempts and the whole call may spend
+  // _totalScrollAttemptsCap, so two is the most that can each be given a full
+  // budget. A third would get only what the first two left over, which is too
+  // little to cross the list it was picked for.
+  static const _maxScrollableCandidates = 2;
   static const _totalScrollAttemptsCap = 400;
   static const _exposureSamples = 21;
   static const _fallbackMaxScrollAttempts = 50;

--- a/packages/marionette_flutter/lib/src/services/widget_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/widget_finder.dart
@@ -54,10 +54,11 @@ class WidgetFinder {
   /// Finds the first element that matches the given [matcher] and is hittable
   /// (i.e. can receive pointer events and is not behind a modal barrier).
   ///
-  /// This should be used by tools that dispatch gestures (tap, enter_text)
-  /// where matching a non-hittable widget would result in a silent failure.
-  /// Tools that need to find offscreen elements (e.g. scroll_to) should use
-  /// [findElement] instead.
+  /// This should be used by tools that dispatch gestures (tap, enter_text) and
+  /// by tools that ask whether the user can reach a widget (scroll_to), where
+  /// matching a widget on a covered layer would result in a silent failure.
+  /// Use [findElement] where a match the user cannot currently reach is still
+  /// a valid answer.
   Element? findHittableElement(
     WidgetMatcher matcher,
     MarionetteConfiguration configuration,

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -319,6 +319,44 @@ void main() {
       },
     );
   });
+
+  group('ScrollSimulator.scrollUntilVisible at list edges', () {
+    testWidgets(
+      'finds a target that only comes into view on the very last drag',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // The loop checks for the target at the top of each iteration but
+        // leaves from the middle: on reaching an edge for the second time it
+        // breaks without going back to the check. The position it stops at was
+        // never examined, so a target whose visible range lies entirely inside
+        // the final step of travel got scrolled to and then missed.
+        final controller = ScrollController(initialScrollOffset: 11000);
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          _buildItemsApp(
+            controller: controller,
+            itemCount: 150,
+            itemExtent: 80,
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const KeyMatcher('item_0'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_0')), findsOneWidget);
+        expect(controller.offset, 0);
+      },
+    );
+  });
 }
 
 /// A page holding [background] under a modal bottom sheet holding [sheet].

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -591,6 +591,165 @@ void main() {
       },
     );
   });
+
+  group('ScrollSimulator.scrollUntilVisible with several scrollables', () {
+    testWidgets(
+      'reaches a target in the sheet when a covered list holds a built copy '
+      'of its name',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // A built match settles the question of which Scrollable owns the
+        // target — but only if the user can reach that Scrollable. Here the
+        // sole built match sits on the covered page, so its owner is a dead
+        // end and the search has to carry on to the sheet, where the real
+        // target is waiting to be built.
+        final sheetController = ScrollController();
+        addTearDown(sheetController.dispose);
+
+        await tester.pumpWidget(
+          _buildSheetApp(
+            background: SizedBox(
+              height: 120,
+              child: ListView(
+                children: const <Widget>[Text('Country 90')],
+              ),
+            ),
+            sheet: _lazyList(
+              controller: sheetController,
+              label: (int index) => 'Country $index',
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const TextMatcher('Country 90'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(sheetController.offset, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'reaches a target inside the smaller of two side-by-side lists',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // The mirror image of the case above: here the narrow list is the one
+        // holding the target, so preferring the larger scrollable is just as
+        // wrong as preferring the first. Neither ranking can know, so both
+        // have to be tried.
+        final railController = ScrollController();
+        final contentController = ScrollController();
+        addTearDown(() {
+          railController.dispose();
+          contentController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: 120,
+                    child: _lazyList(
+                      controller: railController,
+                      label: (int index) => 'Country $index',
+                    ),
+                  ),
+                  Expanded(
+                    child: _lazyList(
+                      controller: contentController,
+                      label: (int index) => 'Article $index',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const TextMatcher('Country 90'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Country 90'), findsOneWidget);
+        expect(railController.offset, greaterThan(0));
+        expect(
+          contentController.offset,
+          0,
+          reason: 'a scrollable tried and abandoned should be put back',
+        );
+      },
+    );
+
+    testWidgets(
+      'fails cleanly when trying one candidate unbuilds another',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // The carousel lives in the first row of a lazily built list, so
+        // dragging the list takes the carousel out of the tree — and with it
+        // the ScrollPosition that the ranking pass saw. Reaching for it then
+        // has to be a miss, not a crash.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ListView.builder(
+                physics: const ClampingScrollPhysics(),
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) {
+                  if (index == 0) {
+                    return SizedBox(
+                      height: 80,
+                      child: ListView.builder(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: 60,
+                        itemBuilder: (BuildContext context, int index) =>
+                            SizedBox(
+                          width: 90,
+                          child: Center(child: Text('Card $index')),
+                        ),
+                      ),
+                    );
+                  }
+                  return SizedBox(height: 120, child: Text('Row $index'));
+                },
+              ),
+            ),
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await expectLater(
+          () => simulator.scrollUntilVisible(
+            const TextMatcher('Card 55'),
+            _configuration,
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+  });
 }
 
 /// A page holding [background] under a modal bottom sheet holding [sheet].

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -7,6 +7,7 @@ import 'package:marionette_flutter/src/services/widget_finder.dart';
 
 const _timeout = Timeout(Duration(seconds: 30));
 const _configuration = MarionetteConfiguration();
+const _listItemCount = 100;
 
 void main() {
   group('ScrollSimulator.scrollUntilVisible', () {
@@ -116,6 +117,308 @@ void main() {
       },
     );
   });
+
+  group('ScrollSimulator.scrollUntilVisible on layered UIs', () {
+    testWidgets(
+      'scrolls the modal list instead of the covered one behind it',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final backgroundController = ScrollController();
+        final sheetController = ScrollController();
+        addTearDown(() {
+          backgroundController.dispose();
+          sheetController.dispose();
+        });
+
+        // Every widget here is uniquely named. The only thing that makes the
+        // covered list win is that it is built first, so it comes first in
+        // the element tree.
+        await tester.pumpWidget(
+          _buildSheetApp(
+            background: Expanded(
+              child: _lazyList(
+                controller: backgroundController,
+                label: (int index) => 'Background item $index',
+              ),
+            ),
+            sheet: _lazyList(
+              controller: sheetController,
+              label: (int index) => 'Country $index',
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        // 'Country 90' is far down the sheet's list, so it is not built yet
+        // and cannot be located by matching alone.
+        await simulator.scrollUntilVisible(
+          const TextMatcher('Country 90'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Country 90'), findsOneWidget);
+        expect(
+          backgroundController.offset,
+          0,
+          reason: 'the covered list should never be scrolled',
+        );
+        expect(sheetController.offset, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'scrolls the list holding the copy of the target the user can reach',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final backgroundController = ScrollController();
+        final sheetController = ScrollController();
+        addTearDown(() {
+          backgroundController.dispose();
+          sheetController.dispose();
+        });
+
+        // Both layers build every row up front, so the covered list holds a
+        // matching row that is in the element tree and comes first. Picking
+        // the scrollable that owns the first match drags the covered list.
+        await tester.pumpWidget(
+          _buildSheetApp(
+            background: Expanded(
+              child: _eagerList(
+                controller: backgroundController,
+                label: (int index) => index == 4 ? 'Save' : 'Note $index',
+              ),
+            ),
+            sheet: _eagerList(
+              controller: sheetController,
+              label: (int index) => index == 90 ? 'Save' : 'Option $index',
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const TextMatcher('Save'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Save'), findsNWidgets(2));
+        expect(
+          find.text('Save').hitTestable(),
+          findsOneWidget,
+          reason: 'the sheet copy should be the one brought into reach',
+        );
+        expect(
+          backgroundController.offset,
+          0,
+          reason: 'the covered list should never be scrolled',
+        );
+        expect(sheetController.offset, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'stops once the target is visible even if a covered widget matches too',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final sheetController = ScrollController();
+        addTearDown(sheetController.dispose);
+
+        // The page behind the sheet holds a matching 'Save' label, but it is
+        // not inside any scrollable, so the right scrollable is still picked.
+        // Only the "am I done yet?" check can fail here.
+        await tester.pumpWidget(
+          _buildSheetApp(
+            background: const Text('Save'),
+            sheet: _lazyList(
+              controller: sheetController,
+              label: (int index) => index == 90 ? 'Save' : 'Option $index',
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const TextMatcher('Save'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Save'), findsNWidgets(2));
+        expect(
+          find.text('Save').hitTestable(),
+          findsOneWidget,
+          reason: 'the covered copy must not be what ended the scroll',
+        );
+        expect(sheetController.offset, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'does not drag a scrollable it knows the user cannot reach',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final listController = ScrollController();
+        final chipController = ScrollController();
+        addTearDown(() {
+          listController.dispose();
+          chipController.dispose();
+        });
+
+        await tester.pumpWidget(
+          _buildCoveredListApp(
+            listController: listController,
+            chipController: chipController,
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        final simulator = ScrollSimulator(dispatcher, WidgetFinder());
+
+        // Neither scrollable can reveal the target: the covered list cannot be
+        // dragged at all, because a drag starts at the same centre point the
+        // reachability check uses, and the chip row has nowhere to scroll.
+        await expectLater(
+          () => simulator.scrollUntilVisible(
+            const TextMatcher('Item 90'),
+            _configuration,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          dispatcher.dragCount,
+          0,
+          reason: 'no gesture should be aimed at a point known to be covered',
+        );
+        expect(listController.offset, 0);
+        expect(chipController.offset, 0);
+      },
+    );
+  });
+}
+
+/// A page holding [background] under a modal bottom sheet holding [sheet].
+///
+/// Once the sheet is open the background stays built and stays earlier in the
+/// element tree, which is what makes it a layered UI.
+Widget _buildSheetApp({required Widget sheet, Widget? background}) {
+  return MaterialApp(
+    home: Builder(
+      builder: (BuildContext context) {
+        return Scaffold(
+          body: Column(
+            children: <Widget>[
+              if (background != null) background,
+              TextButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    builder: (BuildContext context) =>
+                        SizedBox(height: 320, child: sheet),
+                  );
+                },
+                child: const Text('open sheet'),
+              ),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+}
+
+/// A list that builds rows on demand, so a row far down does not exist in the
+/// element tree until it is scrolled near.
+Widget _lazyList({
+  required ScrollController controller,
+  required String Function(int index) label,
+}) {
+  return ListView.builder(
+    controller: controller,
+    physics: const ClampingScrollPhysics(),
+    itemCount: _listItemCount,
+    itemBuilder: (BuildContext context, int index) =>
+        ListTile(title: Text(label(index))),
+  );
+}
+
+/// A list that builds every row up front, so a row scrolled out of view is
+/// still in the element tree and can be matched.
+Widget _eagerList({
+  required ScrollController controller,
+  required String Function(int index) label,
+}) {
+  return SingleChildScrollView(
+    controller: controller,
+    physics: const ClampingScrollPhysics(),
+    child: Column(
+      children: <Widget>[
+        for (int index = 0; index < _listItemCount; index++)
+          ListTile(title: Text(label(index))),
+      ],
+    ),
+  );
+}
+
+/// A scrolling list whose centre is swallowed by a layer above it, next to a
+/// reachable row of chips that has nothing to scroll.
+Widget _buildCoveredListApp({
+  required ScrollController listController,
+  required ScrollController chipController,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Stack(
+        children: <Widget>[
+          ListView.builder(
+            controller: listController,
+            physics: const ClampingScrollPhysics(),
+            itemCount: _listItemCount,
+            itemBuilder: (BuildContext context, int index) =>
+                ListTile(title: Text('Item $index'), minTileHeight: 80),
+          ),
+          const Center(
+            child: AbsorbPointer(child: SizedBox(width: 300, height: 300)),
+          ),
+          Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              height: 48,
+              child: SingleChildScrollView(
+                controller: chipController,
+                scrollDirection: Axis.horizontal,
+                child: const Row(children: <Widget>[Text('chip')]),
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
 }
 
 Widget _buildItemsApp({
@@ -154,6 +457,23 @@ class _WidgetTesterGestureDispatcher extends GestureDispatcher {
   Future<void> drag(Offset from, Offset to) async {
     dragCount++;
     await _tester.drag(_scrollableFinder, to - from);
+    await _tester.pump();
+  }
+}
+
+/// Drags from the exact coordinates the simulator asked for, the way the real
+/// [GestureDispatcher] does. Which scrollable moves is then decided by the
+/// simulator, not by the test.
+class _CoordinateGestureDispatcher extends GestureDispatcher {
+  _CoordinateGestureDispatcher(this._tester);
+
+  final WidgetTester _tester;
+  int dragCount = 0;
+
+  @override
+  Future<void> drag(Offset from, Offset to) async {
+    dragCount++;
+    await _tester.dragFrom(from, to - from);
     await _tester.pump();
   }
 }

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -116,6 +116,70 @@ void main() {
         expect(dispatcher.dragCount, 200);
       },
     );
+
+    testWidgets(
+      'picks the main list over a smaller auxiliary scrollable that '
+      'appears first in the tree',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // Regression test for #76: a screen with a small horizontal chip
+        // row above the main vertical list used to make the fallback
+        // scrollable search latch onto the chip row (first
+        // scrollable-with-range found in traversal order) instead of the
+        // list actually containing the target, so scrollUntilVisible
+        // dragged the wrong axis and never reached below-the-fold targets.
+        final listController = ScrollController();
+        addTearDown(listController.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  SizedBox(
+                    height: 40,
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: 30,
+                      itemBuilder: (context, index) => SizedBox(
+                        width: 60,
+                        child: Center(child: Text('Chip $index')),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: ListView.builder(
+                      controller: listController,
+                      physics: const ClampingScrollPhysics(),
+                      itemCount: 60,
+                      itemBuilder: (context, index) => ListTile(
+                        key: ValueKey('item_$index'),
+                        minTileHeight: 80,
+                        title: Text('Item $index'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _CoordinateGestureDispatcher(tester),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const KeyMatcher('item_40'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_40')), findsOneWidget);
+        expect(listController.offset, greaterThan(0));
+      },
+    );
   });
 
   group('ScrollSimulator.scrollUntilVisible on layered UIs', () {

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -357,6 +357,176 @@ void main() {
       },
     );
   });
+
+  group('ScrollSimulator.scrollUntilVisible over long distances', () {
+    testWidgets(
+      'reaches the end of a list far longer than the attempt cap allows '
+      'at a fixed step',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          _buildItemsApp(
+            controller: controller,
+            itemCount: 400,
+            itemExtent: 80,
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        await ScrollSimulator(dispatcher, WidgetFinder()).scrollUntilVisible(
+          const KeyMatcher('item_390'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_390')), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'reaches a distant target under bouncing physics',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          _buildItemsApp(
+            controller: controller,
+            itemCount: 150,
+            itemExtent: 80,
+            physics: const BouncingScrollPhysics(),
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        await ScrollSimulator(dispatcher, WidgetFinder()).scrollUntilVisible(
+          const KeyMatcher('item_140'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_140')), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'reaches a distant target in a horizontal list',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                physics: const ClampingScrollPhysics(),
+                itemCount: 150,
+                itemBuilder: (BuildContext context, int index) => SizedBox(
+                  key: ValueKey('item_$index'),
+                  width: 100,
+                  child: Center(child: Text('Item $index')),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        await ScrollSimulator(dispatcher, WidgetFinder()).scrollUntilVisible(
+          const KeyMatcher('item_140'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_140')), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'scales the step to the viewport instead of creeping by a fixed amount',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // Pins the step size. Crossing an 11400px extent costs 178 drags at a
+        // fixed 64px and 38 at half of this 600px viewport, so this fails long
+        // before the attempt cap if the step stops scaling.
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          _buildItemsApp(
+            controller: controller,
+            itemCount: 150,
+            itemExtent: 80,
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        await ScrollSimulator(dispatcher, WidgetFinder()).scrollUntilVisible(
+          const KeyMatcher('item_140'),
+          _configuration,
+        );
+
+        expect(dispatcher.dragCount, lessThan(60));
+      },
+    );
+
+    testWidgets(
+      'shrinks the step to the part of the viewport that is not covered',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // Overlays leave a 100px band across the middle of a 600px viewport.
+        // A target is only reported visible when its centre can be hit, so a
+        // half-viewport step would stride over rows that never get a chance to
+        // be seen.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: <Widget>[
+                  ListView.builder(
+                    physics: const ClampingScrollPhysics(),
+                    itemCount: 150,
+                    itemBuilder: (BuildContext context, int index) => SizedBox(
+                      key: ValueKey('item_$index'),
+                      height: 40,
+                      child: Text('Item $index'),
+                    ),
+                  ),
+                  const Align(
+                    alignment: Alignment.topCenter,
+                    child: AbsorbPointer(
+                      child: SizedBox(width: double.infinity, height: 250),
+                    ),
+                  ),
+                  const Align(
+                    alignment: Alignment.bottomCenter,
+                    child: AbsorbPointer(
+                      child: SizedBox(width: double.infinity, height: 250),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // item_100's centre is only hittable between offsets 3670 and 3770,
+        // which a 300px stride steps straight over — 3600 then 3900 — on both
+        // the forward and the reversed pass.
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        await ScrollSimulator(dispatcher, WidgetFinder()).scrollUntilVisible(
+          const KeyMatcher('item_100'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_100')), findsOneWidget);
+      },
+    );
+  });
 }
 
 /// A page holding [background] under a modal bottom sheet holding [sheet].
@@ -463,12 +633,13 @@ Widget _buildItemsApp({
   required ScrollController controller,
   required int itemCount,
   required double itemExtent,
+  ScrollPhysics physics = const ClampingScrollPhysics(),
 }) {
   return MaterialApp(
     home: Scaffold(
       body: ListView.builder(
         controller: controller,
-        physics: const ClampingScrollPhysics(),
+        physics: physics,
         itemCount: itemCount,
         itemBuilder: (BuildContext context, int index) {
           return ListTile(

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -118,6 +118,44 @@ void main() {
     );
 
     testWidgets(
+      'says nothing could be scrolled when no drag was ever possible',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // A list with nowhere to go spends no attempts, so the failure used to
+        // read "after 0 scroll attempts" and hide why it gave up.
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          _buildItemsApp(
+            controller: controller,
+            itemCount: 2,
+            itemExtent: 80,
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        final simulator = ScrollSimulator(dispatcher, WidgetFinder());
+
+        await expectLater(
+          () => simulator.scrollUntilVisible(
+            const KeyMatcher('item_90'),
+            _configuration,
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (StateError error) => error.message,
+              'message',
+              contains('no Scrollable could be scrolled'),
+            ),
+          ),
+        );
+
+        expect(dispatcher.dragCount, 0);
+      },
+    );
+
+    testWidgets(
       'picks the main list over a smaller auxiliary scrollable that '
       'appears first in the tree',
       timeout: _timeout,
@@ -749,6 +787,73 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'tries the next candidate when the one being dragged loses its layout',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // A layer that dismisses itself on a drag leaves the tree between two
+        // turns of the drag loop. Its Element is still referenced but has no
+        // RenderBox behind it, which used to abort the whole call instead of
+        // moving on to the next candidate.
+        final dismissed = ValueNotifier<bool>(false);
+        final targetController = ScrollController();
+        addTearDown(() {
+          dismissed.dispose();
+          targetController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: 500,
+                    child: ValueListenableBuilder<bool>(
+                      valueListenable: dismissed,
+                      builder: (
+                        BuildContext context,
+                        bool gone,
+                        Widget? child,
+                      ) =>
+                          gone ? const SizedBox.shrink() : child!,
+                      child: ListView.builder(
+                        physics: const ClampingScrollPhysics(),
+                        itemCount: _listItemCount,
+                        itemBuilder: (BuildContext context, int index) =>
+                            ListTile(title: Text('Article $index')),
+                      ),
+                    ),
+                  ),
+                  SizedBox(
+                    width: 280,
+                    child: _lazyList(
+                      controller: targetController,
+                      label: (int index) => 'Country $index',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final simulator = ScrollSimulator(
+          _DismissingGestureDispatcher(tester, dismissed),
+          WidgetFinder(),
+        );
+
+        await simulator.scrollUntilVisible(
+          const TextMatcher('Country 90'),
+          _configuration,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Country 90'), findsOneWidget);
+        expect(targetController.offset, greaterThan(0));
+      },
+    );
   });
 }
 
@@ -889,6 +994,24 @@ class _WidgetTesterGestureDispatcher extends GestureDispatcher {
   Future<void> drag(Offset from, Offset to) async {
     dragCount++;
     await _tester.drag(_scrollableFinder, to - from);
+    await _tester.pump();
+  }
+}
+
+/// Drags from the exact coordinates the simulator asked for, then drops the
+/// dismissing layer out of the tree, the way a sheet closed by a drag does.
+class _DismissingGestureDispatcher extends GestureDispatcher {
+  _DismissingGestureDispatcher(this._tester, this._dismissed);
+
+  final WidgetTester _tester;
+  final ValueNotifier<bool> _dismissed;
+  int dragCount = 0;
+
+  @override
+  Future<void> drag(Offset from, Offset to) async {
+    dragCount++;
+    await _tester.dragFrom(from, to - from);
+    _dismissed.value = true;
     await _tester.pump();
   }
 }

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -854,6 +854,86 @@ void main() {
         expect(targetController.offset, greaterThan(0));
       },
     );
+
+    testWidgets(
+      'gives two full-length candidates their whole budget and offers none '
+      'to a third',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        // Each list here is long enough to need a full pass in both
+        // directions, so each one legitimately asks for its whole
+        // per-candidate budget. Two of those account for the total, which is
+        // why the candidate list stops at two: a third could only ever be
+        // handed the leftovers, and a budget too small to cross a list buys
+        // nothing but drags.
+        final firstController = ScrollController();
+        final secondController = ScrollController();
+        final thirdController = ScrollController();
+        addTearDown(() {
+          firstController.dispose();
+          secondController.dispose();
+          thirdController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: 300,
+                    child: _lazyList(
+                      controller: firstController,
+                      label: (int index) => 'Article $index',
+                      itemCount: 345,
+                      minTileHeight: 80,
+                    ),
+                  ),
+                  SizedBox(
+                    width: 260,
+                    child: _lazyList(
+                      controller: secondController,
+                      label: (int index) => 'Country $index',
+                      itemCount: 345,
+                      minTileHeight: 80,
+                    ),
+                  ),
+                  SizedBox(
+                    width: 220,
+                    child: _lazyList(
+                      controller: thirdController,
+                      label: (int index) => 'Note $index',
+                      itemCount: 345,
+                      minTileHeight: 80,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final dispatcher = _CoordinateGestureDispatcher(tester);
+        final simulator = ScrollSimulator(dispatcher, WidgetFinder());
+
+        await expectLater(
+          () => simulator.scrollUntilVisible(
+            const TextMatcher('Missing row'),
+            _configuration,
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        // A drag starts at the centre of the scrollable it aims at, so the
+        // columns dragged name the candidates attempted: 150 and 430 are the
+        // two widest lists, 670 the third.
+        expect(
+          dispatcher.dragOrigins.map((Offset origin) => origin.dx).toSet(),
+          <double>{150, 430},
+        );
+        expect(dispatcher.dragCount, lessThanOrEqualTo(400));
+      },
+    );
   });
 }
 
@@ -892,13 +972,17 @@ Widget _buildSheetApp({required Widget sheet, Widget? background}) {
 Widget _lazyList({
   required ScrollController controller,
   required String Function(int index) label,
+  int itemCount = _listItemCount,
+  double? minTileHeight,
 }) {
   return ListView.builder(
     controller: controller,
     physics: const ClampingScrollPhysics(),
-    itemCount: _listItemCount,
-    itemBuilder: (BuildContext context, int index) =>
-        ListTile(title: Text(label(index))),
+    itemCount: itemCount,
+    itemBuilder: (BuildContext context, int index) => ListTile(
+      title: Text(label(index)),
+      minTileHeight: minTileHeight,
+    ),
   );
 }
 
@@ -1023,11 +1107,13 @@ class _CoordinateGestureDispatcher extends GestureDispatcher {
   _CoordinateGestureDispatcher(this._tester);
 
   final WidgetTester _tester;
-  int dragCount = 0;
+  final List<Offset> dragOrigins = <Offset>[];
+
+  int get dragCount => dragOrigins.length;
 
   @override
   Future<void> drag(Offset from, Offset to) async {
-    dragCount++;
+    dragOrigins.add(from);
     await _tester.dragFrom(from, to - from);
     await _tester.pump();
   }

--- a/packages/marionette_mcp/example/pubspec.lock
+++ b/packages/marionette_mcp/example/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -226,10 +226,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -263,5 +263,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -417,26 +417,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -510,5 +510,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
`scroll_to` fails in five distinct ways that all surface as the same message — `Bad state: Widget not found after N scroll attempts`. That is why they have been reported as one vague issue and attacked with two incompatible patches. This separates them and fixes each.

## What was broken

| | Defect | Commit |
|---|---|---|
| 1 | The "is it visible yet?" check inspected the **first** match in the tree. A covered layer stays built and comes first, so a same-named widget behind a sheet or dialog masked the reachable one forever. | 28f7b56 |
| 2 | The **wrong `Scrollable`** was chosen on layered UIs — tree order, so with a sheet open over a scrolling page it dragged the covered page. No duplicate keys needed: a lazily built list is enough, because the target row does not exist yet. | 28f7b56 |
| 3 | The drag loop checked for the target on **entry** to each iteration but left from the **middle**, so the position the last drag landed on was never examined. It arrived at exactly the right place, noticed it had run out of list, and threw with the target on screen. | d34f4c2 |
| 4 | The step was a fixed **64px** against a 200-attempt cap, so any list longer than ~12,800px (≈170 rows) was **unreachable at any budget**. | 78588ca |
| 5 | With the target not built yet, the owning `Scrollable` was **guessed once** and a wrong guess was fatal. | aab2353, 1bf0ef0 |

Defects 3 and 4 are independent of layering and fail on `main` today for ordinary screens — a 400-row list and a 150-item horizontal list both fail outright. The `BouncingScrollPhysics` case is narrower than first claimed: its widget test does fail on `main`, but the same 150-row, 80px geometry succeeds in the live app on `main`, in 165 drags. The test stays; the claim that it fails outright does not.

## The interesting one

There is no ranking of candidate scrollables that gets defect 5 right. Tree order loses when an auxiliary strip is built before the body it decorates. Largest-area loses the mirror image — a target in a narrow nav rail beside a wide content pane. Both layouts are ordinary, and each defeats the other's heuristic, because nothing in the tree says which `Scrollable` would eventually build a widget that is not there yet.

So the ranking stays but stops being a verdict: reachable before out of reach, with somewhere to go before without, biggest first within a tier — as an **order to attempt**. Whether the target turns up is the only reliable signal. A scrollable tried and abandoned is put back where it was. Screens with a single list, which is nearly all of them, behave exactly as before. Cost is bounded at two candidates and 400 drags total, against the 200 a single list could already spend. Two rather than three because one candidate may spend up to 200 attempts against a 400 total, so three never fit: the first two exhausted the budget and the third was left a slice too small to reach anything. Restoring a third candidate requires making an attempt cheaper first, which is a separate change.

## Provenance

Two commits here are by other people and are preserved with their authorship:

- **28f7b56 — @zafnz**, from #45. Rebased onto `main` and narrowed: the tap and `enter_text` halves of that commit landed separately in #48, and its `ElementResolver` has an equivalent on `main` in `hit_test_utils.dart`. What remains is the `scroll_to` half, which #48 did not cover and which #45 set out to finish. Defects 1 and 2 are their design.
- **aab2353 — @Anandumv**, from #98. Narrowed from replacing the fallback ranking to a tie-break within it, since reachability already decides which layer to scroll. Their `_elementArea` helper and their regression test are in the final code.

## Verification

- 158 tests, `flutter analyze` clean, `dart format` clean. Each commit is independently green: 148 → 149 → 154 → 155 → 158.
- Every new test was confirmed to fail before its fix. Three were additionally checked against a deliberately weakened implementation to prove they are not false positives — removing the `mounted` guard reproduces a `_TypeError`; capping candidates at one fails the nav-rail test; and the occlusion test's first version was a genuine false positive (its target happened to land on the stride grid) and was rewritten.
- **All five defects are now confirmed live**, A/B against a running Linux desktop app by swapping `packages/marionette_flutter/lib`, using eleven repro screens plus a control. Each case fails on `main` and passes here, with the target verified on screen from the screenshot rather than from the exit code. Confirmed: occlusion (`after 136 attempts` → pass), wrong `Scrollable` (`after 200` → pass), list edge (`after 84`, target on screen → pass), 400-row list (`after 200` → pass), 150-item horizontal (`after 200` → pass), `Dismissible` rows (`after 200` → pass), narrow nav rail (`after 52` → pass), and its mirror (`after 60` → pass).
- Worst-case duration is 52–74 s on screens with two long lists. Nothing in `marionette_flutter`, `marionette_mcp`, `marionette_cli` or `mcp_dart` bounds a tool call — `mcp_dart`'s 60 s default applies to outgoing requests only, and the CLI's `--timeout` bounds the connection, not `execute`. Reducing that duration means removing the per-record gesture delay, which is a separate change.
- One thing widget tests cannot show: `tester.dragFrom` compensates for touch slop internally. In a real app with a competing drag recognizer (`Dismissible` rows), `DragStartBehavior.start` discards the whole pending offset, which at the old 64px step meant losing ~50% of every drag. Every drag count here is a lower bound for such apps; the larger step reduces that penalty about fourfold.

## Notes

`_stepFor` sizes the step to half of the viewport run that can actually receive pointer events, sampled with 21 hit tests once per call, rather than half the whole viewport — an app bar or bottom bar hides part of the viewport from hit testing, and a target only counts as visible once its centre can be hit, so striding by half the whole viewport can step clean over one that was only ever inspectable in the exposed strip.

**Out of scope**, unchanged from `main`: nested scrollables (an inner list inside an outer one); the drag origin is still the `Scrollable`'s geometric centre, so a single overlay over that one point still makes `scroll_to` a no-op; and the three tree walks in `ScrollSimulator` still duplicate `WidgetFinder`'s traversal shape — consolidating them widens blast radius to `tap`/`enter_text` and belongs in its own change.

Supersedes #45 and #98. Possibly the cause of #76, which has no reproduction and no follow-up from the reporter — three of the defects here are consistent with that report, but none of them is confirmed to be it, so I would not close it on this.

