### PR TITLE
fix(marionette_flutter): dispatch gestures and measure visibility in the element's view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `scroll_to` being unable to reach targets in long lists: it now scrolls by a share of the visible viewport instead of a fixed 64px, so lists past roughly 170 rows are reachable and shorter ones take far fewer gestures
 - Fix `scroll_to` on screens with more than one scrollable: when the target is not built yet it now tries the two best-ranked reachable scrollables in turn rather than committing to a single guess, so a chip row, tab strip or nav rail no longer swallows the gesture
 - Fix the `scroll_to` failure reading `Widget not found after 0 scroll attempts` when no scrollable could be dragged at all, which hid the real cause
+- Fix every pointer gesture (`tap`, `double_tap`, `long_press`, `secondary_tap`, `swipe`, `pinch_zoom`, `scroll_to`) silently doing nothing, and every element being reported `visible: false`, in an app whose content is not in the implicit view — as with the desktop windowing API: gestures are now dispatched to, and visibility measured against, the view the element is actually in
 
 # 0.6.0
 

--- a/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
+++ b/packages/marionette_flutter/lib/src/services/element_tree_finder.dart
@@ -117,7 +117,7 @@ class ElementTreeFinder {
     }
 
     // Check visibility
-    data['visible'] = _isElementVisible(renderObject);
+    data['visible'] = _isElementVisible(element);
 
     return data;
   }
@@ -169,8 +169,14 @@ class ElementTreeFinder {
     return null;
   }
 
