### PR TITLE
feat: take the rest of the noise out of compact mode

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -15,7 +15,7 @@ Once your agent is connected (see [Configuring your AI tool](#configuring-your-a
 
 | Tool | Description |
 | --- | --- |
-| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, and identifying properties. The agent's primary way to "see" the screen. Pass `compact: true` to omit verbose widget properties (style/decoration/color blobs) and return only identifying fields plus primitive state flags (e.g. `enabled`, `value`, `obscureText`) — much more token-efficient for agent loops; a text field's label/hint is preserved. |
+| `get_interactive_elements` | List the interactive elements currently visible — each with its type, text, key, and identifying properties. The agent's primary way to "see" the screen. Pass `compact: true` to omit verbose widget properties (style/decoration/color blobs) and return only identifying fields plus primitive state flags (e.g. `enabled`, `value`, `obscureText`) — much more token-efficient for agent loops; a text field's label/hint is preserved. Compact also drops rendering details no interaction tool reads (`textAlign`, `softWrap`, `overflow`, `startBehavior`, …), rounds `bounds` to whole logical pixels, and reports `visible` only when an element is **not** visible. |
 | `take_screenshots` | Capture screenshots of all active views, returned as base64 PNGs. |
 | `get_logs` | Retrieve app logs collected since start or the last hot reload. Requires a [`LogCollector`](./logging.md). |
 

--- a/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
@@ -97,7 +97,8 @@ class ElementTreeFinder {
               p.runtimeType != DiagnosticsProperty &&
               p.name != null &&
               p.value != null &&
-              (!compact || _isPrimitive(p.value)))
+              (!compact ||
+                  (_isPrimitive(p.value) && !_isLayoutDetail(p.name!))))
           .map(
             (p) => MapEntry(p.name!, p.value.toString()),
           ),
@@ -111,6 +112,11 @@ class ElementTreeFinder {
 
     if (discoverableText != null) {
       data['text'] = discoverableText;
+      // `Text` also declares its string as `data`, so an element would carry
+      // the same words twice.
+      if (compact && data['data'] == discoverableText) {
+        data.remove('data');
+      }
     }
 
     // The InputDecoration blob is dropped in compact mode, but it carries a
@@ -130,19 +136,35 @@ class ElementTreeFinder {
       try {
         final offset = renderObject.localToGlobal(Offset.zero);
         final size = renderObject.size;
-        data['bounds'] = {
-          'x': offset.dx,
-          'y': offset.dy,
-          'width': size.width,
-          'height': size.height,
-        };
+        // Logical pixels, and the agent uses them to reason about position and
+        // to tap by coordinate — neither needs the sixteen significant digits a
+        // double prints (`411.42857142857144`). Rounded only in compact mode,
+        // so the default payload stays byte-for-byte what it was.
+        data['bounds'] = compact
+            ? {
+                'x': offset.dx.round(),
+                'y': offset.dy.round(),
+                'width': size.width.round(),
+                'height': size.height.round(),
+              }
+            : {
+                'x': offset.dx,
+                'y': offset.dy,
+                'width': size.width,
+                'height': size.height,
+              };
       } catch (_) {
         // Ignore if we can't get bounds
       }
     }
 
-    // Check visibility
-    data['visible'] = _isElementVisible(renderObject);
+    // Check visibility. Every element in the list is on screen in the ordinary
+    // case, so in compact mode this is reported only when it is not — absence
+    // means visible, and the exception stays impossible to miss.
+    final visible = _isElementVisible(renderObject);
+    if (!compact || !visible) {
+      data['visible'] = visible;
+    }
 
     return data;
   }
@@ -150,6 +172,27 @@ class ElementTreeFinder {
   /// Whether [value] is a primitive worth keeping in compact mode.
   static bool _isPrimitive(Object? value) =>
       value is bool || value is num || value is String || value is Enum;
+
+  /// Properties that survive the primitive filter but say nothing an agent can
+  /// act on: they describe how text or gestures are laid out and rendered, and
+  /// no interaction tool reads them (`tap`/`enter_text`/`scroll_to`/`swipe`
+  /// match on key, text, type or coordinates). They are also the ones that
+  /// dominate what is left once the object blobs are gone — every `Text` in a
+  /// list carries five of them.
+  static const _layoutDetails = {
+    'startBehavior',
+    'textAlign',
+    'textDirection',
+    'softWrap',
+    'overflow',
+    'textScaler',
+    'textWidthBasis',
+    'textHeightBehavior',
+    'locale',
+    'selectionColor',
+  };
+
+  static bool _isLayoutDetail(String name) => _layoutDetails.contains(name);
 
   String? _extractKeyValue(Key? key) {
     if (key is ValueKey<String>) {

--- a/packages/marionette_flutter/test/element_tree_finder_test.dart
+++ b/packages/marionette_flutter/test/element_tree_finder_test.dart
@@ -146,6 +146,83 @@ void main() {
     });
   });
 
+  group('ElementTreeFinder compact mode, second pass', () {
+    testWidgets('drops layout details that survive the primitive filter',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Text(
+                'Agenda',
+                textAlign: TextAlign.center,
+                softWrap: false,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final verbose =
+          _finder.findInteractiveElements().firstWhere((e) => e['type'] == 'Text');
+      expect(verbose.containsKey('textAlign'), isTrue,
+          reason: 'default output is unchanged');
+
+      final compact = _finder
+          .findInteractiveElements(compact: true)
+          .firstWhere((e) => e['type'] == 'Text');
+      for (final name in [
+        'textAlign',
+        'textDirection',
+        'softWrap',
+        'overflow',
+        'textScaler',
+        'textWidthBasis',
+      ]) {
+        expect(compact.containsKey(name), isFalse,
+            reason: '$name is a rendering detail no interaction tool reads');
+      }
+      expect(compact['text'], 'Agenda',
+          reason: 'the words themselves stay');
+      expect(compact.containsKey('data'), isFalse,
+          reason: "Text declares its string twice; compact keeps one");
+    });
+
+    testWidgets('rounds bounds and omits visible when the element is visible',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: ElevatedButton(onPressed: () {}, child: const Text('Go')),
+            ),
+          ),
+        ),
+      );
+
+      final verbose = _finder
+          .findInteractiveElements()
+          .firstWhere((e) => e['type'] == 'ElevatedButton');
+      final verboseBounds = verbose['bounds']! as Map<String, dynamic>;
+      expect(verboseBounds['x'], isA<double>(),
+          reason: 'default output keeps the raw doubles');
+      expect(verbose['visible'], isTrue,
+          reason: 'default output always states visibility');
+
+      final compact = _finder
+          .findInteractiveElements(compact: true)
+          .firstWhere((e) => e['type'] == 'ElevatedButton');
+      final compactBounds = compact['bounds']! as Map<String, dynamic>;
+      for (final key in ['x', 'y', 'width', 'height']) {
+        expect(compactBounds[key], isA<int>(),
+            reason: 'compact rounds $key to a whole logical pixel');
+      }
+      expect(compactBounds['x'], (verboseBounds['x']! as double).round());
+      expect(compact.containsKey('visible'), isFalse);
+    });
+  });
+
   group('ElementTreeFinder compact mode', () {
     testWidgets('drops style/object blobs but keeps primitive state and bounds',
         (tester) async {
@@ -181,7 +258,8 @@ void main() {
       expect(compactButton['enabled'], isNotNull,
           reason: 'compact keeps the primitive enabled flag');
       expect(compactButton.containsKey('bounds'), isTrue);
-      expect(compactButton['visible'], isTrue);
+      expect(compactButton.containsKey('visible'), isFalse,
+          reason: 'compact reports visibility only when it is false');
     });
 
     testWidgets(


### PR DESCRIPTION
Stacked on #89 — three follow-ups, all inside `compact` so the default payload stays byte-for-byte what it was.

#89's value-type filter takes the object blobs, which is the big win on a stock configuration. What it cannot take is the noise that is **already primitive** — and on an app whose `MarionetteConfiguration` is tuned (custom `isInteractiveWidget` / `shouldStopTraversal`, which is what you tell people to do), that noise is nearly all of what is left.

### What this adds

- **Rendering details.** `textAlign`, `textDirection`, `softWrap`, `overflow`, `textScaler`, `textWidthBasis`, `startBehavior`, `textHeightBehavior`, `locale`, `selectionColor` survive the primitive filter and say nothing an agent can act on: `tap` / `enter_text` / `scroll_to` / `swipe` match on key, text, type or coordinates. Every `Text` in a list carries five of them.
- **Bounds precision.** `"x": 411.42857142857144` — sixteen significant digits for a logical pixel. Rounded to whole pixels in compact mode.
- **`visible: true` on every element.** Reported now only when an element is **not** visible. Absence means visible, so the exception stays impossible to miss and the common case costs nothing.
- `Text` declares its string as `data` as well as having it extracted into `text` — compact keeps one copy.

### Measured

One screen of a real app (a conference app, ~48 interactive elements), simulated over a captured payload:

| | as-is | compact (#89) | + this PR |
|---|---|---|---|
| stock `MarionetteConfiguration` | 23 225 | 13 517 (**−42%**) | 6 497 (**−73%**) |
| tuned `MarionetteConfiguration` | 9 767 | 9 335 (**−5%**) | 4 777 (**−52%**) |

That second row is the one I would look at: the better an app is configured, the less of the remaining payload #89 alone can reach.

For scale — an Opus screenshot of the same screen costs ~2 500 tokens. At ~4 800 characters the compact view finally lands in the same order of magnitude as looking at a picture, while carrying keys, types and state.

### One behavior change to your test

The `visible` contract changes, so one assertion in the compact group flips:

```diff
-      expect(compactButton['visible'], isTrue);
+      expect(compactButton.containsKey('visible'), isFalse,
+          reason: 'compact reports visibility only when it is false');
```

Two tests added: one for the rendering-detail deny-list (and that the default output still carries them), one for rounded bounds plus the omitted `visible`.

`flutter test`: 132 / 137 / 88 across the three packages. `dart analyze`: clean. Docs updated in `docs/mcp-tools.md`.

### A question rather than a change

`compact` is opt-in and defaults to `false`. An agent only benefits if it decides to pass `compact: true`, which it does from the tool description — so in practice most runs will keep paying for `ButtonStyle` dumps. Given that nothing dropped in compact mode is read by any interaction tool, is the default worth flipping? Happy to do it here if you agree; it felt like your call rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzFBctU6zBCd6ndkVHFTXt