-  /// Checks if the element is currently visible on screen.
-  bool _isElementVisible(RenderObject? renderObject) {
+  /// Checks if the element is currently visible in the view it is mounted in.
+  ///
+  /// Measures against that view rather than the first one the platform knows
+  /// about: an app driven by the desktop windowing API renders into a view
+  /// other than the implicit one, and [RenderObject.localToGlobal] is relative
+  /// to the owning view anyway.
+  bool _isElementVisible(Element element) {
+    final renderObject = element.renderObject;
     if (renderObject == null || !renderObject.attached) {
       return false;
     }
@@ -187,10 +193,11 @@ class ElementTreeFinder {
 
       try {
         final offset = renderObject.localToGlobal(Offset.zero);
-        final screenSize = WidgetsBinding
-                .instance.platformDispatcher.views.first.physicalSize /
-            WidgetsBinding
-                .instance.platformDispatcher.views.first.devicePixelRatio;
+        final view = viewOf(element);
+        if (view == null) {
+          return true;
+        }
+        final screenSize = view.physicalSize / view.devicePixelRatio;
 
         final isOnScreen = offset.dx + size.width >= 0 &&
             offset.dy + size.height >= 0 &&

--- a/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
+++ b/packages/marionette_flutter/lib/src/services/gesture_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:marionette_flutter/src/binding/marionette_configuration.dart';
+import 'package:marionette_flutter/src/services/hit_test_utils.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 import 'package:marionette_flutter/src/services/widget_matcher.dart';
 
@@ -26,7 +27,7 @@ class GestureDispatcher {
   ) async {
     // Fast path for coordinate-based tapping
     if (matcher is CoordinatesMatcher) {
-      await _dispatchTapAtPosition(matcher.offset);
+      await _dispatchTapAtPosition(matcher.offset, viewId: _defaultViewId());
       return;
     }
 
@@ -40,7 +41,38 @@ class GestureDispatcher {
   }
 
   Future<void> _dispatchTapAtElement(Element element) async {
-    await _dispatchTapAtPosition(_globalCenterOf(element));
+    await _dispatchTapAtPosition(
+      _globalCenterOf(element),
+      viewId: _viewIdOfElement(element),
+    );
+  }
+
+  /// Returns the id of the view [element] is mounted in.
+  ///
+  /// Pointer events carry the view they are meant for; without it they are
+  /// hit-tested against the implicit view, which renders nothing in an app
+  /// driven by the desktop windowing API.
+  int _viewIdOfElement(Element element) {
+    final viewId = viewIdOf(element);
+    if (viewId == null) {
+      throw StateError(
+        'Cannot dispatch a gesture: the element is not mounted in a View and '
+        'there is no implicit view to fall back to',
+      );
+    }
+    return viewId;
+  }
+
+  /// Returns the id of the view coordinate-based gestures are dispatched to.
+  int _defaultViewId() {
+    final viewId = defaultViewId();
+    if (viewId == null) {
+      throw StateError(
+        'Cannot dispatch a gesture: no view is being rendered and there is no '
+        'implicit view to fall back to',
+      );
+    }
+    return viewId;
   }
 
   /// Returns the global position of the center of [element]'s [RenderBox].
@@ -61,22 +93,41 @@ class GestureDispatcher {
     return renderObject.localToGlobal(center);
   }
 
-  Future<void> _dispatchTapAtPosition(Offset globalPosition) async {
+  Future<void> _dispatchTapAtPosition(
+    Offset globalPosition, {
+    required int viewId,
+  }) async {
     final pointerId = _nextPointerId++;
 
     // Build the event records
     final records = [
       // Pointer down immediately
       [
-        PointerAddedEvent(position: globalPosition, device: _kDeviceId),
+        PointerAddedEvent(
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
         PointerDownEvent(
-            pointer: pointerId, position: globalPosition, device: _kDeviceId),
+          pointer: pointerId,
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
       ],
       // Pointer up after a short delay, then remove the device
       [
         PointerUpEvent(
-            pointer: pointerId, position: globalPosition, device: _kDeviceId),
-        PointerRemovedEvent(position: globalPosition, device: _kDeviceId),
+          pointer: pointerId,
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
+        PointerRemovedEvent(
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
       ],
     ];
 
@@ -104,7 +155,11 @@ class GestureDispatcher {
     required int buttons,
   }) async {
     if (matcher is CoordinatesMatcher) {
-      await _dispatchMouseTapAtPosition(matcher.offset, buttons);
+      await _dispatchMouseTapAtPosition(
+        matcher.offset,
+        buttons,
+        viewId: _defaultViewId(),
+      );
       return;
     }
 
@@ -113,13 +168,18 @@ class GestureDispatcher {
     if (element == null) {
       throw Exception('Element matching ${matcher.toJson()} not found');
     }
-    await _dispatchMouseTapAtPosition(_globalCenterOf(element), buttons);
+    await _dispatchMouseTapAtPosition(
+      _globalCenterOf(element),
+      buttons,
+      viewId: _viewIdOfElement(element),
+    );
   }
 
   Future<void> _dispatchMouseTapAtPosition(
     Offset globalPosition,
-    int buttons,
-  ) async {
+    int buttons, {
+    required int viewId,
+  }) async {
     final pointerId = _nextPointerId++;
 
     final records = [
@@ -129,6 +189,7 @@ class GestureDispatcher {
           position: globalPosition,
           kind: PointerDeviceKind.mouse,
           device: _kMouseDeviceId,
+          viewId: viewId,
         ),
         PointerDownEvent(
           pointer: pointerId,
@@ -136,6 +197,7 @@ class GestureDispatcher {
           kind: PointerDeviceKind.mouse,
           buttons: buttons,
           device: _kMouseDeviceId,
+          viewId: viewId,
         ),
       ],
       // Button released (buttons: 0), then the device is removed.
@@ -146,11 +208,13 @@ class GestureDispatcher {
           kind: PointerDeviceKind.mouse,
           buttons: 0,
           device: _kMouseDeviceId,
+          viewId: viewId,
         ),
         PointerRemovedEvent(
           position: globalPosition,
           kind: PointerDeviceKind.mouse,
           device: _kMouseDeviceId,
+          viewId: viewId,
         ),
       ],
     ];
@@ -174,7 +238,11 @@ class GestureDispatcher {
     }
 
     if (matcher is CoordinatesMatcher) {
-      await _dispatchDoubleTapAtPosition(matcher.offset, delay);
+      await _dispatchDoubleTapAtPosition(
+        matcher.offset,
+        delay,
+        viewId: _defaultViewId(),
+      );
       return;
     }
 
@@ -191,21 +259,26 @@ class GestureDispatcher {
     Element element,
     Duration delay,
   ) async {
-    await _dispatchDoubleTapAtPosition(_globalCenterOf(element), delay);
+    await _dispatchDoubleTapAtPosition(
+      _globalCenterOf(element),
+      delay,
+      viewId: _viewIdOfElement(element),
+    );
   }
 
   Future<void> _dispatchDoubleTapAtPosition(
     Offset globalPosition,
-    Duration delay,
-  ) async {
+    Duration delay, {
+    required int viewId,
+  }) async {
     // First tap
-    await _dispatchTapAtPosition(globalPosition);
+    await _dispatchTapAtPosition(globalPosition, viewId: viewId);
 
     // Wait between taps for double-tap recognition
     await Future<void>.delayed(delay);
 
     // Second tap
-    await _dispatchTapAtPosition(globalPosition);
+    await _dispatchTapAtPosition(globalPosition, viewId: viewId);
   }
 
   /// Simulates a long press on an element that matches the given [matcher].
@@ -224,7 +297,11 @@ class GestureDispatcher {
     }
 
     if (matcher is CoordinatesMatcher) {
-      await _dispatchLongPressAtPosition(matcher.offset, duration);
+      await _dispatchLongPressAtPosition(
+        matcher.offset,
+        duration,
+        viewId: _defaultViewId(),
+      );
       return;
     }
 
@@ -241,20 +318,33 @@ class GestureDispatcher {
     Element element,
     Duration duration,
   ) async {
-    await _dispatchLongPressAtPosition(_globalCenterOf(element), duration);
+    await _dispatchLongPressAtPosition(
+      _globalCenterOf(element),
+      duration,
+      viewId: _viewIdOfElement(element),
+    );
   }
 
   Future<void> _dispatchLongPressAtPosition(
     Offset globalPosition,
-    Duration duration,
-  ) async {
+    Duration duration, {
+    required int viewId,
+  }) async {
     final pointerId = _nextPointerId++;
 
     final records = [
       [
-        PointerAddedEvent(position: globalPosition, device: _kDeviceId),
+        PointerAddedEvent(
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
         PointerDownEvent(
-            pointer: pointerId, position: globalPosition, device: _kDeviceId),
+          pointer: pointerId,
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
       ],
     ];
 
@@ -268,8 +358,16 @@ class GestureDispatcher {
     await _handlePointerEventRecord([
       [
         PointerUpEvent(
-            pointer: pointerId, position: globalPosition, device: _kDeviceId),
-        PointerRemovedEvent(position: globalPosition, device: _kDeviceId),
+          pointer: pointerId,
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
+        PointerRemovedEvent(
+          position: globalPosition,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
       ],
     ]);
   }
@@ -303,7 +401,7 @@ class GestureDispatcher {
           'Must be one of: left, right, up, down'),
     };
 
-    await drag(start, end);
+    await drag(start, end, viewId: _viewIdOfElement(element));
   }
 
   /// Simulates a pinch zoom gesture centered on an element matching [matcher].
@@ -332,6 +430,7 @@ class GestureDispatcher {
         matcher.offset,
         scale: scale,
         startDistance: startDistance,
+        viewId: _defaultViewId(),
       );
       return;
     }
@@ -348,6 +447,7 @@ class GestureDispatcher {
       globalCenter,
       scale: scale,
       startDistance: startDistance,
+      viewId: _viewIdOfElement(element),
     );
   }
 
@@ -355,6 +455,7 @@ class GestureDispatcher {
     Offset center, {
     required double scale,
     required double startDistance,
+    required int viewId,
   }) async {
     final pointer1Id = _nextPointerId++;
     final pointer2Id = _nextPointerId++;
@@ -372,19 +473,29 @@ class GestureDispatcher {
     // Phase 1: Both fingers down
     final records = <List<PointerEvent>>[
       [
-        PointerAddedEvent(position: start1, device: _kDeviceId),
+        PointerAddedEvent(
+          position: start1,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
         PointerDownEvent(
           pointer: pointer1Id,
           position: start1,
           device: _kDeviceId,
+          viewId: viewId,
         ),
       ],
       [
-        PointerAddedEvent(position: start2, device: _kSecondDeviceId),
+        PointerAddedEvent(
+          position: start2,
+          device: _kSecondDeviceId,
+          viewId: viewId,
+        ),
         PointerDownEvent(
           pointer: pointer2Id,
           position: start2,
           device: _kSecondDeviceId,
+          viewId: viewId,
         ),
       ],
     ];
@@ -401,11 +512,13 @@ class GestureDispatcher {
           pointer: pointer1Id,
           position: pos1,
           device: _kDeviceId,
+          viewId: viewId,
         ),
         PointerMoveEvent(
           pointer: pointer2Id,
           position: pos2,
           device: _kSecondDeviceId,
+          viewId: viewId,
         ),
       ]);
     }
@@ -420,16 +533,26 @@ class GestureDispatcher {
           pointer: pointer1Id,
           position: end1,
           device: _kDeviceId,
+          viewId: viewId,
         ),
         PointerUpEvent(
           pointer: pointer2Id,
           position: end2,
           device: _kSecondDeviceId,
+          viewId: viewId,
         ),
       ],
       [
-        PointerRemovedEvent(position: end1, device: _kDeviceId),
-        PointerRemovedEvent(position: end2, device: _kSecondDeviceId),
+        PointerRemovedEvent(
+          position: end1,
+          device: _kDeviceId,
+          viewId: viewId,
+        ),
+        PointerRemovedEvent(
+          position: end2,
+          device: _kSecondDeviceId,
+          viewId: viewId,
+        ),
       ],
     ]);
 
@@ -437,7 +560,12 @@ class GestureDispatcher {
   }
 
   /// Simulates a drag gesture from [from] to [to].
-  Future<void> drag(Offset from, Offset to) async {
+  ///
+  /// [viewId] is the view the drag is dispatched to; it defaults to the first
+  /// rendered view. Callers that start from an element should pass that
+  /// element's view instead.
+  Future<void> drag(Offset from, Offset to, {int? viewId}) async {
+    final resolvedViewId = viewId ?? _defaultViewId();
     final pointerId = _nextPointerId++;
 
     final delta = to - from;
@@ -459,20 +587,38 @@ class GestureDispatcher {
           position: position,
           delta: stepDelta,
           device: _kDeviceId,
+          viewId: resolvedViewId,
         ),
       ]);
     }
 
     final records = [
       [
-        PointerAddedEvent(position: from, device: _kDeviceId),
+        PointerAddedEvent(
+          position: from,
+          device: _kDeviceId,
+          viewId: resolvedViewId,
+        ),
         PointerDownEvent(
-            pointer: pointerId, position: from, device: _kDeviceId),
+          pointer: pointerId,
+          position: from,
+          device: _kDeviceId,
+          viewId: resolvedViewId,
+        ),
       ],
       ...moveRecords,
       [
-        PointerUpEvent(pointer: pointerId, position: to, device: _kDeviceId),
-        PointerRemovedEvent(position: to, device: _kDeviceId),
+        PointerUpEvent(
+          pointer: pointerId,
+          position: to,
+          device: _kDeviceId,
+          viewId: resolvedViewId,
+        ),
+        PointerRemovedEvent(
+          position: to,
+          device: _kDeviceId,
+          viewId: resolvedViewId,
+        ),
       ],
     ];
 

--- a/packages/marionette_flutter/lib/src/services/hit_test_utils.dart
+++ b/packages/marionette_flutter/lib/src/services/hit_test_utils.dart
@@ -1,5 +1,38 @@
+import 'dart:ui' show FlutterView;
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+
+/// Returns the view the [element] is mounted in.
+///
+/// The single place the element-to-view question is answered, so discovery,
+/// dispatch and the visibility check cannot drift apart. Falls back to the
+/// implicit view for an element that is not below a [View] of its own, and
+/// returns null when there is no view to resolve at all.
+FlutterView? viewOf(Element element) {
+  final view = element.findAncestorWidgetOfExactType<View>();
+  return view?.view ?? WidgetsBinding.instance.platformDispatcher.implicitView;
+}
+
+/// Returns the id of the view the [element] is mounted in.
+int? viewIdOf(Element element) => viewOf(element)?.viewId;
+
+/// Returns the id of the view to use when there is no element to ask.
+///
+/// Prefers the first rendered view: in an ordinary app that is the implicit
+/// view, and in an app driven by the desktop windowing API the implicit view
+/// exists but is never rendered, so the first rendered view is the window the
+/// user sees. Returns null when nothing is rendered and there is no implicit
+/// view either.
+int? defaultViewId() {
+  // Not `firstOrNull`: that lives in package:collection, which this package
+  // does not depend on.
+  final renderViews = WidgetsBinding.instance.renderViews;
+  if (renderViews.isNotEmpty) {
+    return renderViews.first.flutterView.viewId;
+  }
+  return WidgetsBinding.instance.platformDispatcher.implicitView?.viewId;
+}
 
 /// Checks if the [element] can receive pointer events.
 ///
@@ -32,9 +65,7 @@ bool isElementHittableAt(Element element, Offset localPoint) {
     return false;
   }
 
-  final view = element.findAncestorWidgetOfExactType<View>();
-  final viewId = view?.view.viewId ??
-      WidgetsBinding.instance.platformDispatcher.implicitView?.viewId;
+  final viewId = viewIdOf(element);
   if (viewId == null) {
     return false;
   }

--- a/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
+++ b/packages/marionette_flutter/lib/src/services/scroll_simulator.dart
@@ -334,7 +334,11 @@ class ScrollSimulator {
 
       final to = globalPosition + moveStep;
       final beforePosition = position.pixels;
-      await _gestureDispatcher.drag(globalPosition, to);
+      await _gestureDispatcher.drag(
+        globalPosition,
+        to,
+        viewId: viewIdOf(scrollable),
+      );
       drags++;
 
       final afterPosition = position.pixels;

--- a/packages/marionette_flutter/test/element_tree_finder_test.dart
+++ b/packages/marionette_flutter/test/element_tree_finder_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:marionette_flutter/src/services/element_tree_finder.dart';
 
+import 'multi_view_test_helpers.dart';
+
 const _configuration = MarionetteConfiguration();
 const _finder = ElementTreeFinder(_configuration);
 
@@ -202,4 +204,91 @@ void main() {
       );
     });
   });
+
+  group('ElementTreeFinder visibility in a non-implicit view', () {
+    testWidgets(
+      'an element inside the view is visible even when the implicit view is '
+      'smaller',
+      (tester) async {
+        // 1000x1000 logical at the test device pixel ratio of 3 — larger than
+        // the implicit view (800x600), so an element past the implicit view's
+        // width is still well inside this one.
+        final fakeView = FakeView(tester.view)
+          ..physicalSize = const Size(3000, 3000);
+
+        await tester.pumpWidget(
+          wrapWithView: false,
+          View(
+            view: fakeView,
+            child: _probeAt(const Offset(850, 100)),
+          ),
+        );
+
+        final probe = _findProbe();
+        expect(probe['visible'], isTrue,
+            reason: 'Visibility must be measured against the view the element '
+                'is mounted in, not the implicit view');
+      },
+    );
+
+    testWidgets(
+      'an element painted past the view bounds is not visible',
+      (tester) async {
+        // 400x300 logical — smaller than the implicit view, so the offset
+        // below is outside this view while still inside the implicit one.
+        final fakeView = FakeView(tester.view)
+          ..physicalSize = const Size(1200, 900);
+
+        await tester.pumpWidget(
+          wrapWithView: false,
+          View(
+            view: fakeView,
+            child: _probeAt(const Offset(500, 0)),
+          ),
+        );
+
+        final probe = _findProbe();
+        expect(probe['visible'], isFalse,
+            reason: 'An element painted beyond its own view is off screen '
+                'even though the implicit view would be large enough');
+      },
+    );
+  });
+}
+
+/// A hit-testable probe placed at [offset] within its view.
+///
+/// [Transform.translate] moves the probe for hit testing as well as for
+/// painting — the hit test is performed at the translated position — and hit
+/// tests are not clipped to the view bounds, so the probe stays reachable
+/// wherever it is put, including past the edge of its own view. That is what
+/// makes it usable here: reachability is held constant, and the only thing
+/// that varies is where the probe sits relative to its view, which is exactly
+/// what the visibility check measures.
+Widget _probeAt(Offset offset) {
+  return Transform.translate(
+    offset: offset,
+    child: Align(
+      alignment: Alignment.topLeft,
+      child: SizedBox(
+        width: 100,
+        height: 100,
+        child: GestureDetector(
+          key: const ValueKey('probe'),
+          behavior: HitTestBehavior.opaque,
+          onTap: () {},
+        ),
+      ),
+    ),
+  );
+}
+
+Map<String, dynamic> _findProbe() {
+  final elements = _finder.findInteractiveElements();
+  return elements.firstWhere(
+    (e) => e['key'] == 'probe',
+    orElse: () => throw StateError(
+      'The probe should be discoverable: $elements',
+    ),
+  );
 }

--- a/packages/marionette_flutter/test/gesture_dispatcher_test.dart
+++ b/packages/marionette_flutter/test/gesture_dispatcher_test.dart
@@ -5,6 +5,8 @@ import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 
+import 'multi_view_test_helpers.dart';
+
 const _timeout = Timeout(Duration(seconds: 10));
 
 void main() {
@@ -858,4 +860,306 @@ void main() {
       },
     );
   });
+
+  group('GestureDispatcher - multi-view', () {
+    testWidgets(
+      'tap by coordinates reaches the rendered view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var tapped = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(onTap: () => tapped = true),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.tap(
+              const CoordinatesMatcher(400, 300),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(
+          tapped,
+          isTrue,
+          reason: 'A coordinate tap must reach the widget in the rendered '
+              'view, not the implicit view that renders nothing',
+        );
+      },
+    );
+
+    testWidgets(
+      'tap by key reaches the element\'s own view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var tapped = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(
+            key: const ValueKey('target'),
+            onTap: () => tapped = true,
+          ),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.tap(
+              const KeyMatcher('target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(
+          tapped,
+          isTrue,
+          reason: 'An element tap must be dispatched into the view the '
+              'element is mounted in',
+        );
+      },
+    );
+
+    testWidgets(
+      'doubleTap reaches the element\'s own view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var doubleTapped = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(
+            key: const ValueKey('target'),
+            onDoubleTap: () => doubleTapped = true,
+          ),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.doubleTap(
+              const KeyMatcher('target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(doubleTapped, isTrue);
+      },
+    );
+
+    testWidgets(
+      'longPress reaches the element\'s own view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var longPressed = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(
+            key: const ValueKey('target'),
+            onLongPress: () => longPressed = true,
+          ),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.longPress(
+              const KeyMatcher('target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+              duration: const Duration(milliseconds: 600),
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(longPressed, isTrue);
+      },
+    );
+
+    testWidgets(
+      'secondaryTap reaches the element\'s own view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var secondaryTapped = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(
+            key: const ValueKey('target'),
+            onSecondaryTap: () => secondaryTapped = true,
+          ),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.secondaryTap(
+              const KeyMatcher('target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(secondaryTapped, isTrue);
+      },
+    );
+
+    testWidgets(
+      'pinchZoom reaches the element\'s own view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var scaled = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(
+            key: const ValueKey('target'),
+            onScaleUpdate: (details) => scaled = true,
+          ),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.pinchZoom(
+              const KeyMatcher('target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+              scale: 2,
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(
+          scaled,
+          isTrue,
+          reason: 'The pinch must be recognised by the widget in the '
+              'non-implicit view, not merely be tagged with its view id',
+        );
+      },
+    );
+
+    testWidgets(
+      'swipe reaches the element\'s own view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var panned = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(
+            key: const ValueKey('target'),
+            onPanUpdate: (details) => panned = true,
+          ),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(() => dispatcher.swipe(
+              const KeyMatcher('target'),
+              WidgetFinder(),
+              const MarionetteConfiguration(),
+              direction: 'up',
+              distance: 100,
+            ));
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(
+          panned,
+          isTrue,
+          reason: 'The swipe must be recognised by the widget in the '
+              'non-implicit view, not merely be tagged with its view id',
+        );
+      },
+    );
+
+    testWidgets(
+      'drag by coordinates reaches the rendered view',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        var panned = false;
+        final fakeView = await _pumpInFakeView(
+          tester,
+          _gestureTarget(onPanUpdate: (details) => panned = true),
+        );
+        final events = _recordPointerEvents();
+
+        final dispatcher = GestureDispatcher();
+        await tester.runAsync(
+          () => dispatcher.drag(const Offset(400, 350), const Offset(400, 250)),
+        );
+        await tester.pump();
+
+        _expectAllInView(events, fakeView);
+        expect(
+          panned,
+          isTrue,
+          reason: 'A coordinate drag must be recognised by the widget in the '
+              'rendered view, not merely be tagged with its view id',
+        );
+      },
+    );
+  });
+}
+
+/// Mounts [child] as the whole content of a non-implicit view.
+///
+/// `wrapWithView: false` leaves the implicit view without a `RenderView`, which
+/// is the shape of an app rendering through the desktop windowing API.
+Future<FakeView> _pumpInFakeView(WidgetTester tester, Widget child) async {
+  final fakeView = FakeView(tester.view);
+  await tester.pumpWidget(
+    wrapWithView: false,
+    View(view: fakeView, child: child),
+  );
+  return fakeView;
+}
+
+/// A centered gesture target that is hit-testable on its own.
+Widget _gestureTarget({
+  Key? key,
+  VoidCallback? onTap,
+  VoidCallback? onDoubleTap,
+  VoidCallback? onLongPress,
+  VoidCallback? onSecondaryTap,
+  GestureDragUpdateCallback? onPanUpdate,
+  GestureScaleUpdateCallback? onScaleUpdate,
+}) {
+  return Center(
+    child: GestureDetector(
+      key: key,
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      onDoubleTap: onDoubleTap,
+      onLongPress: onLongPress,
+      onSecondaryTap: onSecondaryTap,
+      onPanUpdate: onPanUpdate,
+      onScaleUpdate: onScaleUpdate,
+      child: const SizedBox(width: 200, height: 200),
+    ),
+  );
+}
+
+/// Collects every pointer event the binding routes, for the length of the test.
+List<PointerEvent> _recordPointerEvents() {
+  final events = <PointerEvent>[];
+  void record(PointerEvent event) => events.add(event);
+
+  GestureBinding.instance.pointerRouter.addGlobalRoute(record);
+  addTearDown(
+    () => GestureBinding.instance.pointerRouter.removeGlobalRoute(record),
+  );
+  return events;
+}
+
+void _expectAllInView(List<PointerEvent> events, FakeView view) {
+  expect(events, isNotEmpty, reason: 'Should have dispatched events');
+  for (final event in events) {
+    expect(
+      event.viewId,
+      equals(view.viewId),
+      reason: '${event.runtimeType} should carry the view id of the view it '
+          'is meant for, otherwise it hit-tests against a view that renders '
+          'nothing',
+    );
+  }
 }

--- a/packages/marionette_flutter/test/multi_view_test_helpers.dart
+++ b/packages/marionette_flutter/test/multi_view_test_helpers.dart
@@ -1,0 +1,34 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// A [FlutterView] with its own [viewId] that never reaches the engine.
+///
+/// Mounting content under `View(view: FakeView(tester.view), child: …)` with
+/// `pumpWidget(wrapWithView: false, …)` reproduces the shape of an app that
+/// renders through the desktop windowing API: the implicit view exists but has
+/// no `RenderView`, and everything the user sees lives in another view.
+///
+/// Modelled on Flutter's own `packages/flutter/test/widgets/multi_view_testing.dart`.
+class FakeView extends TestFlutterView {
+  FakeView(FlutterView view, {this.viewId = 100})
+      : super(
+          view: view,
+          platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
+          display: view.display as TestDisplay,
+        );
+
+  @override
+  final int viewId;
+
+  @override
+  void render(Scene scene, {Size? size}) {
+    // Do not render the scene in the engine: it only observes the one view it
+    // was given, and expects no more than one `Scene` per frame.
+  }
+
+  @override
+  void updateSemantics(SemanticsUpdate update) {
+    // Do not send the update to the engine, for the same reason as [render].
+  }
+}

--- a/packages/marionette_flutter/test/no_implicit_view_test.dart
+++ b/packages/marionette_flutter/test/no_implicit_view_test.dart
@@ -1,0 +1,115 @@
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
+import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
+import 'package:marionette_flutter/src/services/widget_finder.dart';
+
+void main() {
+  // Replaces the default bindings so the implicit view can be hidden inside a
+  // test body, which is the only state in which no view is resolvable at all.
+  final binding = _NoImplicitViewWidgetsBinding();
+
+  testWidgets(
+    'a gesture refuses to dispatch when no view can be resolved',
+    timeout: const Timeout(Duration(seconds: 30)),
+    (WidgetTester tester) async {
+      final events = <PointerEvent>[];
+      void record(PointerEvent event) => events.add(event);
+
+      GestureBinding.instance.pointerRouter.addGlobalRoute(record);
+      addTearDown(
+        () => GestureBinding.instance.pointerRouter.removeGlobalRoute(record),
+      );
+
+      binding.hideAllViews();
+      try {
+        expect(WidgetsBinding.instance.renderViews, isEmpty);
+        expect(
+          WidgetsBinding.instance.platformDispatcher.implicitView,
+          isNull,
+        );
+
+        // Called without runAsync on purpose: the refusal happens before the
+        // dispatcher awaits anything, so the returned future is already failed
+        // — and a dispatcher that does not refuse hangs on its own delays,
+        // which the test timeout above turns into a failure either way.
+        await expectLater(
+          GestureDispatcher().tap(
+            const CoordinatesMatcher(100, 100),
+            WidgetFinder(),
+            const MarionetteConfiguration(),
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (StateError error) => error.message,
+              'message',
+              contains('no view is being rendered'),
+            ),
+          ),
+        );
+      } finally {
+        binding.showAllViews();
+      }
+
+      expect(
+        events,
+        isEmpty,
+        reason: 'Nothing may be dispatched when there is no view to dispatch '
+            'it to — an event without a resolvable view silently targets the '
+            'implicit view and hits nothing',
+      );
+    },
+  );
+}
+
+/// A [TestPlatformDispatcher] whose `implicitView` can be hidden.
+class _NoImplicitViewPlatformDispatcher extends TestPlatformDispatcher {
+  _NoImplicitViewPlatformDispatcher({required super.platformDispatcher})
+      : _superPlatformDispatcher = platformDispatcher;
+
+  final PlatformDispatcher _superPlatformDispatcher;
+
+  bool implicitViewHidden = false;
+
+  @override
+  TestFlutterView? get implicitView => implicitViewHidden
+      ? null
+      : _superPlatformDispatcher.implicitView as TestFlutterView?;
+}
+
+/// Test bindings that can report having no view at all, modelled on Flutter's
+/// own `packages/flutter/test/widgets/multi_view_testing.dart`.
+///
+/// The test harness always keeps one [RenderView] around for the implicit
+/// view, so hiding the implicit view alone is not enough to reproduce an app
+/// that has no view to dispatch to — [renderViews] is hidden along with it.
+class _NoImplicitViewWidgetsBinding extends AutomatedTestWidgetsFlutterBinding {
+  late final _NoImplicitViewPlatformDispatcher _platformDispatcher =
+      _NoImplicitViewPlatformDispatcher(
+    platformDispatcher: super.platformDispatcher,
+  );
+
+  bool _viewsHidden = false;
+
+  @override
+  _NoImplicitViewPlatformDispatcher get platformDispatcher =>
+      _platformDispatcher;
+
+  @override
+  Iterable<RenderView> get renderViews =>
+      _viewsHidden ? const <RenderView>[] : super.renderViews;
+
+  void hideAllViews() {
+    _viewsHidden = true;
+    platformDispatcher.implicitViewHidden = true;
+  }
+
+  void showAllViews() {
+    _viewsHidden = false;
+    platformDispatcher.implicitViewHidden = false;
+  }
+}

--- a/packages/marionette_flutter/test/scroll_simulator_test.dart
+++ b/packages/marionette_flutter/test/scroll_simulator_test.dart
@@ -5,6 +5,8 @@ import 'package:marionette_flutter/src/services/gesture_dispatcher.dart';
 import 'package:marionette_flutter/src/services/scroll_simulator.dart';
 import 'package:marionette_flutter/src/services/widget_finder.dart';
 
+import 'multi_view_test_helpers.dart';
+
 const _timeout = Timeout(Duration(seconds: 30));
 const _configuration = MarionetteConfiguration();
 const _listItemCount = 100;
@@ -935,6 +937,48 @@ void main() {
       },
     );
   });
+
+  group('ScrollSimulator.scrollUntilVisible in a non-implicit view', () {
+    testWidgets(
+      'drags the scrollable in the view it is mounted in',
+      timeout: _timeout,
+      (WidgetTester tester) async {
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        final fakeView = FakeView(tester.view);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          View(
+            view: fakeView,
+            child: _buildItemsApp(
+              controller: controller,
+              itemCount: 40,
+              itemExtent: 80,
+            ),
+          ),
+        );
+
+        final dispatcher = _ScrollingGestureDispatcher(tester, controller);
+        final simulator = ScrollSimulator(dispatcher, WidgetFinder());
+
+        await simulator.scrollUntilVisible(
+          const KeyMatcher('item_30'),
+          _configuration,
+        );
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('item_30')), findsOneWidget);
+        expect(dispatcher.viewIds, isNotEmpty);
+        expect(
+          dispatcher.viewIds,
+          everyElement(equals(fakeView.viewId)),
+          reason: 'Each drag must be aimed at the view the scrollable lives '
+              'in, otherwise it hit-tests against a view that renders nothing',
+        );
+      },
+    );
+  });
 }
 
 /// A page holding [background] under a modal bottom sheet holding [sheet].
@@ -1075,7 +1119,7 @@ class _WidgetTesterGestureDispatcher extends GestureDispatcher {
   int dragCount = 0;
 
   @override
-  Future<void> drag(Offset from, Offset to) async {
+  Future<void> drag(Offset from, Offset to, {int? viewId}) async {
     dragCount++;
     await _tester.drag(_scrollableFinder, to - from);
     await _tester.pump();
@@ -1092,10 +1136,35 @@ class _DismissingGestureDispatcher extends GestureDispatcher {
   int dragCount = 0;
 
   @override
-  Future<void> drag(Offset from, Offset to) async {
+  Future<void> drag(Offset from, Offset to, {int? viewId}) async {
     dragCount++;
     await _tester.dragFrom(from, to - from);
     _dismissed.value = true;
+    await _tester.pump();
+  }
+}
+
+/// Records the view each drag was aimed at and moves the list by the drag's
+/// own delta.
+///
+/// Scrolling through the controller keeps the test about the view the
+/// simulator picks; that the pointer events themselves land in that view is
+/// covered by the gesture dispatcher's own multi-view tests.
+class _ScrollingGestureDispatcher extends GestureDispatcher {
+  _ScrollingGestureDispatcher(this._tester, this._controller);
+
+  final WidgetTester _tester;
+  final ScrollController _controller;
+  final List<int?> viewIds = <int?>[];
+
+  @override
+  Future<void> drag(Offset from, Offset to, {int? viewId}) async {
+    viewIds.add(viewId);
+
+    final target = _controller.offset - (to.dy - from.dy);
+    _controller.jumpTo(
+      target.clamp(0.0, _controller.position.maxScrollExtent).toDouble(),
+    );
     await _tester.pump();
   }
 }
@@ -1112,7 +1181,7 @@ class _CoordinateGestureDispatcher extends GestureDispatcher {
   int get dragCount => dragOrigins.length;
 
   @override
-  Future<void> drag(Offset from, Offset to) async {
+  Future<void> drag(Offset from, Offset to, {int? viewId}) async {
     dragOrigins.add(from);
     await _tester.dragFrom(from, to - from);
     await _tester.pump();


### PR DESCRIPTION
## Summary

In an app whose content does not live in the implicit view — for example a desktop app built on the windowing API (`runWidget` + `RegularWindow`, everything rendered through `View(view: controller.rootView, …)`) — `marionette_flutter` 0.6.0 connects, discovers elements and takes screenshots, but every pointer gesture reports success and changes nothing, and every element is reported as `visible: false`.

This PR makes gestures and the visibility check use the view the element is actually in.

## Root cause

`GestureDispatcher` built every `Pointer*Event` without a `viewId`, so the events carried view 0. `GestureBinding.handlePointerEvent` hit-tests through `RendererBinding.hitTestInView(result, position, event.viewId)`, and when the implicit view has no `RenderView` nothing is hit. The tool still answered "Tapped" because nothing checked whether the hit test reached anything.

Independently, `ElementTreeFinder._isElementVisible` measured against `platformDispatcher.views.first`, i.e. the implicit view, whose size does not describe the window.

Element discovery was unaffected because `isElementHittable` already resolved the element's own `View`; the dispatcher and the visibility check just did not share that lookup.

## Affected tools

All pointer gestures go through the same dispatch path, so all of them were affected: `tap`, `double_tap`, `long_press`, `secondary_tap`, `swipe` (element and coordinate form), `pinch_zoom`, and `scroll_to` (it drags through `GestureDispatcher.drag`). `enter_text`, `press_key`, `press_back_button`, `set_device_config` and screenshots do not use pointer events and were fine.

## Changes

- `hit_test_utils.dart`: new shared helpers `viewOf`, `viewIdOf` and `defaultViewId`. `isElementHittableAt` uses them, so discovery, dispatch and the visibility check resolve the view in one place.
- `gesture_dispatcher.dart`: every pointer event carries a `viewId`. Element-based gestures use the element's view; coordinate-based gestures use the first rendered view (the implicit view in an ordinary app, so behaviour there is unchanged). If no view can be resolved at all, the dispatcher throws a `StateError` instead of silently targeting view 0.
- `element_tree_finder.dart`: `visible` is measured against the element's own view.
- `scroll_simulator.dart`: passes the scrollable's view to `drag`.
- Changelog entry under Unreleased.

No change to `marionette_mcp` or `marionette_cli`; the wire protocol is untouched.

## Tests

A `FakeView` test helper (modelled on Flutter's own `multi_view_testing.dart`) mounts content under a non-implicit `View` with `pumpWidget(wrapWithView: false, …)`, so the implicit view has no `RenderView` — the same shape as a windowing-API app.

- One test per gesture (`tap` by coordinates and by key, `doubleTap`, `longPress`, `secondaryTap`, `pinchZoom`, `swipe`, coordinate `drag`) asserting that the widget's callback fires and that every dispatched event carries the fake view's id. All eight failed before the fix with `Expected: <100> Actual: <0>`.
- `scrollUntilVisible` inside the fake view reaches a target below the fold and aims every drag at that view.
- Visibility: an element inside the fake view is `visible: true` even when it lies outside the implicit view's bounds; one painted past its own view's bounds is `visible: false`.
- A gesture with no resolvable view is refused with a `StateError` and dispatches nothing.

Existing tests are unchanged and still pass (`flutter analyze --fatal-infos lib`, `dart format --set-exit-if-changed lib`, `flutter test --no-pub` in `packages/marionette_flutter`).

Verified manually against a macOS app running on the windowing API (Flutter master with `--enable-windowing`): before, all 32 discovered elements were `visible: false` and taps did nothing; after, they are `visible: true` and taps by coordinates and by text toggle the widgets.

## Follow-ups (out of scope here)

- `screencast_service.dart` and the `viewportSizeProvider` in `marionette_binding.dart` still pick `renderViews.first`; in a multi-window app that is an arbitrary window. `defaultViewId()` deliberately mirrors that choice so all three agree.
- An optional `viewId` argument on the tools would let a multi-window app choose a window for coordinate-based gestures.
- The dispatcher still reports success when a hit test reaches no widget.
